### PR TITLE
Update order of items inside a manifest types tag @W-7832373@

### DIFF
--- a/src/metadata-registry/manifestGenerator.ts
+++ b/src/metadata-registry/manifestGenerator.ts
@@ -39,10 +39,10 @@ export class ManifestGenerator {
     const metadataMap = this.createMetadataMap(components);
     for (const metadataType of metadataMap.keys()) {
       output = output.concat('  <types>\n');
-      output = output.concat(`    <name>${metadataType}</name>\n`);
       for (const metadataName of metadataMap.get(metadataType)) {
         output = output.concat(`    <members>${metadataName}</members>\n`);
       }
+      output = output.concat(`    <name>${metadataType}</name>\n`);
       output = output.concat('  </types>\n');
     }
     output = output.concat(`  <version>${apiVersion}</version>\n`, this.packageModuleEnd);

--- a/test/metadata-registry/manifestGenerator.test.ts
+++ b/test/metadata-registry/manifestGenerator.test.ts
@@ -31,7 +31,7 @@ describe('ManifestGenerator', () => {
     let expectedManifest = '<?xml version="1.0" encoding="UTF-8"?>\n';
     expectedManifest += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexClass</name>\n    <members>someName</members>\n  </types>\n';
+      '  <types>\n    <members>someName</members>\n    <name>ApexClass</name>\n  </types>\n';
     expectedManifest += '  <version>48.0</version>\n</Package>';
     expect(manifestGenerator.createManifest([component])).to.equal(expectedManifest);
   });
@@ -47,9 +47,9 @@ describe('ManifestGenerator', () => {
     let expectedManifest = '<?xml version="1.0" encoding="UTF-8"?>\n';
     expectedManifest += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexClass</name>\n    <members>apexClass1</members>\n  </types>\n';
+      '  <types>\n    <members>apexClass1</members>\n    <name>ApexClass</name>\n  </types>\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexTrigger</name>\n    <members>apexTrigger1</members>\n  </types>\n';
+      '  <types>\n    <members>apexTrigger1</members>\n    <name>ApexTrigger</name>\n  </types>\n';
     expectedManifest += '  <version>48.0</version>\n</Package>';
     expect(manifestGenerator.createManifest([component1, component2])).to.equal(expectedManifest);
   });
@@ -69,9 +69,9 @@ describe('ManifestGenerator', () => {
     let expectedManifest = '<?xml version="1.0" encoding="UTF-8"?>\n';
     expectedManifest += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexClass</name>\n    <members>apexClass1</members>\n    <members>apexClass2</members>\n  </types>\n';
+      '  <types>\n    <members>apexClass1</members>\n    <members>apexClass2</members>\n    <name>ApexClass</name>\n  </types>\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexTrigger</name>\n    <members>apexTrigger1</members>\n  </types>\n';
+      '  <types>\n    <members>apexTrigger1</members>\n    <name>ApexTrigger</name>\n  </types>\n';
     expectedManifest += '  <version>48.0</version>\n</Package>';
     expect(manifestGenerator.createManifest([component1, component2, component3])).to.equal(
       expectedManifest
@@ -93,9 +93,9 @@ describe('ManifestGenerator', () => {
     let expectedManifest = '<?xml version="1.0" encoding="UTF-8"?>\n';
     expectedManifest += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexClass</name>\n    <members>apexClass1</members>\n    <members>apexClass2</members>\n  </types>\n';
+      '  <types>\n    <members>apexClass1</members>\n    <members>apexClass2</members>\n    <name>ApexClass</name>\n  </types>\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexTrigger</name>\n    <members>apexTrigger1</members>\n  </types>\n';
+      '  <types>\n    <members>apexTrigger1</members>\n    <name>ApexTrigger</name>\n  </types>\n';
     expectedManifest += '  <version>48.0</version>\n</Package>';
     expect(manifestGenerator.createManifest([component1, component3, component2])).to.equal(
       expectedManifest
@@ -109,7 +109,7 @@ describe('ManifestGenerator', () => {
     let expectedManifest = '<?xml version="1.0" encoding="UTF-8"?>\n';
     expectedManifest += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n';
     expectedManifest +=
-      '  <types>\n    <name>ApexClass</name>\n    <members>someName</members>\n  </types>\n';
+      '  <types>\n    <members>someName</members>\n    <name>ApexClass</name>\n  </types>\n';
     expectedManifest += '  <version>45.0</version>\n</Package>';
     expect(manifestGenerator.createManifest([component], '45.0')).to.equal(expectedManifest);
   });


### PR DESCRIPTION
### What does this PR do?
These changes update the manifest `<types>` content order. Although the manifest does work when using it for deploy/retrieve operations, the format does not follow our doc samples and what customers expect.

Currently we output:
```
  <types>
    <name>AuraDefinitionBundle</name>
    <members>myFancyCmp</members>
  </types>
```
And this PR updates it to be
```
  <types>
    <members>dummyCmp</members>
    <name>AuraDefinitionBundle</name>
  </types>
```
