### PR TITLE
Migrate common types

### DIFF
--- a/src/client/deployStrategies/auraDeploy.ts
+++ b/src/client/deployStrategies/auraDeploy.ts
@@ -7,7 +7,7 @@
 import { readFileSync } from 'fs';
 import { AuraDefinition } from '../../utils/deploy';
 import { extName, baseName } from '../../utils';
-import { SourcePath } from '../../types';
+import { SourcePath } from '../../common';
 import {
   ComponentStatus,
   ComponentDeployment,

--- a/src/client/diagnosticUtil.ts
+++ b/src/client/diagnosticUtil.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 import { registryData } from '../metadata-registry';
 import { basename } from 'path';
 import { ComponentDeployment, DeployMessage, ComponentDiagnostic } from './types';

--- a/src/client/metadataApi.ts
+++ b/src/client/metadataApi.ts
@@ -22,7 +22,7 @@ import { MetadataConverter } from '../convert';
 import { DeployError } from '../errors';
 import { SourceComponent } from '../metadata-registry';
 import { DiagnosticUtil } from './diagnosticUtil';
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 
 export const DEFAULT_API_OPTIONS = {
   rollbackOnError: true,

--- a/src/client/toolingApi.ts
+++ b/src/client/toolingApi.ts
@@ -6,7 +6,7 @@
  */
 import { getDeployStrategy } from './deployStrategies';
 import { SourceClientError } from '../errors';
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 import { nls } from '../i18n';
 import { buildQuery, queryToFileMap } from './retrieveUtil';
 import { createFiles } from '../utils';

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Connection } from '@salesforce/core';
-import { SourcePath } from '../types/common';
+import { SourcePath } from '../common/types';
 import { RegistryAccess, SourceComponent } from '../metadata-registry';
 
 // ------------------------------------------------

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export { MetadataType, MetadataComponent, SourcePath } from './types';

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TypeIndex, SuffixIndex } from './registry';
+import { TypeIndex, SuffixIndex } from '../types/registry';
 
 /**
  * File system path to a source file of a metadata component.

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SfdxFileFormat, ConvertOutputConfig, SourcePath, ConvertResult } from '../types';
+import { SfdxFileFormat, ConvertOutputConfig, ConvertResult } from '../types';
 import { ManifestGenerator, RegistryAccess, SourceComponent } from '../metadata-registry';
 import { promises } from 'fs';
 import { join } from 'path';
@@ -19,6 +19,7 @@ import {
 } from './streams';
 import { PACKAGE_XML_FILE, DEFAULT_PACKAGE_PREFIX } from '../utils/constants';
 import { ConversionError } from '../errors';
+import { SourcePath } from '../common';
 
 export class MetadataConverter {
   private registryAccess: RegistryAccess;

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -11,8 +11,9 @@ import { pipeline as cbPipeline, Readable, Transform, Writable } from 'stream';
 import { promisify } from 'util';
 import { LibraryError } from '../errors';
 import { RegistryAccess, SourceComponent } from '../metadata-registry';
-import { SfdxFileFormat, SourcePath, WriteInfo, WriterFormat } from '../types';
+import { SfdxFileFormat, WriteInfo, WriterFormat } from '../types';
 import { ensureFileExists } from '../utils/fileSystemHandler';
+import { SourcePath } from '../common';
 
 export const pipeline = promisify(cbPipeline);
 

--- a/src/convert/transformers/default.ts
+++ b/src/convert/transformers/default.ts
@@ -4,12 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { MetadataTransformer, WriterFormat, SourcePath } from '../../types';
+import { MetadataTransformer, WriterFormat } from '../../types';
 import { META_XML_SUFFIX } from '../../utils';
 import { createReadStream } from 'fs';
 import { sep, join, basename } from 'path';
 import { LibraryError } from '../../errors';
 import { SourceComponent } from '../../metadata-registry';
+import { SourcePath } from '../../common';
 
 /**
  * The default metadata transformer.

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { nls } from '../i18n';
-import { MetadataType, SourcePath } from '../types';
+import { MetadataType, SourcePath } from '../common';
 
 export class LibraryError extends Error {
   constructor(messageKey: string, args?: string | string[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,5 @@ export {
   VirtualTreeContainer,
   SourceComponent,
 } from './metadata-registry';
-export {
-  ConvertOutputConfig,
-  ConvertResult,
-  MetadataComponent,
-  TreeContainer,
-  VirtualDirectory,
-} from './types';
+export { ConvertOutputConfig, ConvertResult, TreeContainer, VirtualDirectory } from './types';
+export { MetadataComponent } from './common';

--- a/src/metadata-registry/adapters/baseSourceAdapter.ts
+++ b/src/metadata-registry/adapters/baseSourceAdapter.ts
@@ -4,14 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  SourceAdapter,
-  MetadataType,
-  MetadataRegistry,
-  SourcePath,
-  MetadataXml,
-  TreeContainer,
-} from '../../types';
+import { SourceAdapter, MetadataRegistry, MetadataXml, TreeContainer } from '../../types';
 import { parseMetadataXml } from '../../utils/registry';
 import * as registryData from '../data/registry.json';
 import { RegistryError, UnexpectedForceIgnore } from '../../errors';
@@ -20,6 +13,7 @@ import { ForceIgnore } from '../forceIgnore';
 import { dirname, basename } from 'path';
 import { NodeFSTreeContainer } from '../treeContainers';
 import { SourceComponent } from '../sourceComponent';
+import { MetadataType, SourcePath } from '../../common';
 
 export abstract class BaseSourceAdapter implements SourceAdapter {
   protected type: MetadataType;

--- a/src/metadata-registry/adapters/decomposedSourceAdapter.ts
+++ b/src/metadata-registry/adapters/decomposedSourceAdapter.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { MixedContentSourceAdapter } from './mixedContentSourceAdapter';
-import { SourcePath } from '../../types';
+import { SourcePath } from '../../common';
 import { parseMetadataXml } from '../../utils/registry';
 import { SourceComponent } from '../sourceComponent';
 

--- a/src/metadata-registry/adapters/defaultSourceAdapter.ts
+++ b/src/metadata-registry/adapters/defaultSourceAdapter.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { BaseSourceAdapter } from './baseSourceAdapter';
-import { SourcePath } from '../../types';
+import { SourcePath } from '../../common';
 import { SourceComponent } from '../sourceComponent';
 
 /**

--- a/src/metadata-registry/adapters/matchingContentSourceAdapter.ts
+++ b/src/metadata-registry/adapters/matchingContentSourceAdapter.ts
@@ -7,7 +7,7 @@
 import { META_XML_SUFFIX } from '../../utils';
 import { BaseSourceAdapter } from './baseSourceAdapter';
 import { ExpectedSourceFilesError, UnexpectedForceIgnore } from '../../errors';
-import { SourcePath } from '../../types';
+import { SourcePath } from '../../common';
 import { extName } from '../../utils/path';
 import { SourceComponent } from '../sourceComponent';
 

--- a/src/metadata-registry/adapters/mixedContentSourceAdapter.ts
+++ b/src/metadata-registry/adapters/mixedContentSourceAdapter.ts
@@ -8,7 +8,8 @@ import { BaseSourceAdapter } from './baseSourceAdapter';
 import { dirname, basename, sep } from 'path';
 import { ExpectedSourceFilesError } from '../../errors';
 import { baseName } from '../../utils/path';
-import { SourcePath, MetadataType, TreeContainer } from '../../types';
+import { SourcePath, MetadataType } from '../../common';
+import { TreeContainer } from '../../types';
 import { SourceComponent } from '../sourceComponent';
 
 /**

--- a/src/metadata-registry/adapters/sourceAdapterFactory.ts
+++ b/src/metadata-registry/adapters/sourceAdapterFactory.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { MetadataRegistry, MetadataType, SourceAdapter, TreeContainer } from '../../types';
+import { MetadataRegistry, SourceAdapter, TreeContainer } from '../../types';
 import { BundleSourceAdapter } from './bundleSourceAdapter';
 import { DecomposedSourceAdapter } from './decomposedSourceAdapter';
 import { MatchingContentSourceAdapter } from './matchingContentSourceAdapter';
@@ -12,6 +12,7 @@ import { MixedContentSourceAdapter } from './mixedContentSourceAdapter';
 import { DefaultSourceAdapter } from './defaultSourceAdapter';
 import { RegistryError } from '../../errors';
 import { ForceIgnore } from '../forceIgnore';
+import { MetadataType } from '../../common';
 
 enum AdapterId {
   Bundle = 'bundle',

--- a/src/metadata-registry/forceIgnore.ts
+++ b/src/metadata-registry/forceIgnore.ts
@@ -9,7 +9,7 @@ import * as gitignore from 'gitignore-parser';
 import { sep, relative, join, dirname, basename } from 'path';
 import { readFileSync } from 'fs';
 import { FORCE_IGNORE_FILE } from '../utils/constants';
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 import { searchUp } from '../utils/fileSystemHandler';
 
 export class ForceIgnore {

--- a/src/metadata-registry/manifestGenerator.ts
+++ b/src/metadata-registry/manifestGenerator.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataComponent } from '../types';
+import { MetadataComponent } from '../common';
 import { RegistryAccess } from './registryAccess';
 import { RegistryError } from '../errors';
 import { SourceComponent } from './sourceComponent';

--- a/src/metadata-registry/registryAccess.ts
+++ b/src/metadata-registry/registryAccess.ts
@@ -8,19 +8,14 @@ import { basename, dirname, join, sep } from 'path';
 import { NodeFSTreeContainer, registryData } from '.';
 import { MetadataTransformerFactory } from '../convert/transformers';
 import { TypeInferenceError } from '../errors';
-import {
-  MetadataRegistry,
-  MetadataTransformer,
-  MetadataType,
-  SourcePath,
-  TreeContainer,
-} from '../types';
+import { MetadataRegistry, MetadataTransformer, TreeContainer } from '../types';
 import { extName, parentName } from '../utils/path';
 import { deepFreeze, parseMetadataXml } from '../utils/registry';
 import { MixedContentSourceAdapter } from './adapters/mixedContentSourceAdapter';
 import { SourceAdapterFactory } from './adapters/sourceAdapterFactory';
 import { ForceIgnore } from './forceIgnore';
 import { SourceComponent } from './sourceComponent';
+import { MetadataType, SourcePath } from '../common';
 
 /**
  * Resolver for metadata type and component objects.

--- a/src/metadata-registry/sourceComponent.ts
+++ b/src/metadata-registry/sourceComponent.ts
@@ -4,18 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  MetadataType,
-  SourcePath,
-  TreeContainer,
-  VirtualDirectory,
-  MetadataComponent,
-} from '../types';
+import { TreeContainer, VirtualDirectory } from '../types';
 import { join, dirname } from 'path';
 import { ForceIgnore } from './forceIgnore';
 import { parseMetadataXml } from '../utils/registry';
 import { baseName } from '../utils';
 import { NodeFSTreeContainer, VirtualTreeContainer } from './treeContainers';
+import { MetadataType, SourcePath, MetadataComponent } from '../common';
 
 export type ComponentProperties = {
   name: string;

--- a/src/metadata-registry/treeContainers.ts
+++ b/src/metadata-registry/treeContainers.ts
@@ -4,12 +4,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourcePath, VirtualDirectory, TreeContainer } from '../types';
+import { VirtualDirectory, TreeContainer } from '../types';
 import { join, dirname, basename } from 'path';
 import { baseName } from '../utils';
 import { parseMetadataXml } from '../utils/registry';
 import { lstatSync, existsSync, readdirSync, promises as fsPromises } from 'fs';
 import { LibraryError } from '../errors';
+import { SourcePath } from '../common';
 
 /**
  * An extendable base class for implementing the `TreeContainer` interface

--- a/src/types/conversion.ts
+++ b/src/types/conversion.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourcePath } from './common';
+import { SourcePath } from '../common/types';
 import { Readable } from 'stream';
 import { SourceComponent } from '../metadata-registry';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export { MetadataType, MetadataComponent, SourcePath } from './common';
 export {
   MetadataRegistry,
   MetadataXml,

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataType, SourcePath } from './common';
+import { MetadataType, SourcePath } from '../common/types';
 import { SourceComponent } from '../metadata-registry';
 
 /**

--- a/src/utils/fileSystemHandler.ts
+++ b/src/utils/fileSystemHandler.ts
@@ -7,7 +7,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 
 export function ensureDirectoryExists(filePath: string): void {
   if (fs.existsSync(filePath)) {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -6,7 +6,7 @@
  */
 
 import { basename, dirname, extname } from 'path';
-import { SourcePath } from '../types';
+import { SourcePath } from '../common';
 
 /**
  * Get the file or directory name at the end of a path. Different from `path.basename`

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SourcePath, MetadataXml } from '../types';
+import { MetadataXml } from '../types';
 import { basename } from 'path';
+import { SourcePath } from '../common';
 
 /**
  * Returns the `MetadataXml` info from a given file path. If the path is not a

--- a/test/metadata-registry/adapters/baseSourceAdapter.ts
+++ b/test/metadata-registry/adapters/baseSourceAdapter.ts
@@ -9,7 +9,7 @@ import { mockRegistry } from '../../mock/registry';
 import { DefaultSourceAdapter } from '../../../src/metadata-registry/adapters/defaultSourceAdapter';
 import { expect, assert } from 'chai';
 import { BaseSourceAdapter } from '../../../src/metadata-registry/adapters/baseSourceAdapter';
-import { SourcePath } from '../../../src/types';
+import { SourcePath } from '../../../src/common';
 import { RegistryError, UnexpectedForceIgnore } from '../../../src/errors';
 import { nls } from '../../../src/i18n';
 import { RegistryTestUtil } from '../registryTestUtil';

--- a/test/metadata-registry/registryTestUtil.ts
+++ b/test/metadata-registry/registryTestUtil.ts
@@ -5,12 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { createSandbox, SinonSandbox } from 'sinon';
-import { SourcePath, MetadataType, VirtualDirectory } from '../../src/types';
+import { VirtualDirectory } from '../../src/types';
 import { ForceIgnore } from '../../src/metadata-registry/forceIgnore';
 import { SourceAdapterFactory } from '../../src/metadata-registry/adapters/sourceAdapterFactory';
 import { VirtualTreeContainer } from '../../src/metadata-registry/treeContainers';
 import { mockRegistry } from '../mock/registry';
 import { RegistryAccess, SourceComponent } from '../../src/metadata-registry';
+import { MetadataType, SourcePath } from '../../src/common';
 
 export class RegistryTestUtil {
   private env: SinonSandbox;

--- a/test/mock/registry/geneConstants.ts
+++ b/test/mock/registry/geneConstants.ts
@@ -6,7 +6,7 @@
  */
 import { mockRegistry } from '.';
 import { join } from 'path';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Constants for a type that uses the BaseSourceAdapter
 const type = mockRegistry.types.genewilder;

--- a/test/mock/registry/kathyConstants.ts
+++ b/test/mock/registry/kathyConstants.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { mockRegistry } from '.';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Constants for a type that uses the BaseSourceAdapter and is inFolder
 const type = mockRegistry.types.kathybates;

--- a/test/mock/registry/keanuConstants.ts
+++ b/test/mock/registry/keanuConstants.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { mockRegistry } from '.';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Constants for a matching content file type
 const type = mockRegistry.types.keanureeves;

--- a/test/mock/registry/reginaConstants.ts
+++ b/test/mock/registry/reginaConstants.ts
@@ -7,7 +7,7 @@
 import { join } from 'path';
 import { mockRegistry } from '.';
 import { baseName } from '../../../src/utils';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Constants for a decomposed type
 const type = mockRegistry.types.reginaking;

--- a/test/mock/registry/simonConstants.ts
+++ b/test/mock/registry/simonConstants.ts
@@ -6,7 +6,7 @@
  */
 import { mockRegistry } from '.';
 import { join } from 'path';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Bundle content
 const type = mockRegistry.types.simonpegg;

--- a/test/mock/registry/tarajiConstants.ts
+++ b/test/mock/registry/tarajiConstants.ts
@@ -6,7 +6,7 @@
  */
 import { join, basename, dirname } from 'path';
 import { mockRegistry } from '.';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Mixed content with directory as content
 const type = mockRegistry.types.tarajihenson;

--- a/test/mock/registry/tinaConstants.ts
+++ b/test/mock/registry/tinaConstants.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { mockRegistry } from '.';
-import { SourceComponent } from '../../../src/metadata-registry';
+import { SourceComponent } from '../../../src';
 
 // Mixed content type in folders
 const type = mockRegistry.types.tinafey;

--- a/test/utils/path.ts
+++ b/test/utils/path.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { expect } from 'chai';
-import { baseName } from '../../src/utils/path';
+import { baseName } from '../../src/utils';
 
 describe('Path Utils', () => {
   const root = join('path', 'to', 'whatever');


### PR DESCRIPTION
### What does this PR do?

Migrate common types to a new common module. Continuation of having types live in their respective module.