### PR TITLE
chore: bump @salesforce/core to 2.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=10.17.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.12.0",
+    "@salesforce/core": "2.18.2",
     "archiver": "4.0.1",
     "fast-xml-parser": "^3.17.4",
     "gitignore-parser": "0.0.2",

--- a/test/client/deployStrategies/auraDeploy.test.ts
+++ b/test/client/deployStrategies/auraDeploy.test.ts
@@ -39,6 +39,8 @@ describe('Aura Deploy Strategy', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/test/client/deployStrategies/baseDeploy.test.ts
+++ b/test/client/deployStrategies/baseDeploy.test.ts
@@ -30,6 +30,8 @@ describe('Base Deploy Strategy', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/test/client/deployStrategies/containerDeploy.test.ts
+++ b/test/client/deployStrategies/containerDeploy.test.ts
@@ -65,6 +65,8 @@ describe('Container Deploy Strategy', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/test/client/deployStrategies/lwcDeploy.test.ts
+++ b/test/client/deployStrategies/lwcDeploy.test.ts
@@ -90,6 +90,8 @@ describe('LWC Deploy Strategy', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/test/client/retrieve.test.ts
+++ b/test/client/retrieve.test.ts
@@ -61,6 +61,8 @@ describe('Tooling Retrieve', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/test/client/toolingApi.test.ts
+++ b/test/client/toolingApi.test.ts
@@ -31,6 +31,8 @@ describe('Tooling API tests', () => {
     $$.setConfigStubContents('AuthInfoConfig', {
       contents: await testData.getConfig(),
     });
+    // Stub retrieveMaxApiVersion to get over "Domain Not Found: The org cannot be found" error
+    sandboxStub.stub(Connection.prototype, 'retrieveMaxApiVersion').resolves('50.0');
     mockConnection = await Connection.create({
       authInfo: await AuthInfo.create({
         username: testData.username,

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,26 +245,27 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.12.0.tgz#c719bfb3b286922d9b312b9b6a61dfc9ad53e8d8"
-  integrity sha512-sXTYoCjWeWD/xY1+fdHgaS71ldq4pqIBAZncnxNUOr7NgvVM++omgMQ4Ey/ZqeRjuWZ7YGXzJMqwbktpptoQ6w==
+"@salesforce/core@2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.18.2.tgz#77b737c8311daab4564b6cb50aac764e68efec89"
+  integrity sha512-1qAZRBF80LjiDTitKAZS8+kvguARc8Q9WBNUkPj3Kz95srei0lg/eiS7IMzREJD0OOfXxMVFPGtgw/8Du50w/g==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.3.2"
+    "@salesforce/kit" "^1.3.3"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.0.0"
     "@types/graceful-fs" "^4.1.3"
-    "@types/jsforce" "1.9.20"
+    "@types/jsforce" "1.9.23"
+    "@types/mkdirp" "1.0.0"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"
-    jsforce "1.9.3"
+    jsforce "^1.10.0"
     jsonwebtoken "8.5.0"
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
 
-"@salesforce/kit@^1.3.2":
+"@salesforce/kit@^1.3.3":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.4.0.tgz#4a43a8633f967066895d865813907eea071ef541"
   integrity sha512-/6owokpdkljkbM5axJ7xVgn6ggMS1YJgtD8zv2gBAfIHT/EgIMnwkyU6Rymb8QmWp93q/RoHXdgNQkDonWYSqw==
@@ -373,10 +374,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jsforce@1.9.20":
-  version "1.9.20"
-  resolved "https://registry.yarnpkg.com/@types/jsforce/-/jsforce-1.9.20.tgz#7bd379c9bdc499973814d8948dbc2ef5fa4f8d2a"
-  integrity sha512-eeQ3WynhRhK1JLi0WzILHkHalYBEcf1NhQWk9l30S9UqIy6Df/OOOJGYjORSLBsuF8dNWxKVWMRNsSktXmXh6A==
+"@types/jsforce@1.9.23":
+  version "1.9.23"
+  resolved "https://registry.yarnpkg.com/@types/jsforce/-/jsforce-1.9.23.tgz#06c2b604e02bfc8ba1143c6bf53530e565f18bae"
+  integrity sha512-p1aqPWapTAG5xpTpebj4jSs5cwpNHe5PYFtEXCIjsSgfFgIW7GgQb5X/43/M8gkZNcGe8kchykrD9UgYKjz3eQ==
   dependencies:
     "@types/node" "*"
 
@@ -399,6 +400,13 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
   integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/mkdirp@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.0.tgz#16ce0eabe4a9a3afe64557ad0ee6886ec3d32927"
+  integrity sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==
   dependencies:
     "@types/node" "*"
 
@@ -1324,10 +1332,10 @@ csprng@*, csprng@~0.1.2:
   dependencies:
     sequin "*"
 
-csv-parse@^4.6.3:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.12.0.tgz#fd42d6291bbaadd51d3009f6cadbb3e53b4ce026"
-  integrity sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg==
+csv-parse@^4.10.1:
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.15.1.tgz#fc5a0a1b24eaa6d4c24892daa387c46f7f92f8d2"
+  integrity sha512-TXIvRtNp0fqMJbk3yPR35bQIDzMH4khDwduElzE7Fl1wgnl25mnWYLSLqd/wS5GsDoX1rWtysivEYMNsz5jKwQ==
 
 csv-stringify@^1.0.4:
   version "1.1.2"
@@ -2728,20 +2736,20 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-1.9.3.tgz#caea681c0fd8dcea79459b81c2019f4425eacd12"
-  integrity sha512-NJiBoTfsSElVZnh1MO7zv8anDPdy6vBVG19SEJ5pQtE+QJKFksjy4tpXbyzVyBft5Lo6Npr1HIPUP+RkVd9weQ==
+jsforce@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-1.10.1.tgz#ca1cf58d4439d94e1f84482d83081acd12c93269"
+  integrity sha512-rv+UpBR9n/sWdgLhyPOJuKgT9ZKngypYf9XOHoXVRpSllvTFCjn+M3H81Nu1oYjPH9JKXVS8hL1dmmq8+kOAJg==
   dependencies:
     base64-url "^2.2.0"
     co-prompt "^1.0.0"
     coffeescript "^1.10.0"
     commander "^2.9.0"
-    csv-parse "^4.6.3"
+    csv-parse "^4.10.1"
     csv-stringify "^1.0.4"
     faye "^1.2.0"
     inherits "^2.0.1"
-    lodash "^4.17.14"
+    lodash "^4.17.19"
     multistream "^2.0.5"
     opn "^5.3.0"
     promise "^7.1.1"


### PR DESCRIPTION
### What does this PR do?
Bumps the version of @salesforce/core to 2.18.2

### What issues does this PR fix or reference?

Follow up to #229, @W-8853141@