### PR TITLE
fix: bump the version of @salesforce/core for PollingClient fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=12.11.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.23.2",
+    "@salesforce/core": "2.24.1",
     "@salesforce/kit": "^1.5.0",
     "@salesforce/ts-types": "^1.4.2",
     "archiver": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=12.11.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.24.1",
+    "@salesforce/core": "2.24.2",
     "@salesforce/kit": "^1.5.0",
     "@salesforce/ts-types": "^1.4.2",
     "archiver": "4.0.1",

--- a/test/client/metadataTransfer.test.ts
+++ b/test/client/metadataTransfer.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { createSandbox, SinonFakeTimers, SinonStub } from 'sinon';
+import { createSandbox, SinonStub } from 'sinon';
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import { ComponentSet } from '../../src';
 import { MetadataTransfer } from '../../src/client/metadataTransfer';
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import { MetadataTransferError } from '../../src/errors';
 import { mockConnection } from '../mock/client';
 import { fail } from 'assert';
+import { sleep } from '@salesforce/kit';
 
 const $$ = testSetup();
 const env = createSandbox();
@@ -50,13 +51,11 @@ class TestTransfer extends MetadataTransfer<MetadataRequestStatus, MetadataTrans
 }
 
 describe('MetadataTransfer', () => {
-  let clock: SinonFakeTimers;
   let connection: Connection;
 
   let operation: TestTransfer;
 
   beforeEach(async () => {
-    clock = env.useFakeTimers();
     connection = await mockConnection($$);
     operation = new TestTransfer({
       components: new ComponentSet(),
@@ -170,6 +169,27 @@ describe('MetadataTransfer', () => {
       expect(listenerStub.callCount).to.equal(1);
     });
 
+    it('should wait for polling function to return before queing another', async () => {
+      const { checkStatus } = operation.lifecycle;
+      const checkStatusRuntime = 50;
+      const callOrder: string[] = [];
+      checkStatus.onFirstCall().callsFake(async () => {
+        callOrder.push('firstCall1');
+        await sleep(checkStatusRuntime);
+        callOrder.push('firstCall2');
+        return { done: false };
+      });
+      checkStatus.onSecondCall().callsFake(async () => {
+        callOrder.push('secondCall1');
+        return { done: true };
+      });
+
+      await operation.pollStatus(20);
+
+      expect(checkStatus.callCount).to.equal(2);
+      expect(callOrder).to.deep.equal(['firstCall1', 'firstCall2', 'secondCall1']);
+    });
+
     it('should emit wrapped error if something goes wrong', async () => {
       const { checkStatus } = operation.lifecycle;
       const originalError = new Error('whoops');
@@ -201,8 +221,12 @@ describe('MetadataTransfer', () => {
   });
 
   describe('Cancellation', () => {
-    it('should exit even before status has been checked before cancel request', async () => {
+    it('should exit without calling checkStatus if transfer is immediately canceled', async () => {
       const { checkStatus } = operation.lifecycle;
+      const cancelListenerStub = env.stub();
+      const updateListenerStub = env.stub();
+      operation.onCancel(() => cancelListenerStub());
+      operation.onUpdate(() => updateListenerStub());
 
       await operation.start();
       const operationPromise = operation.pollStatus();
@@ -211,51 +235,28 @@ describe('MetadataTransfer', () => {
 
       expect(checkStatus.notCalled).to.be.true;
       expect(result).to.deep.equal({ id: '1' });
+      expect(cancelListenerStub.callCount).to.equal(1);
+      expect(updateListenerStub.callCount).to.equal(0);
     });
 
-    it('should continue polling until cancel operation finishes asynchonously', async () => {
+    it('should exit after checkStatus if transfer is marked for cancelation', async () => {
+      const { checkStatus } = operation.lifecycle;
       const cancelListenerStub = env.stub();
-      const { checkStatus, cancel } = operation.lifecycle;
-      checkStatus.returns({ status: RequestStatus.InProgress });
-      cancel.callsFake(() => {
-        // when cancel is called, set status to canceling
-        checkStatus.returns({ status: RequestStatus.Canceling });
-        return false;
-      });
-
-      const operationPromise = operation.pollStatus();
-
-      queueMicrotask(() => {
-        // cancel right after lifecycle starts
-        operation.cancel();
-        queueMicrotask(() => {
-          // schedule clock to break first wait
-          queueMicrotask(() => {
-            clock.tick(110);
-            queueMicrotask(() => {
-              // schedule clock to break second wait
-              queueMicrotask(() => {
-                clock.tick(110);
-              });
-            });
-          });
-        });
-      });
-
+      const updateListenerStub = env.stub();
       operation.onCancel(() => cancelListenerStub());
-
-      operation.onUpdate((result) => {
-        if (checkStatus.callCount === 2) {
-          // should be canceling by second poll
-          expect(result.status).to.equal(RequestStatus.Canceling);
-          // force third poll to have cancel status
-          checkStatus.returns({ status: RequestStatus.Canceled, done: true });
-        }
+      operation.onUpdate(() => updateListenerStub());
+      checkStatus.onFirstCall().callsFake(async () => {
+        await operation.cancel();
+        return { status: RequestStatus.InProgress, done: false };
       });
 
-      await operationPromise;
+      await operation.start();
+      const result = await operation.pollStatus();
 
+      expect(checkStatus.calledOnce).to.be.true;
+      expect(result).to.deep.equal({ id: '1' });
       expect(cancelListenerStub.callCount).to.equal(1);
+      expect(updateListenerStub.callCount).to.equal(1);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,25 +245,23 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@2.23.2":
-  version "2.23.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.23.2.tgz#cdb02677c51562b496fe796a3bc69d68a23f3026"
-  integrity sha512-LTnl7ElWrIgIYqYWLWL9KUrCI4kCEKaQlglUEJWBDLSUM0rfW3EnChLMaXZTCkqGjYLbldfRh8GXMxyejpoSTw==
+"@salesforce/core@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.24.1.tgz#0b2943ae642b84fd7bf9e60a87caf7454f129e14"
+  integrity sha512-oXb4x6UNkg++BlQd2wd/sdOlYCsQ1kMlruVJkcvQdLXXUHBjIl4ciV9f0NLQ2bjpU8vUtjlSmZR7cDruHDw9NA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.0"
     "@salesforce/schemas" "^1.0.1"
-    "@salesforce/ts-types" "^1.0.0"
-    "@types/graceful-fs" "^4.1.3"
-    "@types/jsforce" "1.9.23"
-    "@types/mkdirp" "1.0.0"
+    "@salesforce/ts-types" "^1.5.13"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"
-    jsforce "^1.10.0"
+    jsforce "^1.10.1"
     jsonwebtoken "8.5.0"
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
+    ts-retry-promise "^0.6.0"
 
 "@salesforce/kit@^1.5.0":
   version "1.5.8"
@@ -287,7 +285,7 @@
     sinon "5.1.1"
     tslib "^1.10.0"
 
-"@salesforce/ts-types@^1.0.0", "@salesforce/ts-types@^1.4.2", "@salesforce/ts-types@^1.4.3":
+"@salesforce/ts-types@^1.4.2", "@salesforce/ts-types@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.4.3.tgz#941ceac6d72a2983ec03d5263b509f25bab574c3"
   integrity sha512-Fdx9KEBalwxBFkP0ZW9uIcndjFys9fm8ma9vItd3EwPZLJcAHWfBa5/y9uHLAvYHkKK8F8FYE0sRrVZ1cn48hw==
@@ -372,20 +370,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/graceful-fs@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
-  integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/jsforce@1.9.23":
-  version "1.9.23"
-  resolved "https://registry.yarnpkg.com/@types/jsforce/-/jsforce-1.9.23.tgz#06c2b604e02bfc8ba1143c6bf53530e565f18bae"
-  integrity sha512-p1aqPWapTAG5xpTpebj4jSs5cwpNHe5PYFtEXCIjsSgfFgIW7GgQb5X/43/M8gkZNcGe8kchykrD9UgYKjz3eQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/json-schema@^7.0.3":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -405,13 +389,6 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
   integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/mkdirp@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.0.tgz#16ce0eabe4a9a3afe64557ad0ee6886ec3d32927"
-  integrity sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==
   dependencies:
     "@types/node" "*"
 
@@ -2793,7 +2770,7 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@^1.10.0:
+jsforce@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-1.10.1.tgz#ca1cf58d4439d94e1f84482d83081acd12c93269"
   integrity sha512-rv+UpBR9n/sWdgLhyPOJuKgT9ZKngypYf9XOHoXVRpSllvTFCjn+M3H81Nu1oYjPH9JKXVS8hL1dmmq8+kOAJg==
@@ -4873,6 +4850,11 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
+
+ts-retry-promise@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.6.0.tgz#95643500d5388eed25abc90aa2e99c8b6c5a7bc9"
+  integrity sha512-8DF80uA7JPu6m8ouHxGkyBpPTIGQnsgIUgLDqcRaD7EEhVowjG72KqCX334gsa1P+AmzeTVdd/xEzVFCAuPCtg==
 
 tslib@^1.10.0, tslib@^1.9.0:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,15 +245,18 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.24.1.tgz#0b2943ae642b84fd7bf9e60a87caf7454f129e14"
-  integrity sha512-oXb4x6UNkg++BlQd2wd/sdOlYCsQ1kMlruVJkcvQdLXXUHBjIl4ciV9f0NLQ2bjpU8vUtjlSmZR7cDruHDw9NA==
+"@salesforce/core@2.24.2":
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.24.2.tgz#d699af286bcf00051a85c63a9c60aa8146fd8b5f"
+  integrity sha512-J5fPpHOKVsliQe0tH6IsSt71VLAP7vuStimxdixI4k2JBkyrGFvvJ8+O8qFQ1Je0037A0xN0haT+ky2QivAZPg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.0"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.5.13"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/jsforce" "^1.9.29"
+    "@types/mkdirp" "^1.0.1"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"
@@ -370,6 +373,20 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/graceful-fs@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
+  integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/jsforce@^1.9.29":
+  version "1.9.30"
+  resolved "https://registry.yarnpkg.com/@types/jsforce/-/jsforce-1.9.30.tgz#725cba4175ddc17cf9902b6e647f2ed4a9614b50"
+  integrity sha512-T0fgAfa99sx13gkClPkJsQRHzTcJ0Rgj7//6XEY9Qq6VRQH0U+cxlM1fqAsQ8rhAfAzyGhQk+j1nR1cWkp06NQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -389,6 +406,13 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
   integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/mkdirp@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
+  integrity sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
### What does this PR do?
Bump the version of @salesforce/core to 2.24.1 to get a fix for the PollingClient.  Fix and write more unit
tests to guard against regressions.

### What issues does this PR fix or reference?
@W-9505934@

### Functionality Before
The PollingClient from the `@salesforce/core` library had a bug that was not awaiting the result of the polling function before the setInterval timer would call the polling function again.  This was causing larger metadata retrieves to throw an error because the request would complete but the polling would send another request to the server and that extra request(s) would cause an error.

### Functionality After
The fixed PollingClient in the core library now properly waits for the polling function to return before polling again.
