### PR TITLE
Fix zip conversion when directories do not exist

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -7,7 +7,7 @@
 import { SfdxFileFormat, ConvertOutputConfig, ConvertResult } from './types';
 import { ManifestGenerator, RegistryAccess, SourceComponent } from '../metadata-registry';
 import { promises } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { ensureDirectoryExists } from '../utils/fileSystemHandler';
 import { Writable } from 'stream';
 import {
@@ -53,7 +53,6 @@ export class MetadataConverter {
         case 'directory':
           writer = new StandardWriter(packagePath);
           const manifestPath = join(packagePath, PACKAGE_XML_FILE);
-          ensureDirectoryExists(packagePath);
           tasks.push(promises.writeFile(manifestPath, manifestContents));
           break;
         case 'zip':
@@ -86,7 +85,12 @@ export class MetadataConverter {
     if (outputDirectory) {
       const name = packageName || `${DEFAULT_PACKAGE_PREFIX}_${Date.now()}`;
       packagePath = join(outputDirectory, name);
-      packagePath += outputConfig.type === 'zip' ? '.zip' : '';
+      if (outputConfig.type === 'zip') {
+        packagePath += '.zip';
+        ensureDirectoryExists(dirname(packagePath));
+      } else {
+        ensureDirectoryExists(packagePath);
+      }
     }
     return packagePath;
   }

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -11,7 +11,7 @@ import { ManifestGenerator, RegistryAccess, registryData } from '../../src/metad
 import * as streams from '../../src/convert/streams';
 import * as fs from 'fs';
 import * as fsUtil from '../../src/utils/fileSystemHandler';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { expect, assert } from 'chai';
 import { PACKAGE_XML_FILE, DEFAULT_PACKAGE_PREFIX } from '../../src/utils/constants';
 import { ConversionError } from '../../src/errors';
@@ -132,6 +132,18 @@ describe('MetadataConverter', () => {
   });
 
   describe('Zip Output', () => {
+    it('should ensure directory exists before starting conversion', async () => {
+      const zipPath = packageOutput + '.zip';
+      await converter.convert(components, 'metadata', {
+        type: 'zip',
+        outputDirectory,
+        packageName,
+      });
+
+      expect(ensureDirectoryStub.calledBefore(pipelineStub)).to.be.true;
+      expect(ensureDirectoryStub.firstCall.args[0]).to.equal(dirname(zipPath));
+    });
+
     it('should create conversion pipeline with fs write configuration', async () => {
       await converter.convert(components, 'metadata', {
         type: 'zip',


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with metadata conversion. If a directory in the provided output path does not exist (for zip or directory format), we automatically create the needed directories

### What issues does this PR fix or reference?

@W-8091341@


