### PR TITLE
fix: make forceignore exported as a top level feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,5 +29,6 @@ export {
   SourceComponent,
   TreeContainer,
   VirtualDirectory,
+  ForceIgnore,
 } from './metadata-registry';
 export { MetadataType, MetadataComponent, SourcePath } from './common';

--- a/src/metadata-registry/index.ts
+++ b/src/metadata-registry/index.ts
@@ -25,6 +25,7 @@ export {
   SuffixIndex,
   DecompositionStrategy,
 } from './types';
+export { ForceIgnore } from './forceIgnore';
 
 /**
  * Direct access to the JSON registry data. Useful for autocompletions.


### PR DESCRIPTION
### What does this PR do?
Surfaces `ForceIgnore` to the top of the library so it can be imported using `@salesforce/source-deploy-retrieve`

### What issues does this PR fix or reference?
@W-8291059@
