### PR TITLE
Changelog for v1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.0.18 - August 6, 2020
+
+## Added
+
+- Add readFile to TreeContainer ([PR #96](https://github.com/forcedotcom/source-deploy-retrieve/pull/96))
+
+## Fixed
+
+- Replaced module `gitignore-parser` for parsing forceignore files with `ignore` ([PR #98](https://github.com/forcedotcom/source-deploy-retrieve/pull/98))
+
 # 1.0.17 - July 28, 2020
 
 ## Added


### PR DESCRIPTION
### What does this PR do?
Changelog updates for 1.0.18. This did not end up being pulled in for the release of 1.0.18 since the release was triggered off of the port PR.