### PR TITLE
fix: add support for sourceApiVersion

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -272,11 +272,7 @@ export class MetadataApiDeploy extends MetadataTransfer<MetadataApiDeployStatus,
 
   protected async pre(): Promise<AsyncResult> {
     const converter = new MetadataConverter();
-    const { zipBuffer } = await converter.convert(
-      Array.from(this.components.getSourceComponents()),
-      'metadata',
-      { type: 'zip' }
-    );
+    const { zipBuffer } = await converter.convert(this.components, 'metadata', { type: 'zip' });
     const connection = await this.getConnection();
     await this.maybeSaveTempDirectory('metadata');
     return connection.deploy(zipBuffer, this.options.apiOptions);

--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -146,19 +146,13 @@ export abstract class MetadataTransfer<
       try {
         const source = cs || this.components || new ComponentSet();
         const converter = new MetadataConverter();
+        await converter.convert(source, target, {
+          type: 'directory',
+          outputDirectory: mdapiTempDir,
+        });
         if (target === 'source') {
-          await converter.convert(source.getSourceComponents().toArray(), target, {
-            type: 'directory',
-            outputDirectory: mdapiTempDir,
-          });
-          // for source convert the package.xml isn't included, we'll write that separately
-
+          // for source convert the package.xml isn't included so write it separately
           fs.writeFileSync(join(mdapiTempDir, 'package.xml'), source.getPackageXml());
-        } else {
-          await converter.convert(source.getSourceComponents().toArray(), target, {
-            type: 'directory',
-            outputDirectory: mdapiTempDir,
-          });
         }
       } catch (e) {
         this.logger.debug(e);
@@ -171,7 +165,7 @@ export abstract class MetadataTransfer<
       this.usernameOrConnection = await Connection.create({
         authInfo: await AuthInfo.create({ username: this.usernameOrConnection }),
       });
-      if (this.apiVersion) {
+      if (this.apiVersion && this.apiVersion !== this.usernameOrConnection.version) {
         this.usernameOrConnection.setApiVersion(this.apiVersion);
         this.logger.debug(`Overriding apiVersion to: ${this.apiVersion}`);
       }

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -46,7 +46,15 @@ export type RetrieveSetOptions = Omit<MetadataApiRetrieveOptions, 'components'>;
 export class ComponentSet extends LazyCollection<MetadataComponent> {
   public static readonly WILDCARD = '*';
   private static readonly KEY_DELIMITER = '#';
+  /**
+   * The metadata API version to use. E.g., 52.0
+   */
   public apiVersion: string;
+  /**
+   * The metadata API version of the deployed/retrieved source.
+   * This is used as the value for the `version` field in the manifest.
+   */
+  public sourceApiVersion: string;
   public fullName?: string;
   private registry: RegistryAccess;
   private components = new Map<string, Map<string, SourceComponent>>();
@@ -246,7 +254,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     return {
       Package: {
         types: typeMembers,
-        version: this.apiVersion,
+        version: this.sourceApiVersion || this.apiVersion,
         fullName: this.fullName,
       },
     };

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -49,10 +49,36 @@ export class MetadataConverter {
     components: Iterable<SourceComponent>,
     targetFormat: SfdxFileFormat,
     output: ConvertOutputConfig
+  ): Promise<ConvertResult>;
+
+  /**
+   * Convert metadata components within a `ComponentSet` to another SFDX file format.
+   *
+   * @param componentSet ComponentSet to convert
+   * @param targetFormat Format to convert the component files to
+   * @param output Configuration for outputting the converted files
+   */
+  public async convert(
+    componentSet: ComponentSet,
+    targetFormat: SfdxFileFormat,
+    output: ConvertOutputConfig
+  ): Promise<ConvertResult>;
+
+  public async convert(
+    comps: ComponentSet | Iterable<SourceComponent>,
+    targetFormat: SfdxFileFormat,
+    output: ConvertOutputConfig
   ): Promise<ConvertResult> {
     try {
-      // it's possible the components came from a component set, so this may be redundant in some cases...
-      const cs = new ComponentSet(components, this.registry);
+      let cs: ComponentSet;
+      let components: Iterable<SourceComponent>;
+      if (comps instanceof ComponentSet) {
+        cs = comps;
+        components = Array.from(comps.getSourceComponents());
+      } else {
+        cs = new ComponentSet(comps, this.registry);
+        components = comps;
+      }
       let manifestContents;
       const isSource = targetFormat === 'source';
       const tasks = [];

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -53,8 +53,7 @@ describe('MetadataApiDeploy', () => {
 
         await operation.start();
 
-        expect(convertStub.calledWith(components.toArray(), 'metadata', { type: 'zip' })).to.be
-          .true;
+        expect(convertStub.calledWith(components, 'metadata', { type: 'zip' })).to.be.true;
       });
 
       it('should call deploy with zip', async () => {

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -318,6 +318,31 @@ describe('ComponentSet', () => {
       });
     });
 
+    it('should return an object representing the package manifest with sourceApiVersion', () => {
+      const set = ComponentSet.fromSource({
+        fsPaths: ['.'],
+        registry: mockRegistry,
+        tree: manifestFiles.TREE,
+      });
+      set.sourceApiVersion = '45.0';
+      expect(set.getObject()).to.deep.equal({
+        Package: {
+          fullName: undefined,
+          types: [
+            {
+              name: 'DecomposedTopLevel',
+              members: ['a'],
+            },
+            {
+              name: 'MixedContentSingleFile',
+              members: ['b', 'c'],
+            },
+          ],
+          version: set.sourceApiVersion,
+        },
+      });
+    });
+
     it('should interpret folder components as members of the type they are a container for', () => {
       const member = { fullName: 'Test_Folder', type: 'McifFolder' };
       const set = new ComponentSet([member], mockRegistry);

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -159,6 +159,27 @@ describe('MetadataConverter', () => {
       ]);
     });
 
+    it('should write manifest for metadata format conversion with sourceApiVersion', async () => {
+      const timestamp = 123456;
+      const packagePath = join(
+        outputDirectory,
+        `${MetadataConverter.DEFAULT_PACKAGE_PREFIX}_${timestamp}`
+      );
+      env.stub(Date, 'now').returns(timestamp);
+      const compSet = new ComponentSet(components, mockRegistry);
+      compSet.sourceApiVersion = '45.0';
+      const expectedContents = compSet.getPackageXml();
+
+      await converter.convert(compSet, 'metadata', { type: 'directory', outputDirectory });
+
+      expect(writeFileStub.calledBefore(pipelineStub)).to.be.true;
+      expect(writeFileStub.firstCall.args).to.deep.equal([
+        join(packagePath, MetadataConverter.PACKAGE_XML_FILE),
+        expectedContents,
+      ]);
+      expect(expectedContents).to.contain(`<version>${compSet.sourceApiVersion}</version>`);
+    });
+
     it('should write the fullName entry when packageName is provided', async () => {
       const timestamp = 123456;
       const packageName = 'examplePackage';

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -82,9 +82,7 @@ export async function stubMetadataDeploy(
     .resolves(MOCK_RECENTLY_VALIDATED_ID_SOAP);
 
   const convertStub = sandbox.stub(MetadataConverter.prototype, 'convert');
-  convertStub
-    .withArgs(Array.from(options.components), 'metadata', { type: 'zip' })
-    .resolves({ zipBuffer });
+  convertStub.withArgs(options.components, 'metadata', { type: 'zip' }).resolves({ zipBuffer });
 
   const defaultStatus = { success: false, done: false, status: RequestStatus.Pending };
   const status: Partial<MetadataApiDeployStatus> = Object.assign(defaultStatus, MOCK_ASYNC_RESULT);


### PR DESCRIPTION
### What does this PR do?
Adds the ability to set the manifest version from a ComponentSet.  This is necessary to support source that is in a format specific to an API version.  Also overloads the MetadataConverter.convert() method to take a ComponentSet or list of Components.

### What issues does this PR fix or reference?
 @W-9604681@

### Functionality Before
It was not possible to change the version within the generated manifest for a deploy or retrieve

### Functionality After
The `sourceApiVersion` within a sfdx-project.json can be used to change the generated manifest version.
