### PR TITLE
feat: multiple resolve targets when parsing manifest

### DIFF
--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -29,7 +29,7 @@ export interface FromSourceOptions extends WorkingSetOptions {
 }
 
 export interface FromManifestOptions extends FromSourceOptions {
-  resolve?: string | Iterable<string>;
+  resolve?: Iterable<string>;
   literalWildcard?: boolean;
 }
 

--- a/src/collections/workingSet.ts
+++ b/src/collections/workingSet.ts
@@ -93,6 +93,7 @@ export class WorkingSet implements MetadataSet, Iterable<MetadataComponent> {
     }
 
     if (shouldResolve) {
+      // if it's a string, don't iterate over the characters
       const toResolve = typeof options.resolve === 'string' ? [options.resolve] : options.resolve;
       for (const fsPath of toResolve) {
         ws.resolveSourceComponents(fsPath, {

--- a/test/collections/workingSet.test.ts
+++ b/test/collections/workingSet.test.ts
@@ -201,7 +201,7 @@ describe('WorkingSet', () => {
         expect(Array.from(ws)).to.deep.equal(expected);
       });
 
-      it('should initialize with source backed components when specifying iterable resolve option', async () => {
+      it('should initialize with source backed components when specifying non-string iterable resolve option', async () => {
         const ws = await WorkingSet.fromManifestFile('subset.xml', {
           registry: mockRegistry,
           tree,


### PR DESCRIPTION
### What does this PR do?

Allows specifying multiple targets to resolve source components from a manifest against. This covers the use case of resolving source components for multiple package directories.

```typescript
const ws = await WorkingSet.fromManifestFile('package.xml', {
  resolve: ['/path/to/force-app', '/path/to/test-app', '/path/to/another-one']
});

// or

const ws = await WorkingSet.fromManifestFile('package.xml', {
  resolve: '/path/to/force-app'
});
```

### What issues does this PR fix or reference?

@W-8507891@
