### PR TITLE
Add testLevel to MetadataApiDeployOptions type

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -326,5 +326,5 @@ export interface MetadataApiDeployOptions {
   runAllTests?: boolean;
   runTests?: string[];
   singlePackage?: boolean;
-  testLevel?: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg'
+  testLevel?: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
 }


### PR DESCRIPTION
### What does this PR do?
Adds the ability to define a testLevel for a deployment.

### What issues does this PR fix or reference?
part of @W-9014446@

### Functionality Before
Without this you'll have to use // @ts-ignore in your code

### Functionality After
tsc is happy again
