### PR TITLE
fix: add WaveComponent to metadata registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1047,6 +1047,16 @@
         "adapter": "matchingContentFile"
       }
     },
+    "wavecomponent": {
+      "id": "wavecomponent",
+      "name": "WaveComponent",
+      "suffix": "wcomp",
+      "directoryName": "wave",
+      "inFolder": false,
+      "strategies": {
+        "adapter": "matchingContentFile"
+      }
+    },
     "wavexmd": {
       "id": "wavexmd",
       "name": "WaveXmd",
@@ -2077,6 +2087,7 @@
     "geodata": "eclairgeodata",
     "wlens": "wavelens",
     "wdash": "wavedashboard",
+    "wcomp": "wavecomponent",
     "xmd": "wavexmd",
     "wdf": "wavedataflow",
     "wdpr": "waverecipe",


### PR DESCRIPTION
What does this PR do?
Add WaveComponent to metadata registry here so deploy and retrieve work.
WaveComponent works like WaveDashboard since it's an extension of WaveDashboard.

What issues does this PR fix or reference?
@W-9520846@

Functionality Before
Currently, deploy and retrieve on WaveComponent returns error from this library and plugins-source.

Functionality After
It works, tested via resolve('/path/to/wave/file.comp') and when linked into plugins-source linked into sfdx.
