### PR TITLE
fix: merge deploy api options

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -189,7 +189,8 @@ export class MetadataApiDeploy extends MetadataTransfer<MetadataApiDeployStatus,
 
   constructor(options: MetadataApiDeployOptions) {
     super(options);
-    this.options = Object.assign({}, MetadataApiDeploy.DEFAULT_OPTIONS, options);
+    options.apiOptions = { ...MetadataApiDeploy.DEFAULT_OPTIONS.apiOptions, ...options.apiOptions };
+    this.options = Object.assign({}, options);
   }
 
   protected async pre(): Promise<{ id: string }> {

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -16,7 +16,7 @@ import {
 import { expect } from 'chai';
 import { basename, join } from 'path';
 import { MOCK_ASYNC_RESULT, stubMetadataDeploy } from '../mock/client/transferOperations';
-import { DeployResult } from '../../src/client/metadataApiDeploy';
+import { DeployResult, MetadataApiDeploy } from '../../src/client/metadataApiDeploy';
 import { mockRegistry, matchingContentFile } from '../mock/registry';
 import { META_XML_SUFFIX } from '../../src/common';
 import {
@@ -551,6 +551,39 @@ describe('MetadataApiDeploy', () => {
 
         expect(responses).to.deep.equal(expected);
       });
+    });
+  });
+
+  describe('Constructor', () => {
+    it('should merge default API options', () => {
+      const mdApiDeploy = new MetadataApiDeploy({
+        usernameOrConnection: 'testing',
+        components: new ComponentSet(),
+        apiOptions: {
+          checkOnly: true,
+          testLevel: 'RunLocalTests',
+        },
+      });
+      // @ts-ignore testing private property
+      const mdOpts = mdApiDeploy.options;
+      expect(mdOpts.apiOptions).to.have.property('checkOnly', true);
+      expect(mdOpts.apiOptions).to.have.property('rollbackOnError', true);
+      expect(mdOpts.apiOptions).to.have.property('ignoreWarnings', false);
+      expect(mdOpts.apiOptions).to.have.property('singlePackage', true);
+      expect(mdOpts.apiOptions).to.have.property('testLevel', 'RunLocalTests');
+    });
+
+    it('should use default API options', () => {
+      const mdApiDeploy = new MetadataApiDeploy({
+        usernameOrConnection: 'testing',
+        components: new ComponentSet(),
+      });
+      // @ts-ignore testing private property
+      const mdOpts = mdApiDeploy.options;
+      expect(mdOpts.apiOptions).to.have.property('rollbackOnError', true);
+      expect(mdOpts.apiOptions).to.have.property('ignoreWarnings', false);
+      expect(mdOpts.apiOptions).to.have.property('checkOnly', false);
+      expect(mdOpts.apiOptions).to.have.property('singlePackage', true);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
This will merge deploy api options with the defaults rather than using them only when undefined

### What issues does this PR fix or reference?
@W-8942811@

### Functionality Before
If partial api options were defined during the deploy, it would use those and not apply the defaults which would cause problems.  If no api options were defined it would use the defaults.

### Functionality After
If partial api options are defined during the deploy, it merges the defaults.  This allows the defaults to be used when some options are specified and some are not.
