### PR TITLE
Fix CustomSite components being identified as SiteDotComs

### DIFF
--- a/scripts/metadata-registry/update.js
+++ b/scripts/metadata-registry/update.js
@@ -70,7 +70,7 @@ function update() {
 
     // populate mixedContent index
     if (!suffix) {
-      registry.mixedContent[directoryName] = typeId;
+      registry.strictTypeFolder[directoryName] = typeId;
     }
   }
 

--- a/src/metadata-registry/adapters/baseSourceAdapter.ts
+++ b/src/metadata-registry/adapters/baseSourceAdapter.ts
@@ -105,7 +105,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
     const metaXml = parseMetadataXml(path);
     if (metaXml) {
       let isRootMetadataXml = false;
-      const requireStrictParent = !!this.registry.mixedContent[this.type.directoryName];
+      const requireStrictParent = !!this.registry.strictTypeFolder[this.type.directoryName];
       if (requireStrictParent) {
         const parentPath = dirname(path);
         const typeDirName = basename(this.type.inFolder ? dirname(parentPath) : parentPath);

--- a/src/metadata-registry/data/registry.json
+++ b/src/metadata-registry/data/registry.json
@@ -1679,34 +1679,66 @@
     "documentFolder": "documentfolder",
     "emailFolder": "emailFolder"
   },
-  "mixedContent": {
+  "strictTypeFolder": {
     "experiences": "experiencebundle",
     "aura": "auradefinitionbundle",
     "lwc": "lightningcomponentbundle",
     "documents": "document",
     "waveTemplates": "wavetemplatebundle",
     "objects": "customobject",
-    "staticresources": "staticresource"
+    "staticresources": "staticresource",
+    "sites": "customsite"
   },
   "strategies": {
-    "apexclass": { "adapter": "matchingContentFile" },
-    "apexpage": { "adapter": "matchingContentFile" },
-    "apexcomponent": { "adapter": "matchingContentFile" },
-    "apextrigger": { "adapter": "matchingContentFile" },
-    "auradefinitionbundle": { "adapter": "bundle" },
-    "certificate": { "adapter": "matchingContentFile" },
-    "contentasset": { "adapter": "matchingContentFile" },
+    "apexclass": {
+      "adapter": "matchingContentFile"
+    },
+    "apexpage": {
+      "adapter": "matchingContentFile"
+    },
+    "apexcomponent": {
+      "adapter": "matchingContentFile"
+    },
+    "apextrigger": {
+      "adapter": "matchingContentFile"
+    },
+    "auradefinitionbundle": {
+      "adapter": "bundle"
+    },
+    "certificate": {
+      "adapter": "matchingContentFile"
+    },
+    "contentasset": {
+      "adapter": "matchingContentFile"
+    },
     "customobject": {
       "adapter": "decomposed",
       "transformer": "decomposed"
     },
-    "document": { "adapter": "mixedContent" },
-    "emailtemplate": { "adapter": "matchingContentFile" },
-    "experiencebundle": { "adapter": "mixedContent" },
-    "lightningcomponentbundle": { "adapter": "bundle" },
-    "networkbranding": { "adapter": "matchingContentFile" },
-    "staticresource": { "adapter": "mixedContent" },
-    "wavetemplatebundle": { "adapter": "bundle" }
+    "document": {
+      "adapter": "mixedContent"
+    },
+    "emailtemplate": {
+      "adapter": "matchingContentFile"
+    },
+    "experiencebundle": {
+      "adapter": "mixedContent"
+    },
+    "lightningcomponentbundle": {
+      "adapter": "bundle"
+    },
+    "networkbranding": {
+      "adapter": "matchingContentFile"
+    },
+    "sitedotcom": {
+      "adapter": "matchingContentFile"
+    },
+    "staticresource": {
+      "adapter": "mixedContent"
+    },
+    "wavetemplatebundle": {
+      "adapter": "bundle"
+    }
   },
   "apiVersion": "48.0"
 }

--- a/src/metadata-registry/registryAccess.ts
+++ b/src/metadata-registry/registryAccess.ts
@@ -98,7 +98,7 @@ export class RegistryAccess {
           components.push(component);
           // don't traverse further if not in a root type directory. performance optimization
           // for mixed content types and ensures we don't add duplicates of the component.
-          const isMixedContent = !!this.registry.mixedContent[component.type.directoryName];
+          const isMixedContent = !!this.registry.strictTypeFolder[component.type.directoryName];
           const typeDir = basename(dirname(component.type.inFolder ? dirname(fsPath) : fsPath));
           if (isMixedContent && typeDir !== component.type.directoryName) {
             return components;
@@ -137,11 +137,11 @@ export class RegistryAccess {
   private resolveType(fsPath: SourcePath): MetadataType | undefined {
     let typeId: string;
 
-    // attempt 1 - check if the file is part of a mixed content type
+    // attempt 1 - check if the file is part of a component that requires a strict type folder
     const pathParts = new Set(fsPath.split(sep));
-    for (const directoryName of Object.keys(this.registry.mixedContent)) {
+    for (const directoryName of Object.keys(this.registry.strictTypeFolder)) {
       if (pathParts.has(directoryName)) {
-        typeId = this.registry.mixedContent[directoryName];
+        typeId = this.registry.strictTypeFolder[directoryName];
         // types with folders only have folder components living at the top level.
         // if the fsPath is a folder component, let a future strategy deal with it
         const isFolderType = this.getTypeFromName(typeId).inFolder;

--- a/src/metadata-registry/types.ts
+++ b/src/metadata-registry/types.ts
@@ -31,7 +31,7 @@ export type MetadataRegistry = {
   /**
    * Index mapping directoryNames to type ids for types with mixed content.
    */
-  mixedContent: {
+  strictTypeFolder: {
     [directoryName: string]: string;
   };
   /**

--- a/test/mock/registry/index.ts
+++ b/test/mock/registry/index.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
+import { MetadataRegistry } from '../../../src/metadata-registry';
 
-export const mockRegistry = {
+export const mockRegistry: MetadataRegistry = {
   types: {
     kathybates: {
       id: 'kathybates',
@@ -111,7 +112,7 @@ export const mockRegistry = {
     reginaking: 'regina',
     sean: 'seanconnerys',
   },
-  mixedContent: {
+  strictTypeFolder: {
     dwaynes: 'dwaynejohnson',
     tarajis: 'tarajihenson',
     simons: 'simonpegg',


### PR DESCRIPTION
### What does this PR do?

Sets the proper configuration for CustomSite and SiteDotCom in the registry so that the former isn't misidentified as the latter. This is done by making CustomSites require the type folder name in the path to a component of that type.

### What issues does this PR fix or reference?

@W-7931666@

### Functionality Before

CustomSites identified as SiteDotComs

### Functionality After

CustomSites identified as CustomSites
