### PR TITLE
Compile tests instead of running with ts-node

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 /test
 /scripts
 /contributing
+/lib/test
 
 # Configuration files
 .eslintrc.json

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,9 @@
+{
+  "include": ["lib/src/**/*.js"],
+  "extension": [".js"],
+  "reporter": ["text", "text-summary"],
+  "sourceMap": true,
+  "exclude-after-remap": false,
+  "report-dir": "./test-results/coverage",
+  "temp-dir": "./test-results/coverage/.nyc_output"
+}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ to unlink the library:
 
 `yarn test` runs the suite and outputs code coverage as a text summary
 
-> When running tests, code changes don't need to be built with `yarn build` first since the test suite uses ts-node as its runtime environment. Otherwise, you should run `yarn build` before manually testing changes.
-
 ### Testing with the NPM artifact
 
 The library can also be installed to another local project as a regular NPM module. This is useful for manually testing the package that will be deployed to NPM. Use this instead of the linking process that's described under Development to QA changes before they are published:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.17",
   "gusBuild": "49.1.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/forcedotcom/source-deploy-retrieve#readme",
@@ -58,7 +58,6 @@
     "shx": "^0.3.2",
     "sinon": "^7.3.1",
     "source-map-support": "^0.5.16",
-    "ts-node": "^8.7.0",
     "typescript": "3.7.5"
   },
   "scripts": {
@@ -80,23 +79,5 @@
     "./{src,test}/**/*.{ts,js}": [
       "eslint -c .eslintrc.json --fix"
     ]
-  },
-  "nyc": {
-    "include": [
-      "src/**/*.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
-    ],
-    "reporter": [
-      "text",
-      "text-summary"
-    ],
-    "sourceMap": true,
-    "report-dir": "./test-results/coverage",
-    "temp-dir": "./test-results/coverage/.nyc_output"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --reporter ./test/combinedTestReporter.js
 --reporter-options mochaFile=./test-results/test-results.xml
---require ts-node/register
 --require source-map-support/register
-test/**/*.test.ts
+lib/test/**/*.test.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     "noImplicitAny": true,
     // Needed in order to import registry.json
     "resolveJsonModule": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "lib",
     "preserveConstEnums": true
   },
-  "exclude": ["node_modules", "lib", "test"]
+  "exclude": ["node_modules", "lib"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,11 +418,6 @@ archy@^1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -951,11 +946,6 @@ diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2091,11 +2081,6 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@^1.1.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
 md5@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
@@ -2962,7 +2947,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.17:
+source-map-support@^0.5.16:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -3233,17 +3218,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-ts-node@^8.7.0:
-  version "8.10.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
-  integrity sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
-
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
@@ -3482,11 +3456,6 @@ yargs@^13.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zip-stream@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
### What does this PR do?

Running tests with ts-node has become too big of an issue where it swallows errors in tests and won't tell use why they didn't run. Switching to compile instead.