### PR TITLE
fix: bumps the version of core to 2.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=12.11.0"
   },
   "dependencies": {
-    "@salesforce/core": "2.24.2",
+    "@salesforce/core": "2.25.1",
     "@salesforce/kit": "^1.5.0",
     "@salesforce/ts-types": "^1.4.2",
     "archiver": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,10 +245,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/core@2.24.2":
-  version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.24.2.tgz#d699af286bcf00051a85c63a9c60aa8146fd8b5f"
-  integrity sha512-J5fPpHOKVsliQe0tH6IsSt71VLAP7vuStimxdixI4k2JBkyrGFvvJ8+O8qFQ1Je0037A0xN0haT+ky2QivAZPg==
+"@salesforce/core@2.25.1":
+  version "2.25.1"
+  resolved "https://registry.npmjs.org/@salesforce/core/-/core-2.25.1.tgz#2be78b4fc824bfb69537174a0440ba35d19d8fa4"
+  integrity sha512-kRo1Uce8sFFXNBEu3odJ4zsFkvja+s/cmj7ICI6EvCsgwMHSLCw4P7zhqAsOJnBUim3M2qb4p0HpVtkQ4Cz3Kg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.0"


### PR DESCRIPTION
### What does this PR do?
bumps core to get a PollingClient fix.  The library used by the PollingClient in core would default to a max poll retries of 10 rather than poll until a timeout is reached.  The fix in core was to specify an option to poll infinite retries (but stop if a timeout is hit).

### What issues does this PR fix or reference?
@W-9545459@

### Functionality Before
Large deploys or retrieves would cause an error to be thrown after 10 polling attempts.

### Functionality After
Polling will run until the timeout.
