### PR TITLE
Fix NetworkBranding content file not being included in conversion

### DIFF
--- a/src/metadata-registry/data/registry.json
+++ b/src/metadata-registry/data/registry.json
@@ -1701,6 +1701,7 @@
     "emailtemplate": { "adapter": "matchingContentFile" },
     "experiencebundle": { "adapter": "mixedContent" },
     "lightningcomponentbundle": { "adapter": "bundle" },
+    "networkbranding": { "adapter": "matchingContentFile" },
     "staticresource": { "adapter": "mixedContent" },
     "waveTemplates": { "adapter": "bundle" }
   },


### PR DESCRIPTION
### What does this PR do?

A NetworkBranding component's content file was not included in a conversion. It's because the registry incorrectly resolved the component on account of the type not having the right adapter assigned to it.

### What issues does this PR fix or reference?

@W-7931660@

### Resolved Component Before (missing content property)

```
SourceComponent {
    name: 'cbE_Bikes',
    type:
     { id: 'networkbranding',
       name: 'NetworkBranding',
       suffix: 'networkBranding',
       directoryName: 'networkBranding',
       inFolder: false },
    xml:
     '/Users/b.powell/dev/dx-projects/ebikes-lwc/force-app/main/default/networkBranding/cbE_Bikes.networkBranding-meta.xml',
    parent: undefined,
    _tree: NodeFSTreeContainer {},
    forceIgnore:
     ForceIgnore {
       parser: [Ignore],
       forceIgnoreDirectory: '/Users/b.powell/dev/dx-projects/ebikes-lwc' } }
```

### Resolved Component After (content property set)

```
SourceComponent {
    name: 'cbE_Bikes',
    type:
     { id: 'networkbranding',
       name: 'NetworkBranding',
       suffix: 'networkBranding',
       directoryName: 'networkBranding',
       inFolder: false },
    xml:
     '/Users/b.powell/dev/dx-projects/ebikes-lwc/force-app/main/default/networkBranding/cbE_Bikes.networkBranding-meta.xml',
    parent: undefined,
    content:
     '/Users/b.powell/dev/dx-projects/ebikes-lwc/force-app/main/default/networkBranding/cbE_Bikes.networkBranding',
    _tree: NodeFSTreeContainer {},
    forceIgnore:
     ForceIgnore {
       parser: [Ignore],
       forceIgnoreDirectory: '/Users/b.powell/dev/dx-projects/ebikes-lwc' } }
```
