### PR TITLE
fix: update missing config for wave and time sheet template types

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1969,6 +1969,16 @@
       "suffix": "timeSheetTemplate",
       "directoryName": "timeSheetTemplates",
       "strictDirectoryName": false
+    },
+    "accountrelationshipsharerule": {
+      "id": "accountrelationshipsharerule",
+      "name": "AccountRelationshipShareRule",
+      "suffix": "accountRelationshipShareRule",
+      "directoryName": "accountRelationshipShareRules",
+      "strictDirectoryName": false,
+      "strategies": {
+        "adapter": "matchingContentFile"
+      }
     }
   },
   "suffixes": {
@@ -2165,8 +2175,8 @@
     "cmsConnectSource": "cmsconnectsource",
     "platformEventSubscriberConfig": "platformeventsubscriberconfig",
     "workSkillRouting": "workskillrouting",
-
-    "timeSheetTemplate": "timesheettemplate"
+    "timeSheetTemplate": "timesheettemplate",
+    "accountRelationshipShareRule": "accountrelationshipsharerule"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?

Updates missing configuration for wave types, specifically assigning the `matchingContentFile` adapter for those that have content associated. Also includes a type entry for TimeSheetTemplate. 

### What issues does this PR fix or reference?

@W-9156885@

### Functionality Before

- WaveDashboards were not properly converted to source format
- WaveLens were not properly converted to source format
- WaveDataflow were not properly converted to source format
- WaveRecipe were not properly converted to source format
- TimeSheetTemplate components could not be resolved

### Functionality After

- WaveDashboards, WaveLens, WaveDataflows, WaveRecipes are properly converted to source format
- TimeSheetTemplates can be resolved
