### PR TITLE
chore: update adaptor for AccountRelationshipShareRule

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1975,10 +1975,7 @@
       "name": "AccountRelationshipShareRule",
       "suffix": "accountRelationshipShareRule",
       "directoryName": "accountRelationshipShareRules",
-      "strictDirectoryName": false,
-      "strategies": {
-        "adapter": "matchingContentFile"
-      }
+      "strictDirectoryName": false
     }
   },
   "suffixes": {


### PR DESCRIPTION
### What does this PR do?
Removes the adapter "matchingContentFile" for AccountRelationshipShareRule. When using this adaptor, we were not resolving the components for AccountRelationshipShareRule types and were instead returning undefined.

### What issues does this PR fix or reference?
@W-9156885@

### Functionality Before
Unable to retrieve AccountRelationshipShareRule components.

### Functionality After
Able to retrieve AccountRelationshipShareRule components.
