### PR TITLE
Fix for forceignore on windows with trailing slashes

### DIFF
--- a/test/metadata-registry/forceIgnore.test.ts
+++ b/test/metadata-registry/forceIgnore.test.ts
@@ -50,7 +50,9 @@ describe('ForceIgnore', () => {
     readStub.withArgs(forceIgnorePath).returns(testPattern);
     const forceIgnore = new ForceIgnore(forceIgnorePath);
 
-    let expected = {
+    const file = join('some', 'path', '__tests__', 'myTest.x');
+
+    const expected = {
       eventName: 'FORCE_IGNORE_DIFFERENCE',
       content:
         '**/__tests__/**\n**/*.dup\n**/.*\n**/package2-descriptor.json\n**/package2-manifest.json',
@@ -63,26 +65,8 @@ describe('ForceIgnore', () => {
         '**/package2-descriptor.json',
         '**/package2-manifest.json',
       ],
-      file: 'some/path/__tests__/myTest.x',
+      file,
     };
-
-    if (process.platform === 'win32') {
-      expected = {
-        content:
-          '**\\__tests__\\**\n**\\*.dup\n**\\.*\n**\\package2-descriptor.json\n**\\package2-manifest.json',
-        eventName: 'FORCE_IGNORE_DIFFERENCE',
-        file: 'some\\path\\__tests__\\myTest.x',
-        ignoreLines: [
-          '**\\__tests__\\**',
-          '**\\*.dup',
-          '**\\.*',
-          '**\\package2-descriptor.json',
-          '**\\package2-manifest.json',
-        ],
-        newLibraryResults: true,
-        oldLibraryResults: false,
-      };
-    }
 
     const telemetrySpy = env.spy(Lifecycle.prototype, 'emit');
     // @ts-ignore call the private method directly to avoid excessive stubbing
@@ -90,6 +74,22 @@ describe('ForceIgnore', () => {
     expect(telemetrySpy.calledOnce).to.be.true;
     expect(telemetrySpy.args[0][0]).to.equal('telemetry');
     expect(telemetrySpy.args[0][1]).to.deep.equal(expected);
+  });
+
+  it('Should handle forward slashes on windows', () => {
+    const readStub = env.stub(fs, 'readFileSync');
+    readStub.withArgs(forceIgnorePath).returns('force-app/main/default/classes/');
+    const fi = new ForceIgnore(forceIgnorePath);
+    // @ts-ignore private field
+    expect(fi.parser, 'if constructor throws, parser is not defined').to.not.equal(undefined);
+  });
+
+  it('Should have the correct default in the case the parsers are not initialized', () => {
+    const readStub = env.stub(fs, 'readFileSync');
+    readStub.withArgs(forceIgnorePath).returns('force-app/main/default/classes/');
+    const fi = new ForceIgnore(forceIgnorePath);
+    // @ts-ignore private field
+    expect(fi.accepts(join('force-app', 'main', 'default', 'classes'))).to.be.true;
   });
 
   /**


### PR DESCRIPTION
### What does this PR do?
This PR fixes the way trailing slashes are handled for windows in forceignore files. An error being thrown would cause the `parser` field on the `ForceIgnore` instance to be `undefined` which would cause `denies` and `accepts` methods to return their defaults.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/690

### Functionality Before
On windows, `ForceIgnore` with forceignore files with forward-slashes would fail with the `ignore` package due to  extra `parseContents` parsing. This would leave the instance with method defaults for  `accepts` and `denies` methods.

### Functionality After
`ForceIgnore` does not try eager `parseContents` before using the `ignore` package relying on its default windows handling.
