### PR TITLE
fix: set an overridden apiVersion on a created connection

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -152,6 +152,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     const operationOptions = Object.assign({}, options, {
       components: this,
       registry: this.registry,
+      apiVersion: this.apiVersion,
     });
 
     return new MetadataApiDeploy(operationOptions);
@@ -166,6 +167,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     const operationOptions = Object.assign({}, options, {
       components: this,
       registry: this.registry,
+      apiVersion: this.apiVersion,
     });
 
     return new MetadataApiRetrieve(operationOptions);

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -422,6 +422,24 @@ describe('ComponentSet', () => {
       expect(result).to.deep.equal(expectedOperation);
     });
 
+    it('should properly construct a deploy operation with overridden apiVersion', async () => {
+      const connection = await mockConnection($$);
+      const apiVersion = '50.0';
+      const set = ComponentSet.fromSource('.', { registry: mockRegistry, tree });
+      set.apiVersion = apiVersion;
+      const operationArgs = { components: set, usernameOrConnection: connection, apiVersion };
+      const expectedOperation = new MetadataApiDeploy(operationArgs);
+      const constructorStub = env
+        .stub()
+        .withArgs(operationArgs)
+        .callsFake(() => expectedOperation);
+      Object.setPrototypeOf(MetadataApiDeploy, constructorStub);
+
+      const result = await set.deploy({ usernameOrConnection: connection });
+
+      expect(result).to.deep.equal(expectedOperation);
+    });
+
     it('should throw error if there are no source backed components when deploying', async () => {
       const set = await ComponentSet.fromManifestFile('subset.xml', {
         registry: mockRegistry,
@@ -442,6 +460,32 @@ describe('ComponentSet', () => {
       const connection = await mockConnection($$);
       const set = ComponentSet.fromSource('.', { registry: mockRegistry, tree });
       const operationArgs = {
+        components: set,
+        output: join('test', 'path'),
+        usernameOrConnection: connection,
+      };
+      const expectedOperation = new MetadataApiRetrieve(operationArgs);
+      const constructorStub = env
+        .stub()
+        .withArgs(operationArgs)
+        .callsFake(() => expectedOperation);
+      Object.setPrototypeOf(MetadataApiRetrieve, constructorStub);
+
+      const result = await set.retrieve({
+        output: operationArgs.output,
+        usernameOrConnection: connection,
+      });
+
+      expect(result).to.deep.equal(expectedOperation);
+    });
+
+    it('should properly construct a retrieve operation with overridden apiVersion', async () => {
+      const connection = await mockConnection($$);
+      const apiVersion = '50.0';
+      const set = ComponentSet.fromSource('.', { registry: mockRegistry, tree });
+      set.apiVersion = apiVersion;
+      const operationArgs = {
+        apiVersion,
         components: set,
         output: join('test', 'path'),
         usernameOrConnection: connection,


### PR DESCRIPTION
### What does this PR do?
A connection that is created from a username should use the apiVersion passed rather than the default.  Consumers of the API can then pass a username and an apiVersion and the created connection will have the apiVersion set for them. 

This is currently possible if the consumer creates the Connection themselves and sets the apiVersion but that approach has potential problems with the version of `@salesforce/core` Connection in use by the consumer. 

### What issues does this PR fix or reference?

@W-8942811@

### Functionality Before
Setting apiVersion on the ComponentSet would not apply to the created Connection.

### Functionality After
Setting apiVersion on the ComponentSet now applies to the created Connection.
