### PR TITLE
chore: add CustomFieldTranslation to registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -768,7 +768,7 @@
       "strictDirectoryName": true,
       "children": {
         "types": {
-          "fieldtranslation": {
+          "customfieldtranslation": {
             "id": "customfieldtranslation",
             "name": "CustomFieldTranslation",
             "directoryName": "fields",
@@ -776,10 +776,10 @@
           }
         },
         "suffixes": {
-          "fieldTranslation": "fieldtranslation"
+          "fieldTranslation": "customfieldtranslation"
         },
         "directories": {
-          "fields": "fieldtranslation"
+          "fields": "customfieldtranslation"
         }
       },
       "strategies": {
@@ -2251,7 +2251,8 @@
     "matchingrule": "matchingrules",
     "sharingownerrule": "sharingrules",
     "sharingcriteriarule": "sharingrules",
-    "botversion": "bot"
+    "botversion": "bot",
+    "customfieldtranslation": "customobjecttranslation"
   },
   "apiVersion": "52.0"
 }


### PR DESCRIPTION
### What does this PR do?
Adds `CustomFieldTranslation` type, courtesy of @jayree
https://github.com/jayree/source-deploy-retrieve/commit/f66a025df1b1a2ce825f660c2144ef093e0c3c2c
### What issues does this PR fix or reference?

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
