### PR TITLE
fix: codeowners syntax and package version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,4 @@
 # the repo. Unless a later match takes precedence,
 # @forcedotcom/pdt will be requested for
 # review when someone opens a pull request.
-*       @forcedotcom/pdt
-*       @shetzel
+*       @forcedotcom/pdt @shetzel

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "gusBuild": "49.1.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",


### PR DESCRIPTION
### What does this PR do?

The package.json version was incorrect when last publishing the library. This resets it back to `3.0.0` so when the job runs, it will properly bump to `3.1.0`.

It also fixes an issue with having multiple codeowners.

### What issues does this PR fix or reference?

@W-9544572@
