### PR TITLE
fix: connection issue when deploying or retrieving

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -324,11 +324,11 @@ export class ComponentSet implements Iterable<MetadataComponent> {
   }
 
   private async getConnection(auth: Connection | string): Promise<Connection> {
-    return auth instanceof Connection
-      ? auth
-      : await Connection.create({
+    return typeof auth === 'string'
+      ? await Connection.create({
           authInfo: await AuthInfo.create({ username: auth }),
-        });
+        })
+      : auth;
   }
 
   private sourceKey(component: SourceComponent): string {


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where a Connection object was interpreted as a string during the deploy of a ComponentSet. Using `instanceof` on instances of types that could come from external clients is not the best idea...

### What issues does this PR fix or reference?

@W-8667800@