### PR TITLE
Wr/bot version

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1685,7 +1685,7 @@
           "botversion": {
             "id": "botversion",
             "name": "BotVersion",
-            "directoryName": "",
+            "directoryName": "botVersions",
             "suffix": "botVersion"
           }
         },
@@ -1699,7 +1699,7 @@
       "strategies": {
         "adapter": "decomposed",
         "transformer": "decomposed",
-        "decomposition": "folderPerType"
+        "decomposition": "topLevel"
       }
     },
     "animationrule": {

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -2201,7 +2201,7 @@
     "documents": "document",
     "waveTemplates": "wavetemplatebundle",
     "objects": "customobject",
-    "bot": "bot",
+    "bots": "bot",
     "objectTranslations": "customobjecttranslation",
     "staticresources": "staticresource",
     "sites": "customsite",

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1685,12 +1685,12 @@
           "botversion": {
             "id": "botversion",
             "name": "BotVersion",
-            "directoryName": "botVersions",
+            "directoryName": "",
             "suffix": "botVersion"
           }
         },
         "directories": {
-          "version": "botversion"
+          "botVersions": "botversion"
         },
         "suffixes": {
           "botVersion": "botversion"

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1679,6 +1679,7 @@
       "suffix": "bot",
       "directoryName": "bots",
       "inFolder": false,
+      "strictDirectoryName": true,
       "children": {
         "types": {
           "botversion": {
@@ -1688,9 +1689,17 @@
             "suffix": "botVersion"
           }
         },
+        "directories": {
+          "version": "botversion"
+        },
         "suffixes": {
           "botVersion": "botversion"
         }
+      },
+      "strategies": {
+        "adapter": "decomposed",
+        "transformer": "decomposed",
+        "decomposition": "folderPerType"
       }
     },
     "animationrule": {
@@ -2192,6 +2201,7 @@
     "documents": "document",
     "waveTemplates": "wavetemplatebundle",
     "objects": "customobject",
+    "bot": "bot",
     "objectTranslations": "customobjecttranslation",
     "staticresources": "staticresource",
     "sites": "customsite",

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -2149,6 +2149,7 @@
     "prompt": "prompt",
     "mlDomain": "mldomain",
     "bot": "bot",
+    "botVersion": "botversion",
     "animationRule": "animationrule",
     "deployment": "recordactiondeployment",
     "EmbeddedServiceFlowConfig": "embeddedserviceflowconfig",


### PR DESCRIPTION
### What does this PR do?
Match toolbelt for `Bot` and `BotVersion` metadata types,

I'm not sure if it's ok to change the registry, or if these changes belong in the `typeOverrides.json` file, from the SDR handbook
>This file is large and luckily, not entirely crafted by hand

so some of it is handcrafted...

### What issues does this PR fix or reference?

@W-9543511@

Ignore the "toolbelt" and "SDR" in the screenshots, those were the behaviors, of each prior. SDR now matches the "toolbelt" picture

### Functionality Before
![image (2)](https://user-images.githubusercontent.com/23369140/124959118-20229780-dfd8-11eb-86a6-3687ef84efe8.png)


### Functionality After
![image (3)](https://user-images.githubusercontent.com/23369140/124959132-23b61e80-dfd8-11eb-92a9-50f187db0c16.png)
<insert gif and/or summary>
