### PR TITLE
Fix incorrectly identifying a mixed content component's type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Salesforce source-deploy-retrieve
 
+[![CircleCI](https://circleci.com/gh/forcedotcom/source-deploy-retrieve.svg?style=svg&circle-token=8cab4c48eb81996544b9fa3dfa29e6734376b73f)](https://circleci.com/gh/forcedotcom/source-deploy-retrieve)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+![npm (scoped)](https://img.shields.io/npm/v/@salesforce/source-deploy-retrieve)
+
 Typescript Library to support the Salesforce extensions for VS Code.
 
 Note: This library is in beta and has been released early so we can collect feedback. It may contain bugs, undergo major changes, or be discontinued.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/index.js",
   "author": "Salesforce",

--- a/src/metadata-registry/manifestGenerator.ts
+++ b/src/metadata-registry/manifestGenerator.ts
@@ -13,10 +13,11 @@ export class ManifestGenerator {
   packageModuleStart =
     '<Package xmlns="http://soap.sforce.com/2006/04/metadata">';
   packageModuleEnd = '</Package>';
+  registryAccess = new RegistryAccess();
 
   public createManifest(
     components: MetadataComponent[],
-    apiVersion = new RegistryAccess().getApiVersion()
+    apiVersion = this.registryAccess.getApiVersion()
   ): string {
     let output = this.xmlDef.concat(this.packageModuleStart);
     const metadataMap = this.createMetadataMap(components);
@@ -43,7 +44,9 @@ export class ManifestGenerator {
       Set<string>
     >();
     for (const component of components) {
-      const metadataType = component.type.name;
+      const metadataType = this.registryAccess.getTypeFromName(
+        component.type.name
+      ).name;
       const metadataName = component.fullName;
       if (metadataMap.has(metadataType)) {
         const metadataNames = metadataMap.get(metadataType);

--- a/test/metadata-registry/manifestGenerator.test.ts
+++ b/test/metadata-registry/manifestGenerator.test.ts
@@ -8,6 +8,7 @@
 import { ManifestGenerator } from '../../src/metadata-registry/manifestGenerator';
 import { MetadataComponent } from '../../src/metadata-registry/types';
 import { expect } from 'chai';
+import { AssertionError } from 'assert';
 
 describe('ManifestGenerator', () => {
   const manifestGenerator = new ManifestGenerator();
@@ -112,5 +113,22 @@ describe('ManifestGenerator', () => {
     expect(manifestGenerator.createManifest([component], '45.0')).to.equal(
       '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><types><members>someName</members><name>ApexClass</name></types><version>45.0</version></Package>'
     );
+  });
+
+  it('should throw error for non valid type', () => {
+    const component = {
+      fullName: 'someName',
+      type: { name: 'someveryunknowntype' },
+      xml: '',
+      sources: []
+    } as MetadataComponent;
+    try {
+      manifestGenerator.createManifest([component]);
+      expect.fail('should have failed');
+    } catch (e) {
+      expect(e.message).to.equal(
+        "Missing metadata type definition in registry for id 'someveryunknowntype'"
+      );
+    }
   });
 });


### PR DESCRIPTION
Because we can't predict the suffix of a mixed content type's metadata xml, there's a chance it can collide with another type of the same suffix. E.g. AuraDefinitionBundle has a .app suffix but so does CustomApplication 

@W-7393931@