### PR TITLE
fix: retrieve package names to their respective packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "2.1.3",
+  "version": "2.1.5",
   "gusBuild": "49.1.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -16,7 +16,7 @@ import {
   RetrieveOptions,
   MetadataTransferResult,
   RetrieveRequest,
-  PackageOptions,
+  PackageOption,
   RetrieveExtractOptions,
 } from './types';
 import { MetadataTransfer, MetadataTransferOptions } from './metadataTransfer';
@@ -143,9 +143,9 @@ export class MetadataApiRetrieve extends MetadataTransfer<
   }
 
   protected async pre(): Promise<AsyncResult> {
-    const { packages } = this.options;
+    const packageNames = this.getPackageNames();
 
-    if (this.components.size === 0 && !packages?.length) {
+    if (this.components.size === 0 && !packageNames?.length) {
       throw new MetadataApiRetrieveError('error_no_components_to_retrieve');
     }
 
@@ -157,8 +157,8 @@ export class MetadataApiRetrieve extends MetadataTransfer<
 
     // if we're retrieving with packageNames add it
     // otherwise don't - it causes errors if undefined or an empty array
-    if (packages?.length) {
-      requestBody.packageNames = this.getPackageNames();
+    if (packageNames?.length) {
+      requestBody.packageNames = packageNames;
     }
 
     // @ts-ignore required callback
@@ -182,14 +182,15 @@ export class MetadataApiRetrieve extends MetadataTransfer<
     return this.getPackageOptions()?.map((pkg) => pkg.name);
   }
 
-  private getPackageOptions(): PackageOptions[] {
-    const { packages } = this.options;
-    if (packages?.length) {
-      if (isString(packages[0])) {
-        const pkgs = packages as string[];
-        return pkgs.map((pkg) => ({ name: pkg, outputDir: pkg }));
+  private getPackageOptions(): PackageOption[] {
+    const { packageOptions } = this.options;
+    if (packageOptions?.length) {
+      if (isString(packageOptions[0])) {
+        const packageNames = packageOptions as string[];
+        return packageNames.map((pkg) => ({ name: pkg, outputDir: pkg }));
       } else {
-        const pkgs = packages as PackageOptions[];
+        const pkgs = packageOptions as PackageOption[];
+        // If there isn't an outputDir specified, use the package name.
         return pkgs.map(({ name, outputDir }) => ({ name, outputDir: outputDir || name }));
       }
     }

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -183,8 +183,8 @@ export class MetadataApiRetrieve extends MetadataTransfer<
 
   private async extract(zip: Buffer): Promise<ComponentSet> {
     const components: SourceComponent[] = [];
-    const converter = new MetadataConverter(this.options.registry);
-    const { merge, output, packageNames } = this.options;
+    const { merge, output, packageNames, registry } = this.options;
+    const converter = new MetadataConverter(registry);
     const tree = await ZipTreeContainer.create(zip);
     // initialize with the specified output and unpackaged metadata
     const packageAggregator: Package[] = [{ name: output, zipTreeLocation: 'unpackaged' }];
@@ -209,7 +209,7 @@ export class MetadataApiRetrieve extends MetadataTransfer<
           };
       const zipComponents = ComponentSet.fromSource({
         fsPaths: [pkg.zipTreeLocation],
-        registry: this.options.registry,
+        registry,
         tree,
       })
         .getSourceComponents()
@@ -217,6 +217,6 @@ export class MetadataApiRetrieve extends MetadataTransfer<
       const convertResult = await converter.convert(zipComponents, 'source', outputConfig);
       components.push(...convertResult.converted);
     }
-    return new ComponentSet(components, this.options.registry);
+    return new ComponentSet(components, registry);
   }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -232,7 +232,7 @@ export interface MetadataApiRetrieveStatus {
 // Client options
 // ------------------------------------------------
 
-export interface PackageOptions {
+export interface PackageOption {
   /**
    * The name of the package to retrieve.
    */
@@ -240,10 +240,12 @@ export interface PackageOptions {
   /**
    * The directory where the retrieved package source should be
    * converted. If this is not specified the directory will
-   * default to `<process.cwd()>/PackageOptions.name`.
+   * default to `<process.cwd()>/PackageOption.name`.
    */
   outputDir?: SourcePath;
 }
+
+export type PackageOptions = string[] | PackageOption[];
 
 export interface RetrieveExtractOptions {
   /**
@@ -255,7 +257,7 @@ export interface RetrieveExtractOptions {
   /**
    * The directory where the retrieved source should be converted.
    * This is `RetrieveOptions.output` for unpackaged source, and
-   * `PackageOptions.outputDir` for packaged source.
+   * `PackageOption.outputDir` for packaged source.
    */
   outputDir: SourcePath;
 }
@@ -273,7 +275,7 @@ export interface RetrieveOptions {
   /**
    * A list of package names to retrieve, or package names and their retrieval locations.
    */
-  packages?: string[] | PackageOptions[];
+  packageOptions?: PackageOptions;
 }
 
 export interface MetadataApiDeployOptions {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -240,7 +240,7 @@ export interface PackageOptions {
   /**
    * The directory where the retrieved package source should be
    * converted. If this is not specified the directory will
-   * default to `<process.cwd()>/packageName`.
+   * default to `<process.cwd()>/PackageOptions.name`.
    */
   outputDir?: SourcePath;
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -232,6 +232,34 @@ export interface MetadataApiRetrieveStatus {
 // Client options
 // ------------------------------------------------
 
+export interface PackageOptions {
+  /**
+   * The name of the package to retrieve.
+   */
+  name: string;
+  /**
+   * The directory where the retrieved package source should be
+   * converted. If this is not specified the directory will
+   * default to `<process.cwd()>/packageName`.
+   */
+  outputDir?: SourcePath;
+}
+
+export interface RetrieveExtractOptions {
+  /**
+   * Top most directory within the retrieved zip file.
+   * E.g., `unpackaged` for unpackaged source, or the name of the
+   * package for retrieved package source.
+   */
+  zipTreeLocation: string;
+  /**
+   * The directory where the retrieved source should be converted.
+   * This is `RetrieveOptions.output` for unpackaged source, and
+   * `PackageOptions.outputDir` for packaged source.
+   */
+  outputDir: SourcePath;
+}
+
 export interface RetrieveOptions {
   /**
    * The directory to retrieve components to. If `merge: true`, components are only
@@ -239,13 +267,13 @@ export interface RetrieveOptions {
    */
   output: SourcePath;
   /**
-   * Whether or not to merge and replace input components with the retrieved versions
+   * Whether or not to merge and replace input components with the retrieved versions.
    */
   merge?: boolean;
   /**
-   * A list of package names to retrieve
+   * A list of package names to retrieve, or package names and their retrieval locations.
    */
-  packageNames?: string[];
+  packages?: string[] | PackageOptions[];
 }
 
 export interface MetadataApiDeployOptions {

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -7,6 +7,7 @@
 import { fail } from 'assert';
 import { expect } from 'chai';
 import { createSandbox, match } from 'sinon';
+import { join } from 'path';
 import {
   RetrieveResult,
   ComponentSet,
@@ -14,7 +15,7 @@ import {
   ComponentStatus,
   FileResponse,
   MetadataApiRetrieveStatus,
-  ZipTreeContainer,
+  VirtualTreeContainer,
 } from '../../src';
 import { MetadataApiRetrieveError, MissingJobIdError } from '../../src/errors';
 import { nls } from '../../src/i18n';
@@ -57,7 +58,7 @@ describe('MetadataApiRetrieve', async () => {
         const { operation } = await stubMetadataRetrieve(env, {
           toRetrieve: toRetrieve,
           merge: true,
-          packageNames: [],
+          packages: [],
         });
 
         try {
@@ -69,7 +70,7 @@ describe('MetadataApiRetrieve', async () => {
         }
       });
 
-      it('should call retrieve with for unpackaged data', async () => {
+      it('should call retrieve for unpackaged data', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
@@ -86,11 +87,11 @@ describe('MetadataApiRetrieve', async () => {
         });
       });
 
-      it('should call retrieve with with package', async () => {
+      it('should call retrieve for a package as string[]', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
-          packageNames: ['MyPackage'],
+          packages: ['MyPackage'],
           merge: true,
           successes: toRetrieve,
         };
@@ -100,7 +101,45 @@ describe('MetadataApiRetrieve', async () => {
         expect(retrieveStub.calledOnce).to.be.true;
         expect(retrieveStub.firstCall.args[0]).to.deep.equal({
           apiVersion: toRetrieve.apiVersion,
-          packageNames: options.packageNames,
+          packageNames: options.packages,
+          unpackaged: toRetrieve.getObject().Package,
+        });
+      });
+
+      it('should call retrieve for a package as PackageOptions[] with name only', async () => {
+        const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
+        const options = {
+          toRetrieve,
+          packages: [{ name: 'MyPackage' }],
+          merge: true,
+          successes: toRetrieve,
+        };
+        const { operation, retrieveStub } = await stubMetadataRetrieve(env, options);
+        await operation.start();
+
+        expect(retrieveStub.calledOnce).to.be.true;
+        expect(retrieveStub.firstCall.args[0]).to.deep.equal({
+          apiVersion: toRetrieve.apiVersion,
+          packageNames: [options.packages[0].name],
+          unpackaged: toRetrieve.getObject().Package,
+        });
+      });
+
+      it('should call retrieve for a package as PackageOptions[] with name and outputDir', async () => {
+        const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
+        const options = {
+          toRetrieve,
+          packages: [{ name: 'MyPackage', outputDir: 'fake/output/dir' }],
+          merge: true,
+          successes: toRetrieve,
+        };
+        const { operation, retrieveStub } = await stubMetadataRetrieve(env, options);
+        await operation.start();
+
+        expect(retrieveStub.calledOnce).to.be.true;
+        expect(retrieveStub.firstCall.args[0]).to.deep.equal({
+          apiVersion: toRetrieve.apiVersion,
+          packageNames: [options.packages[0].name],
           unpackaged: toRetrieve.getObject().Package,
         });
       });
@@ -137,6 +176,26 @@ describe('MetadataApiRetrieve', async () => {
     });
 
     describe('pollStatus', () => {
+      const getPackageComponent = (packageName: string): SourceComponent => {
+        const contentName = 'z.mcf';
+        const metaName = `${contentName}-meta.xml`;
+        const type = mockRegistryData.types.matchingcontentfile;
+        return new SourceComponent(
+          {
+            name: 'z',
+            type,
+            xml: join(packageName, type.directoryName, metaName),
+            content: join(packageName, type.directoryName, contentName),
+          },
+          new VirtualTreeContainer([
+            {
+              dirPath: join(packageName, type.directoryName),
+              children: [metaName, contentName],
+            },
+          ])
+        );
+      };
+
       it('should retrieve zip and extract to directory', async () => {
         const component = COMPONENT;
         const toRetrieve = new ComponentSet([component], mockRegistry);
@@ -155,6 +214,73 @@ describe('MetadataApiRetrieve', async () => {
             outputDirectory: MOCK_DEFAULT_OUTPUT,
           })
         ).to.be.true;
+      });
+
+      it('should retrieve zip with packages and extract to default directory', async () => {
+        const component = COMPONENT;
+        const packageName = 'MyPackage';
+        const pkgComponent = getPackageComponent(packageName);
+        const fromSourceSpy = env.spy(ComponentSet, 'fromSource');
+        const toRetrieve = new ComponentSet([component], mockRegistry);
+        const successesCompSet = new ComponentSet([component, pkgComponent], mockRegistry);
+        const { operation, convertStub } = await stubMetadataRetrieve(env, {
+          toRetrieve,
+          packages: [packageName],
+          successes: successesCompSet,
+        });
+
+        await operation.start();
+        await operation.pollStatus();
+
+        expect(convertStub.calledTwice).to.be.true;
+        const convertCall1Args = convertStub.firstCall.args;
+        const convertCall2Args = convertStub.secondCall.args;
+        expect(convertCall1Args[1]).to.equal('source');
+        expect(convertCall1Args[2]).to.deep.equal({
+          type: 'directory',
+          outputDirectory: MOCK_DEFAULT_OUTPUT,
+        });
+        expect(fromSourceSpy.calledTwice).to.be.true;
+        expect(fromSourceSpy.secondCall.args[0]).to.have.deep.property('fsPaths', [packageName]);
+        expect(convertCall2Args[1]).to.equal('source');
+        expect(convertCall2Args[2]).to.deep.equal({
+          type: 'directory',
+          outputDirectory: packageName,
+        });
+      });
+
+      it('should retrieve zip with packages and extract to specified directory', async () => {
+        const component = COMPONENT;
+        const packageName = 'MyPackage';
+        const packageOutputDir = 'myPackageDir';
+        const pkgComponent = getPackageComponent(packageName);
+        const fromSourceSpy = env.spy(ComponentSet, 'fromSource');
+        const toRetrieve = new ComponentSet([component], mockRegistry);
+        const successesCompSet = new ComponentSet([component, pkgComponent], mockRegistry);
+        const { operation, convertStub } = await stubMetadataRetrieve(env, {
+          toRetrieve,
+          packages: [{ name: packageName, outputDir: packageOutputDir }],
+          successes: successesCompSet,
+        });
+
+        await operation.start();
+        await operation.pollStatus();
+
+        expect(convertStub.calledTwice).to.be.true;
+        const convertCall1Args = convertStub.firstCall.args;
+        const convertCall2Args = convertStub.secondCall.args;
+        expect(convertCall1Args[1]).to.equal('source');
+        expect(convertCall1Args[2]).to.deep.equal({
+          type: 'directory',
+          outputDirectory: MOCK_DEFAULT_OUTPUT,
+        });
+        expect(fromSourceSpy.calledTwice).to.be.true;
+        expect(fromSourceSpy.secondCall.args[0]).to.have.deep.property('fsPaths', [packageName]);
+        expect(convertCall2Args[1]).to.equal('source');
+        expect(convertCall2Args[2]).to.deep.equal({
+          type: 'directory',
+          outputDirectory: packageOutputDir,
+        });
       });
 
       it('should save the temp directory if the environment variable is set', async () => {

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -58,7 +58,7 @@ describe('MetadataApiRetrieve', async () => {
         const { operation } = await stubMetadataRetrieve(env, {
           toRetrieve: toRetrieve,
           merge: true,
-          packages: [],
+          packageOptions: [],
         });
 
         try {
@@ -91,7 +91,7 @@ describe('MetadataApiRetrieve', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
-          packages: ['MyPackage'],
+          packageOptions: ['MyPackage'],
           merge: true,
           successes: toRetrieve,
         };
@@ -101,7 +101,7 @@ describe('MetadataApiRetrieve', async () => {
         expect(retrieveStub.calledOnce).to.be.true;
         expect(retrieveStub.firstCall.args[0]).to.deep.equal({
           apiVersion: toRetrieve.apiVersion,
-          packageNames: options.packages,
+          packageNames: options.packageOptions,
           unpackaged: toRetrieve.getObject().Package,
         });
       });
@@ -110,7 +110,7 @@ describe('MetadataApiRetrieve', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
-          packages: [{ name: 'MyPackage' }],
+          packageOptions: [{ name: 'MyPackage' }],
           merge: true,
           successes: toRetrieve,
         };
@@ -120,7 +120,7 @@ describe('MetadataApiRetrieve', async () => {
         expect(retrieveStub.calledOnce).to.be.true;
         expect(retrieveStub.firstCall.args[0]).to.deep.equal({
           apiVersion: toRetrieve.apiVersion,
-          packageNames: [options.packages[0].name],
+          packageNames: [options.packageOptions[0].name],
           unpackaged: toRetrieve.getObject().Package,
         });
       });
@@ -129,7 +129,7 @@ describe('MetadataApiRetrieve', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
-          packages: [{ name: 'MyPackage', outputDir: 'fake/output/dir' }],
+          packageOptions: [{ name: 'MyPackage', outputDir: 'fake/output/dir' }],
           merge: true,
           successes: toRetrieve,
         };
@@ -139,7 +139,7 @@ describe('MetadataApiRetrieve', async () => {
         expect(retrieveStub.calledOnce).to.be.true;
         expect(retrieveStub.firstCall.args[0]).to.deep.equal({
           apiVersion: toRetrieve.apiVersion,
-          packageNames: [options.packages[0].name],
+          packageNames: [options.packageOptions[0].name],
           unpackaged: toRetrieve.getObject().Package,
         });
       });
@@ -225,7 +225,7 @@ describe('MetadataApiRetrieve', async () => {
         const successesCompSet = new ComponentSet([component, pkgComponent], mockRegistry);
         const { operation, convertStub } = await stubMetadataRetrieve(env, {
           toRetrieve,
-          packages: [packageName],
+          packageOptions: [packageName],
           successes: successesCompSet,
         });
 
@@ -259,7 +259,7 @@ describe('MetadataApiRetrieve', async () => {
         const successesCompSet = new ComponentSet([component, pkgComponent], mockRegistry);
         const { operation, convertStub } = await stubMetadataRetrieve(env, {
           toRetrieve,
-          packages: [{ name: packageName, outputDir: packageOutputDir }],
+          packageOptions: [{ name: packageName, outputDir: packageOutputDir }],
           successes: successesCompSet,
         });
 

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -14,6 +14,7 @@ import {
   ComponentStatus,
   FileResponse,
   MetadataApiRetrieveStatus,
+  ZipTreeContainer,
 } from '../../src';
 import { MetadataApiRetrieveError, MissingJobIdError } from '../../src/errors';
 import { nls } from '../../src/i18n';
@@ -71,6 +72,7 @@ describe('MetadataApiRetrieve', async () => {
         merge: true,
         successes: toRetrieve,
       };
+      env.stub(ZipTreeContainer.prototype, 'isDirectory').returns(false);
       const { operation, retrieveStub } = await stubMetadataRetrieve(env, options);
 
       await operation.start();

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -69,28 +69,24 @@ describe('MetadataApiRetrieve', async () => {
         }
       });
 
-      it('should call retrieve with given options', async () => {
+      it('should call retrieve with for unpackaged data', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
-          packageNames: ['MyPackage'],
           merge: true,
           successes: toRetrieve,
         };
-        env.stub(ZipTreeContainer.prototype, 'isDirectory').returns(false);
         const { operation, retrieveStub } = await stubMetadataRetrieve(env, options);
-
         await operation.start();
 
         expect(retrieveStub.calledOnce).to.be.true;
         expect(retrieveStub.firstCall.args[0]).to.deep.equal({
           apiVersion: toRetrieve.apiVersion,
-          packageNames: options.packageNames,
           unpackaged: toRetrieve.getObject().Package,
         });
       });
 
-      it('should call retrieve with given options', async () => {
+      it('should call retrieve with with package', async () => {
         const toRetrieve = new ComponentSet([COMPONENT], mockRegistry);
         const options = {
           toRetrieve,
@@ -99,7 +95,6 @@ describe('MetadataApiRetrieve', async () => {
           successes: toRetrieve,
         };
         const { operation, retrieveStub } = await stubMetadataRetrieve(env, options);
-
         await operation.start();
 
         expect(retrieveStub.calledOnce).to.be.true;

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -535,7 +535,7 @@ describe('ComponentSet', () => {
         components: set,
         output: join('test', 'path'),
         usernameOrConnection: connection,
-        packageNames: ['MyPackage'],
+        packages: ['MyPackage'],
       };
       const expectedOperation = new MetadataApiRetrieve(operationArgs);
       const startStub = env.stub(expectedOperation, 'start').resolves();
@@ -546,7 +546,7 @@ describe('ComponentSet', () => {
       Object.setPrototypeOf(MetadataApiRetrieve, constructorStub);
 
       const result = await set.retrieve({
-        packageNames: ['MyPackage'],
+        packages: ['MyPackage'],
         output: operationArgs.output,
         usernameOrConnection: connection,
       });

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -546,7 +546,7 @@ describe('ComponentSet', () => {
       Object.setPrototypeOf(MetadataApiRetrieve, constructorStub);
 
       const result = await set.retrieve({
-        packages: ['MyPackage'],
+        packageOptions: ['MyPackage'],
         output: operationArgs.output,
         usernameOrConnection: connection,
       });

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -199,13 +199,13 @@ export async function stubMetadataRetrieve(
           if (!packages) {
             zipEntries.push(join('unpackaged', content));
           } else {
-            let pkgs: string[] = [];
+            let packageNames: string[] = [];
             if (typeof packages[0] === 'string') {
-              pkgs = packages as string[];
+              packageNames = packages as string[];
             } else {
-              pkgs = (packages as PackageOptions[]).map((pkg) => pkg.name);
+              packageNames = (packages as PackageOptions[]).map((pkg) => pkg.name);
             }
-            if (pkgs.some((pkg) => content.startsWith(pkg))) {
+            if (packageNames.some((pkg) => content.startsWith(pkg))) {
               zipEntries.push(content);
             }
           }

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -27,7 +27,7 @@ import {
   MetadataApiDeployOptions,
   RequestStatus,
   MetadataApiRetrieveStatus,
-  PackageOptions,
+  PackageOption,
 } from '../../../src/client/types';
 import { ComponentProperties } from '../../../src/resolve/sourceComponent';
 import { normalizeToArray } from '../../../src/utils';
@@ -142,7 +142,7 @@ export async function stubMetadataDeploy(
 
 interface RetrieveStubOptions {
   merge?: boolean;
-  packages?: string[] | PackageOptions[];
+  packageOptions?: string[] | PackageOption[];
   toRetrieve?: ComponentSet;
   messages?: Partial<RetrieveMessage> | Partial<RetrieveMessage>[];
   successes?: ComponentSet;
@@ -166,7 +166,7 @@ export async function stubMetadataRetrieve(
   sandbox: SinonSandbox,
   options: RetrieveStubOptions
 ): Promise<RetrieveOperationLifecycle> {
-  const { toRetrieve: retrievedComponents, packages } = options;
+  const { toRetrieve: retrievedComponents, packageOptions: packages } = options;
   const connection = await mockConnection(testSetup());
 
   const retrieveStub = sandbox.stub(connection.metadata, 'retrieve').resolves(MOCK_ASYNC_RESULT);
@@ -203,7 +203,7 @@ export async function stubMetadataRetrieve(
             if (typeof packages[0] === 'string') {
               packageNames = packages as string[];
             } else {
-              packageNames = (packages as PackageOptions[]).map((pkg) => pkg.name);
+              packageNames = (packages as PackageOption[]).map((pkg) => pkg.name);
             }
             if (packageNames.some((pkg) => content.startsWith(pkg))) {
               zipEntries.push(content);
@@ -245,13 +245,13 @@ export async function stubMetadataRetrieve(
 
   const outputConfigs: ConvertOutputConfig[] = [];
   let converted: SourceComponent[] = [];
-  let pkgs: PackageOptions[];
+  let pkgs: PackageOption[];
 
   if (packages) {
     if (typeof packages[0] === 'string') {
       pkgs = (packages as string[]).map((pkg) => ({ name: pkg, outputDir: pkg }));
     } else {
-      pkgs = packages as PackageOptions[];
+      pkgs = packages as PackageOption[];
     }
   }
 
@@ -307,7 +307,7 @@ export async function stubMetadataRetrieve(
     checkStatusStub,
     convertStub,
     operation: new MetadataApiRetrieve({
-      packages: options.packages,
+      packageOptions: options.packageOptions,
       usernameOrConnection: connection,
       components: retrievedComponents,
       output: MOCK_DEFAULT_OUTPUT,


### PR DESCRIPTION
### What does this PR do?
when retrieving with packagenames, it will place their metadata into their respective package.  The location of the package metadata can also be changed by defining `PackageOptions.outputDir` as part of the retrieve options, which is what the VS Code extension would use.

NOTE: this is a breaking change and will require a major version bump since the name of `RetreiveOptions.packageNames` was changed to `RetrieveOptions.packages`, which is a better name given the changed type of that option.

### What issues does this PR fix or reference?
@W-9252107@

### Functionality Before
before all the metadata was placed under the default package

<insert gif and/or summary>

### Functionality After
the metadata is placed into the expected package dir
<insert gif and/or summary>
