### PR TITLE
Migrate registry types

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { TypeIndex, SuffixIndex } from '../types/registry';
+import { TypeIndex, SuffixIndex } from '../metadata-registry';
 
 /**
  * File system path to a source file of a metadata component.

--- a/src/convert/transformers/metadataTransformerFactory.ts
+++ b/src/convert/transformers/metadataTransformerFactory.ts
@@ -5,9 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { RegistryError } from '../../errors';
-import { MetadataRegistry, MetadataTransformer } from '../../types';
+import { MetadataTransformer } from '../../types';
 import { DefaultTransformer } from './default';
 import { SourceComponent } from '../../metadata-registry/sourceComponent';
+import { MetadataRegistry } from '../../metadata-registry';
 
 const enum TransformerId {
   Standard = 'standard',

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export {
   BaseTreeContainer,
   VirtualTreeContainer,
   SourceComponent,
+  TreeContainer,
+  VirtualDirectory,
 } from './metadata-registry';
-export { ConvertOutputConfig, ConvertResult, TreeContainer, VirtualDirectory } from './types';
+export { ConvertOutputConfig, ConvertResult } from './types';
 export { MetadataComponent } from './common';

--- a/src/metadata-registry/adapters/baseSourceAdapter.ts
+++ b/src/metadata-registry/adapters/baseSourceAdapter.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourceAdapter, MetadataRegistry, MetadataXml, TreeContainer } from '../../types';
+import { SourceAdapter, MetadataRegistry, MetadataXml, TreeContainer } from '../types';
 import { parseMetadataXml } from '../../utils/registry';
 import * as registryData from '../data/registry.json';
 import { RegistryError, UnexpectedForceIgnore } from '../../errors';

--- a/src/metadata-registry/adapters/mixedContentSourceAdapter.ts
+++ b/src/metadata-registry/adapters/mixedContentSourceAdapter.ts
@@ -9,7 +9,7 @@ import { dirname, basename, sep } from 'path';
 import { ExpectedSourceFilesError } from '../../errors';
 import { baseName } from '../../utils/path';
 import { SourcePath, MetadataType } from '../../common';
-import { TreeContainer } from '../../types';
+import { TreeContainer } from '../types';
 import { SourceComponent } from '../sourceComponent';
 
 /**

--- a/src/metadata-registry/adapters/sourceAdapterFactory.ts
+++ b/src/metadata-registry/adapters/sourceAdapterFactory.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { MetadataRegistry, SourceAdapter, TreeContainer } from '../../types';
+import { MetadataRegistry, SourceAdapter, TreeContainer } from '../types';
 import { BundleSourceAdapter } from './bundleSourceAdapter';
 import { DecomposedSourceAdapter } from './decomposedSourceAdapter';
 import { MatchingContentSourceAdapter } from './matchingContentSourceAdapter';

--- a/src/metadata-registry/forceIgnore.ts
+++ b/src/metadata-registry/forceIgnore.ts
@@ -6,7 +6,7 @@
  */
 
 import ignore, { Ignore } from 'ignore/index';
-import { relative, join, dirname, basename } from 'path';
+import { relative, join, dirname } from 'path';
 import { readFileSync } from 'fs';
 import { FORCE_IGNORE_FILE } from '../utils/constants';
 import { SourcePath } from '../common';

--- a/src/metadata-registry/index.ts
+++ b/src/metadata-registry/index.ts
@@ -10,6 +10,15 @@ export { RegistryAccess } from './registryAccess';
 export { ManifestGenerator } from './manifestGenerator';
 export { BaseTreeContainer, NodeFSTreeContainer, VirtualTreeContainer } from './treeContainers';
 export { SourceComponent } from './sourceComponent';
+export {
+  MetadataRegistry,
+  MetadataXml,
+  SourceAdapter,
+  TreeContainer,
+  VirtualDirectory,
+  TypeIndex,
+  SuffixIndex,
+} from './types';
 
 /**
  * Direct access to the JSON registry data. Useful for autocompletions.

--- a/src/metadata-registry/registryAccess.ts
+++ b/src/metadata-registry/registryAccess.ts
@@ -5,10 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { basename, dirname, join, sep } from 'path';
-import { NodeFSTreeContainer, registryData } from '.';
+import { MetadataRegistry, TreeContainer } from './types';
 import { MetadataTransformerFactory } from '../convert/transformers';
 import { TypeInferenceError } from '../errors';
-import { MetadataRegistry, MetadataTransformer, TreeContainer } from '../types';
+import { MetadataTransformer } from '../types';
 import { extName, parentName } from '../utils/path';
 import { deepFreeze, parseMetadataXml } from '../utils/registry';
 import { MixedContentSourceAdapter } from './adapters/mixedContentSourceAdapter';
@@ -16,6 +16,8 @@ import { SourceAdapterFactory } from './adapters/sourceAdapterFactory';
 import { ForceIgnore } from './forceIgnore';
 import { SourceComponent } from './sourceComponent';
 import { MetadataType, SourcePath } from '../common';
+import { NodeFSTreeContainer } from './treeContainers';
+import { registryData } from '.';
 
 /**
  * Resolver for metadata type and component objects.

--- a/src/metadata-registry/sourceComponent.ts
+++ b/src/metadata-registry/sourceComponent.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { TreeContainer, VirtualDirectory } from '../types';
+import { TreeContainer, VirtualDirectory } from './types';
 import { join, dirname } from 'path';
 import { ForceIgnore } from './forceIgnore';
 import { parseMetadataXml } from '../utils/registry';

--- a/src/metadata-registry/treeContainers.ts
+++ b/src/metadata-registry/treeContainers.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { VirtualDirectory, TreeContainer } from '../types';
+import { VirtualDirectory, TreeContainer } from '../metadata-registry';
 import { join, dirname, basename } from 'path';
 import { baseName } from '../utils';
 import { parseMetadataXml } from '../utils/registry';

--- a/src/metadata-registry/types.ts
+++ b/src/metadata-registry/types.ts
@@ -6,7 +6,7 @@
  */
 
 import { MetadataType, SourcePath } from '../common/types';
-import { SourceComponent } from '../metadata-registry';
+import { SourceComponent } from '.';
 
 /**
  * Metadata type definitions

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,13 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-export {
-  MetadataRegistry,
-  MetadataXml,
-  SourceAdapter,
-  TreeContainer,
-  VirtualDirectory,
-} from './registry';
+
 export {
   ConvertResult,
   ConvertOutputConfig,

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataXml } from '../types';
+import { MetadataXml } from '../metadata-registry';
 import { basename } from 'path';
 import { SourcePath } from '../common';
 

--- a/test/client/diagnosticUtil.test.ts
+++ b/test/client/diagnosticUtil.test.ts
@@ -10,7 +10,7 @@ import { registryData, VirtualTreeContainer } from '../../src/metadata-registry'
 import { join } from 'path';
 import { expect } from 'chai';
 import { ComponentDeployment, ComponentStatus, DeployMessage } from '../../src/client/types';
-import { TreeContainer } from '../../src/types/registry';
+import { TreeContainer } from '../../src';
 
 function createDeployment(props: ComponentProperties, tree?: TreeContainer): ComponentDeployment {
   return {

--- a/test/metadata-registry/registryTestUtil.ts
+++ b/test/metadata-registry/registryTestUtil.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { createSandbox, SinonSandbox } from 'sinon';
-import { VirtualDirectory } from '../../src/types';
+import { VirtualDirectory } from '../../src';
 import { ForceIgnore } from '../../src/metadata-registry/forceIgnore';
 import { SourceAdapterFactory } from '../../src/metadata-registry/adapters/sourceAdapterFactory';
 import { VirtualTreeContainer } from '../../src/metadata-registry/treeContainers';

--- a/test/metadata-registry/treeContainers.test.ts
+++ b/test/metadata-registry/treeContainers.test.ts
@@ -15,7 +15,7 @@ import * as fs from 'fs';
 import { join } from 'path';
 import { LibraryError } from '../../src/errors';
 import { nls } from '../../src/i18n';
-import { VirtualDirectory } from '../../src/types';
+import { VirtualDirectory } from '../../src';
 
 describe('Tree Containers', () => {
   const readDirResults = ['a.q', 'a.x-meta.xml', 'b', 'b.x-meta.xml', 'c.z', 'c.x-meta.xml'];


### PR DESCRIPTION
### What does this PR do?

Migrates registry types to the metadata-registry module. Part 3 of a 4 part series of moving types to their own modules.