### PR TITLE
Add BatchCalcJobDefinition to metadata registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1649,7 +1649,8 @@
       "name": "BatchCalcJobDefinition",
       "suffix": "batchCalcJobDefinition",
       "directoryName": "batchCalcJobDefinitions",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "oauthcustomscope": {
       "id": "oauthcustomscope",
@@ -2161,6 +2162,7 @@
     "featureParameterDate": "featureparameterdate",
     "featureParameterInteger": "featureparameterinteger",
     "commandaction": "commandaction",
+    "batchCalcJobDefinition": "batchcalcjobdefinition",
     "oauthcustomscope": "oauthcustomscope",
     "platformEventChannel": "platformeventchannel",
     "customHelpMenuSection": "customhelpmenusection",

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1644,6 +1644,13 @@
       "directoryName": "commandActions",
       "inFolder": false
     },
+    "batchcalcjobdefinition": {
+      "id": "batchcalcjobdefinition",
+      "name": "BatchCalcJobDefinition",
+      "suffix": "batchCalcJobDefinition",
+      "directoryName": "batchCalcJobDefinitions",
+      "inFolder": false
+    },
     "oauthcustomscope": {
       "id": "oauthcustomscope",
       "name": "OauthCustomScope",


### PR DESCRIPTION
### What does this PR do?
Add BatchCalcJobDefinition to metadata registry

### What issues does this PR fix or reference?
A customer tried to retrive the component using sfdx source retrive from VS Code extension and received error "Missing metadata type definition in registry for id 'batchcalcjobdefinition'"
@W-9589556@

### Functionality Before
Retrieve fails through vs code extension

### Functionality After
Retrieve succeeds through vs code extension
