### PR TITLE
chore: update change log date for 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.1.5 - September 30, 2020
+# 1.1.5 - October 1, 2020
 
-## Added 
+## Added
 
 - Add ZipTreeContainer and stream() to TreeContainer interface ([PR #154](https://github.com/forcedotcom/source-deploy-retrieve/pull/154))
 


### PR DESCRIPTION
### What does this PR do?
Minor update to date in change log.