### PR TITLE
@W-7219646@ Manifest creation based on metadata - Throw an error when…

### DIFF
--- a/src/metadata-registry/manifestGenerator.ts
+++ b/src/metadata-registry/manifestGenerator.ts
@@ -13,10 +13,11 @@ export class ManifestGenerator {
   packageModuleStart =
     '<Package xmlns="http://soap.sforce.com/2006/04/metadata">';
   packageModuleEnd = '</Package>';
+  registryAccess = new RegistryAccess();
 
   public createManifest(
     components: MetadataComponent[],
-    apiVersion = new RegistryAccess().getApiVersion()
+    apiVersion = this.registryAccess.getApiVersion()
   ): string {
     let output = this.xmlDef.concat(this.packageModuleStart);
     const metadataMap = this.createMetadataMap(components);
@@ -43,7 +44,9 @@ export class ManifestGenerator {
       Set<string>
     >();
     for (const component of components) {
-      const metadataType = component.type.name;
+      const metadataType = this.registryAccess.getTypeFromName(
+        component.type.name
+      ).name;
       const metadataName = component.fullName;
       if (metadataMap.has(metadataType)) {
         const metadataNames = metadataMap.get(metadataType);

--- a/test/metadata-registry/manifestGenerator.test.ts
+++ b/test/metadata-registry/manifestGenerator.test.ts
@@ -8,6 +8,7 @@
 import { ManifestGenerator } from '../../src/metadata-registry/manifestGenerator';
 import { MetadataComponent } from '../../src/metadata-registry/types';
 import { expect } from 'chai';
+import { AssertionError } from 'assert';
 
 describe('ManifestGenerator', () => {
   const manifestGenerator = new ManifestGenerator();
@@ -112,5 +113,22 @@ describe('ManifestGenerator', () => {
     expect(manifestGenerator.createManifest([component], '45.0')).to.equal(
       '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><types><members>someName</members><name>ApexClass</name></types><version>45.0</version></Package>'
     );
+  });
+
+  it('should throw error for non valid type', () => {
+    const component = {
+      fullName: 'someName',
+      type: { name: 'someveryunknowntype' },
+      xml: '',
+      sources: []
+    } as MetadataComponent;
+    try {
+      manifestGenerator.createManifest([component]);
+      expect.fail('should have failed');
+    } catch (e) {
+      expect(e.message).to.equal(
+        "Missing metadata type definition in registry for id 'someveryunknowntype'"
+      );
+    }
   });
 });


### PR DESCRIPTION
… an invalid metadatype is passed

This came out of Roy's QA - We now fail manifest creation when at least one unknown metadaType is passed.