### PR TITLE
chore: enable EmailServicesFunction

### DIFF
--- a/scripts/update-registry/typeOverride.json
+++ b/scripts/update-registry/typeOverride.json
@@ -1,7 +1,4 @@
 {
-  "emailservicesfunction": {
-    "suffix": null
-  },
   "emailtemplatefolder": {
     "id": "emailfolder",
     "name": "EmailFolder",

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1558,10 +1558,10 @@
     "emailservicesfunction": {
       "id": "emailservicesfunction",
       "name": "EmailServicesFunction",
-      "suffix": null,
+      "suffix": "xml",
       "directoryName": "emailservices",
       "inFolder": false,
-      "strictDirectoryName": true
+      "strictDirectoryName": false
     },
     "integrationhubsettingstype": {
       "id": "integrationhubsettingstype",
@@ -2182,7 +2182,8 @@
     "workSkillRouting": "workskillrouting",
     "timeSheetTemplate": "timesheettemplate",
     "accountRelationshipShareRule": "accountrelationshipsharerule",
-    "IPAddressRange": "ipaddressrange"
+    "IPAddressRange": "ipaddressrange",
+    "xml": "emailservicesfunction"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",
@@ -2194,7 +2195,6 @@
     "objectTranslations": "customobjecttranslation",
     "staticresources": "staticresource",
     "sites": "customsite",
-    "emailservices": "emailservicesfunction"
   },
   "childTypes": {
     "customlabel": "customlabels",

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -127,12 +127,22 @@ export class MetadataResolver {
       // source path or allowed content-only path, otherwise the adapter
       // knows how to handle it
       const shouldResolve =
+        this.parseAsRootMetadataXml(fsPath) ||
         isResolvingSource ||
         !this.parseAsContentMetadataXml(fsPath) ||
         !adapter.allowMetadataWithContent();
       return shouldResolve ? adapter.getComponent(fsPath, isResolvingSource) : undefined;
     }
     throw new TypeInferenceError('error_could_not_infer_type', fsPath);
+  }
+
+  /**
+   * Any metadata xml file (-meta.xml) is potentially a root metadata file.
+   *
+   * @param fsPath File path of a potential metadata xml file
+   */
+  private parseAsRootMetadataXml(fsPath: string): boolean {
+    return !!parseMetadataXml(fsPath);
   }
 
   private resolveType(fsPath: string): MetadataType | undefined {


### PR DESCRIPTION
### What does this PR do?
This PR goes against the [handbook](https://salesforce.quip.com/F3q6AmNSquvE#ZJKACAn1eZP) but enabling this type for a retrieve which would have required adding a new Transfomer/adapter, which would also go against the [handbook](https://salesforce.quip.com/F3q6AmNSquvE#ZJKACABWVSO)

this approach seemed a little better

all credit goes to @jayree
### What issues does this PR fix or reference?

@W-9543539@

### Functionality Before
`EmailServicesFunction` wasn't able to be retrieved
<insert gif and/or summary>

### Functionality After
`EmailServicesFunction` able to be retrieved

<insert gif and/or summary>
