### PR TITLE
fix: add component to component set even when source unresolved

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,7 @@ export {
   MetadataApiDeployOptions,
   RetrieveOptions,
   RetrievePathOptions,
+  RetrieveStatus,
   SourceDeployResult,
   RetrieveMessage,
   SourceRetrieveResult,

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -83,11 +83,11 @@ export class ComponentSet implements Iterable<MetadataComponent> {
     ws.apiVersion = manifestObj.Package.version;
 
     for (const component of ComponentSet.getComponentsFromManifestObject(manifestObj, registry)) {
-      const memberIsWildcard = component.fullName === ComponentSet.WILDCARD;
       if (shouldResolve) {
         filterSet.add(component);
       }
-      if (!shouldResolve || (memberIsWildcard && options?.literalWildcard)) {
+      const memberIsWildcard = component.fullName === ComponentSet.WILDCARD;
+      if (!memberIsWildcard || options?.literalWildcard || !shouldResolve) {
         ws.add(component);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
   MetadataApiDeployOptions,
   RetrieveOptions,
   RetrievePathOptions,
+  RetrieveStatus,
   SourceDeployResult,
   RetrieveMessage,
   SourceRetrieveResult,

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -263,10 +263,25 @@ describe('ComponentSet', () => {
           { fullName: '*', type: mockRegistryData.types.mixedcontentsinglefile },
           ...sourceComponents,
         ]);
+
+        it('should add components even if they were not resolved', async () => {
+          const set = await ComponentSet.fromManifestFile('folderComponent.xml', {
+            registry: mockRegistry,
+            tree,
+            resolve: '.',
+          });
+
+          expect(Array.from(set)).to.deep.equal([
+            {
+              fullName: 'Test_Folder',
+              type: mockRegistryData.types.tinafeyfolder,
+            },
+          ]);
+        });
       });
     });
 
-    describe('fromComponents', () => {
+    describe('constructor', () => {
       it('should initialize non-source backed components from members', () => {
         const set = new ComponentSet(
           [


### PR DESCRIPTION
### What does this PR do?

Adds a non SourceComponent to a ComponentSet when initializing with fromManifestFile and source was not found for a member in the file. 

### What issues does this PR fix or reference?

@W-8532624@
