### PR TITLE
chore: set scheduled build for change case management earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,8 @@ jobs:
       - restore_cache: *restore_cache
       - run: *gh-config
       - run: *install
-      - release-management/install-change-case-mgmt
       - run: *gus-prepare-environment-variables
+      - release-management/install-change-case-mgmt
       - release-management/change-case-create
       - run: *build
       - run:


### PR DESCRIPTION
### What does this PR do?
Sets the scheduled build earlier in the pipeline. There is a check for environment variables when installing the sfchangecase logic.

### What issues does this PR fix or reference?
@W-9085630@
