### PR TITLE
chore: update port PR logic to handle better errors and updates for local branches

### DIFF
--- a/scripts/port-changes.js
+++ b/scripts/port-changes.js
@@ -173,11 +173,10 @@ function isTrueDiff(commitMap) {
 function getPortBranch(baseBranch, version) {
   if (ADD_VERBOSE_LOGGING)
     console.log('\n\nStep 5: Generate the port PR branch based on -r argument');
-  const result = shell.exec(`git checkout -b portPR-v${version} ${baseBranch}`).code;
-  if (result !== 0) {
-    console.log('\n\nManual review required. Unable to generate port branch.');
-    process.exit(-1);
-  }
+  checkErrorCode(
+    shell.exec(`git checkout -b portPR-v${version} ${baseBranch}`).code,
+    '\n\nManual review required. Unable to generate port branch.'
+  );
 }
 
 function getCherryPickCommits(diffList) {


### PR DESCRIPTION
### What does this PR do?
1. Adds checks for error codes instead of strings. If an error code is not 0, we will exit with an error.
2. Changes the local branch update logic. Previously this was not accounting for fetches being performed on the current branch. By default this isn't allowed, which was causing an error. We can make use of the '-u' option, but per git man I don't believe we should use this flag. Instead, we will now just checkout main and do a pull to avoid this issue. It also ensures we always have the latest version as well.

-u flag Information:
> By default git fetch refuses to update the head which corresponds to the current branch. This flag disables the check. This is purely for the internal use for git pull to communicate with git fetch, and unless you are implementing your own Porcelain you are not supposed to use it.

### What issues does this PR fix or reference?
@W-8189197@
