### PR TITLE
fix: resolveComponent no longer tries to resolve ignored dir paths

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -78,9 +78,11 @@ export class MetadataResolver {
       if (this.tree.isDirectory(fsPath)) {
         if (this.resolveDirectoryAsComponent(fsPath)) {
           const component = this.resolveComponent(fsPath, true);
-          if (!inclusiveFilter || inclusiveFilter.has(component)) {
-            components.push(component);
-            ignore.add(component.xml);
+          if (component) {
+            if (!inclusiveFilter || inclusiveFilter.has(component)) {
+              components.push(component);
+              ignore.add(component.xml);
+            }
           }
         } else {
           dirQueue.push(fsPath);
@@ -116,8 +118,8 @@ export class MetadataResolver {
   }
 
   private resolveComponent(fsPath: string, isResolvingSource: boolean): SourceComponent {
-    if (this.isMetadata(fsPath) && this.forceIgnore.denies(fsPath)) {
-      // don't resolve the component if the metadata xml is denied
+    if (this.forceIgnore.denies(fsPath)) {
+      // don't resolve the component if the path is denied
       return;
     }
     const type = this.resolveType(fsPath);

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -78,11 +78,9 @@ export class MetadataResolver {
       if (this.tree.isDirectory(fsPath)) {
         if (this.resolveDirectoryAsComponent(fsPath)) {
           const component = this.resolveComponent(fsPath, true);
-          if (component) {
-            if (!inclusiveFilter || inclusiveFilter.has(component)) {
-              components.push(component);
-              ignore.add(component.xml);
-            }
+          if (component && (!inclusiveFilter || inclusiveFilter.has(component))) {
+            components.push(component);
+            ignore.add(component.xml);
           }
         } else {
           dirQueue.push(fsPath);

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -560,6 +560,39 @@ describe('MetadataResolver', () => {
       });
     });
 
+    it('should ignore directories as fsPaths', () => {
+      // NOTE on what this test is for: When an ExperienceBundle type is retrieved
+      // as part of a project's metadata, but the ExperienceBundle dir and all files
+      // in that dir are ignored, it would throw an error. This ensures it doesn't
+      // throw and also doesn't resolve any components.
+      const dirPath = taraji.TARAJI_DIR;
+      const fsPath = taraji.TARAJI_CONTENT_PATH;
+      const topLevelXmlPath = taraji.TARAJI_XML_PATHS[0];
+      testUtil.stubForceIgnore({ seed: dirPath, deny: [fsPath, topLevelXmlPath] });
+      const access = testUtil.createMetadataResolver([
+        {
+          dirPath,
+          children: [basename(fsPath), basename(topLevelXmlPath)],
+        },
+        {
+          dirPath: fsPath,
+          children: [],
+        },
+      ]);
+      testUtil.stubAdapters([
+        {
+          type: mockRegistryData.types.tarajihenson,
+          componentMappings: [
+            {
+              path: topLevelXmlPath,
+              component: taraji.TARAJI_COMPONENT,
+            },
+          ],
+        },
+      ]);
+      expect(access.getComponentsFromPath(dirPath).length).to.equal(0);
+    });
+
     describe('Filtering', () => {
       it('should only return components present in filter', async () => {
         const resolver = testUtil.createMetadataResolver([


### PR DESCRIPTION
### What does this PR do?
Changes MetadataResolver.resolveComponent() to check if all paths are forceignored (including directories) rather than just metadata files before resolution so that errors aren't thrown in certain cases (see below).

This PR is courtesy of @jayree.  Thank you!

### What issues does this PR fix or reference?
@W-9543674@

### Functionality Before
With `.forceignore` contents that include an entry of `**/test1`, which should ignore test1 directories the following command would cause an error:
`sfdx force:source:retrieve -p force-app`

ERROR running force:source:retrieve:  Metadata xml file unpackaged/experiences/test1.site-meta.xml is forceignored but is required for unpackaged/experiences/test1

### Functionality After
No error is thrown for the same command and the same `.forceignore` contents
