### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 # @forcedotcom/pdt will be requested for
 # review when someone opens a pull request.
 *       @forcedotcom/pdt
+*       @forcedotcom/platform-cli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # @forcedotcom/pdt will be requested for
 # review when someone opens a pull request.
 *       @forcedotcom/pdt
-*       @forcedotcom/platform-cli
+*       @shetzel


### PR DESCRIPTION
Add the CLI team as co-owners.  The team will need write access to the repo if it doesn't already.
