### PR TITLE
fix: decomposing an object should not create empty parent xml

### DIFF
--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -64,6 +64,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     const composedMetadata = (await component.parseXml())[type.name];
     const rootXmlObject: XmlJson = { [type.name]: {} };
 
+    let childrenOnlyTags = true;
     for (const [tagName, collection] of Object.entries(composedMetadata)) {
       const childTypeId = type?.children?.directories[tagName];
 
@@ -92,17 +93,20 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
           });
         }
       } else {
+        childrenOnlyTags = false;
         rootXmlObject[type.name][tagName] = collection as JsonArray;
       }
     }
 
-    writeInfos.push({
-      source: new JsToXml(rootXmlObject),
-      relativeDestination: join(
-        rootPackagePath,
-        `${parentFullName}.${type.suffix}${META_XML_SUFFIX}`
-      ),
-    });
+    if (!childrenOnlyTags) {
+      writeInfos.push({
+        source: new JsToXml(rootXmlObject),
+        relativeDestination: join(
+          rootPackagePath,
+          `${parentFullName}.${type.suffix}${META_XML_SUFFIX}`
+        ),
+      });
+    }
 
     return { component, writeInfos };
   }

--- a/test/convert/transformers/decomposedMetadataTransformer.ts
+++ b/test/convert/transformers/decomposedMetadataTransformer.ts
@@ -235,5 +235,69 @@ describe('DecomposedMetadataTransformer', () => {
         ],
       });
     });
+
+    it('should not create parent xml during decomposition when only children are being decomposed', async () => {
+      const { type, fullName } = component;
+      const transformer = new DecomposedMetadataTransformer(mockRegistry);
+      const root = join('main', 'default', type.directoryName, fullName);
+      env.stub(component, 'parseXml').resolves({
+        ReginaKing: {
+          ys: { fullName: 'child', test: 'testVal' },
+          xs: [
+            { fullName: 'child2', test: 'testVal2' },
+            { fullName: 'child3', test: 'testVal3' },
+          ],
+        },
+      });
+
+      const result = await transformer.toSourceFormat(component);
+      expect(result).to.deep.equal({
+        component,
+        writeInfos: [
+          {
+            source: new JsToXml({
+              Y: {
+                [XML_NS_KEY]: XML_NS,
+                fullName: 'child',
+                test: 'testVal',
+              },
+            }),
+            relativeDestination: join(
+              root,
+              type.children.types.y.directoryName,
+              'child.y-meta.xml'
+            ),
+          },
+          {
+            source: new JsToXml({
+              X: {
+                [XML_NS_KEY]: XML_NS,
+                fullName: 'child2',
+                test: 'testVal2',
+              },
+            }),
+            relativeDestination: join(
+              root,
+              type.children.types.x.directoryName,
+              'child2.x-meta.xml'
+            ),
+          },
+          {
+            source: new JsToXml({
+              X: {
+                [XML_NS_KEY]: XML_NS,
+                fullName: 'child3',
+                test: 'testVal3',
+              },
+            }),
+            relativeDestination: join(
+              root,
+              type.children.types.x.directoryName,
+              'child3.x-meta.xml'
+            ),
+          },
+        ],
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where a parent xml is created during decomposition when there are only children tags present in the object

### What issues does this PR fix or reference?

@W-8120029@

