### PR TITLE
feat: add workskillrouting type to registry

### DIFF
--- a/src/metadata-registry/data/registry.json
+++ b/src/metadata-registry/data/registry.json
@@ -1923,6 +1923,26 @@
       "directoryName": "PlatformEventSubscriberConfigs",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "workskillrouting": {
+      "id": "workskillrouting",
+      "name": "WorkSkillRouting",
+      "suffix": "workSkillRouting",
+      "directoryName": "workSkillRoutings",
+      "strictDirectoryName": false,
+      "children": {
+        "types": {
+          "workskillroutingattribute": {
+            "id": "workskillroutingattribute",
+            "name": "WorkSkillRoutingAttribute",
+            "directoryName": "workSkillRoutingAttributes",
+            "suffix": "workSkillRoutingAttribute"
+          }
+        },
+        "suffixes": {
+          "workSkillRoutingAttribute": "workskillroutingattribute"
+        }
+      }
     }
   },
   "suffixes": {
@@ -2117,7 +2137,8 @@
     "entityImplements": "entityimplements",
     "audience": "audience",
     "cmsConnectSource": "cmsconnectsource",
-    "platformEventSubscriberConfig": "platformeventsubscriberconfig"
+    "platformEventSubscriberConfig": "platformeventsubscriberconfig",
+    "workSkillRouting": "workskillrouting"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?

Adds a missing type definition for [WorkSkillRouting](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_workskillrouting.htm) to the registry file. This enables users to resolve components of the `WorkSkillRouting` type.

### What issues does this PR fix or reference?

@W-9088125@

### Functionality Before

Type inference error thrown when resolving `WorkSkillRouting` components

### Functionality After

Now can resolve `WorkSkillRouting` components
