### PR TITLE
chore: add context restriction for publish-workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ workflows:
         - hold: # Requires manual approval in Circle Ci
             type: approval
         - publish:
+            context: pdt-publish-restricted-context
             filters:
               branches:
                 only:


### PR DESCRIPTION
### What does this PR do?
Restricts approval access for circle ci workflows. Only members of the GitHub Team 'PDT' should be able to approve workflows for publishing.

### What issues does this PR fix or reference?
@W-8165486@