### PR TITLE
fix: export MetadataApiDeployStatus from the top level

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,6 +15,7 @@ export { ToolingApi, ToolingDeployOptions, ToolingRetrieveOptions } from './tool
 export {
   AsyncResult,
   FileResponse,
+  MetadataApiDeployStatus,
   MetadataApiRetrieveStatus,
   RetrieveOptions,
   SourceDeployResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   ToolingRetrieveOptions,
   DeployResult,
   FileResponse,
+  MetadataApiDeployStatus,
   MetadataApiRetrieveStatus,
   RetrieveOptions,
   SourceDeployResult,


### PR DESCRIPTION
### What does this PR do?
Export MetadataApiDeployStatus from the top level

### What issues does this PR fix or reference?

@https://github.com/forcedotcom/salesforcedx-vscode/pull/3314 @[W-9458908](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000OSFmYAO/view)

### Functionality Before

MetadataApiDeployStatus was only in src/client

### Functionality After

Now MetadataApiDeployStatus is exported from the top-level index.ts
