### PR TITLE
feat: adds option to convert source directly to the specified directory

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -13,7 +13,7 @@ import {
 } from './types';
 import { SourceComponent } from '../resolve';
 import { promises } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, join, normalize } from 'path';
 import { ensureDirectoryExists } from '../utils/fileSystemHandler';
 import {
   ComponentReader,
@@ -124,10 +124,20 @@ export class MetadataConverter {
 
   private getPackagePath(outputConfig: DirectoryConfig | ZipConfig): SourcePath | undefined {
     let packagePath: SourcePath;
-    const { outputDirectory, packageName, type } = outputConfig;
+    const { genUniqueDir = true, outputDirectory, packageName, type } = outputConfig;
     if (outputDirectory) {
-      const name = packageName || `${MetadataConverter.DEFAULT_PACKAGE_PREFIX}_${Date.now()}`;
-      packagePath = join(outputDirectory, name);
+      if (packageName) {
+        packagePath = join(outputDirectory, packageName);
+      } else {
+        if (genUniqueDir) {
+          packagePath = join(
+            outputDirectory,
+            `${MetadataConverter.DEFAULT_PACKAGE_PREFIX}_${Date.now()}`
+          );
+        } else {
+          packagePath = normalize(outputDirectory);
+        }
+      }
 
       if (type === 'zip') {
         packagePath += '.zip';

--- a/src/convert/types.ts
+++ b/src/convert/types.ts
@@ -29,21 +29,30 @@ type PackageName = {
   packageName?: string;
 };
 
-export type DirectoryConfig = PackageName & {
-  type: 'directory';
+type UniqueOutputDir = {
   /**
-   * Directory path to output the converted package to.
+   * Whether to generate a unique directory within the outputDirectory. Default is true.
    */
-  outputDirectory: SourcePath;
+  genUniqueDir?: boolean;
 };
 
-export type ZipConfig = PackageName & {
-  type: 'zip';
-  /**
-   * Directory path to output the zip package to.
-   */
-  outputDirectory?: SourcePath;
-};
+export type DirectoryConfig = PackageName &
+  UniqueOutputDir & {
+    type: 'directory';
+    /**
+     * Directory path to output the converted package to.
+     */
+    outputDirectory: SourcePath;
+  };
+
+export type ZipConfig = PackageName &
+  UniqueOutputDir & {
+    type: 'zip';
+    /**
+     * Directory path to output the zip package to.
+     */
+    outputDirectory?: SourcePath;
+  };
 
 export type MergeConfig = {
   type: 'merge';

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -66,6 +66,16 @@ describe('MetadataConverter', () => {
     expect(pipelineStub.firstCall.args[2].rootDestination).to.equal(packagePath);
   });
 
+  it('should convert to specified output dir', async () => {
+    await converter.convert(components, 'metadata', {
+      type: 'directory',
+      outputDirectory,
+      genUniqueDir: false,
+    });
+
+    expect(pipelineStub.firstCall.args[2].rootDestination).to.equal(outputDirectory);
+  });
+
   it('should throw ConversionError when an error occurs', async () => {
     const error = new Error('whoops!');
     const expectedError = new ConversionError(error);
@@ -185,6 +195,18 @@ describe('MetadataConverter', () => {
         type: 'zip',
         outputDirectory,
         packageName,
+      });
+
+      expect(ensureDirectoryStub.calledBefore(pipelineStub)).to.be.true;
+      expect(ensureDirectoryStub.firstCall.args[0]).to.equal(dirname(zipPath));
+    });
+
+    it('should convert to specified output dir', async () => {
+      const zipPath = outputDirectory + '.zip';
+      await converter.convert(components, 'metadata', {
+        type: 'zip',
+        outputDirectory,
+        genUniqueDir: false,
       });
 
       expect(ensureDirectoryStub.calledBefore(pipelineStub)).to.be.true;


### PR DESCRIPTION
Rather than necessarily generating a directory within the specified output directory, convert
directly to that output directory.

How to use the new functionality:
```typescript
await converter.convert(cs.getSourceComponents().toArray(), 'metadata', {
      type: 'directory',
      outputDirectory: 'my/output/dir',
      genUniqueDir: false,
    });
```

@W-9260936@