### PR TITLE
Update to Typescript 3.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sinon": "^7.3.1",
     "source-map-support": "^0.5.16",
     "ts-node": "^8.7.0",
-    "typescript": "~3.3"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "shx rm -rf ./lib && tsc -b",

--- a/test/metadata-registry/manifestGenerator.test.ts
+++ b/test/metadata-registry/manifestGenerator.test.ts
@@ -11,7 +11,6 @@ import { RegistryAccess, SourceComponent, registryData } from '../../src/metadat
 import { SinonSandbox, createSandbox } from 'sinon';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as stream from 'stream';
 import { fail } from 'assert';
 
 describe('ManifestGenerator', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,10 +3290,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@~3.3:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
### What does this PR do?
Updating to Typescript 3.7.5 to match the version being used by the vscode extensions.

### What issues does this PR fix or reference?

@W-7854050@
