### PR TITLE
chore: export a retrieve result type

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,6 +14,7 @@ export {
   RetrieveOptions,
   RetrievePathOptions,
   SourceDeployResult,
+  RetrieveMessage,
   SourceRetrieveResult,
   ToolingDeployOptions,
   ToolingDeployStatus,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
   RetrieveOptions,
   RetrievePathOptions,
   SourceDeployResult,
+  RetrieveMessage,
   SourceRetrieveResult,
   ToolingDeployOptions,
   ToolingDeployStatus,


### PR DESCRIPTION
### What does this PR do?
This PR exports RetrieveMessage so consumers can easily parse SourceRetrieveResult after a retrieve operation

### What issues does this PR fix or reference?

 @W-8277418@

