### PR TITLE
fix: remove octet-stream as archive type

### DIFF
--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -22,7 +22,6 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
     'application/zip',
     'application/x-zip-compressed',
     'application/jar',
-    'application/octet-stream',
   ]);
   private static readonly DEFAULT_CONTENT_TYPE = 'application/octet-stream';
   private static readonly FALLBACK_TYPE_MAP = new Map<string, string>([


### PR DESCRIPTION
### What does this PR do?

Removes the `application/octet-stream` as an archive classified mime-type. This will prevent the StaticResource transformer from attempting to unzip these resources since they aren't necessarily archives. Instead they are copied as `.bin` files.

### What issues does this PR fix or reference?

@W-8115028@