### PR TITLE
chore: invalid empty bundle types filtered from result

### DIFF
--- a/src/resolve/adapters/bundleSourceAdapter.ts
+++ b/src/resolve/adapters/bundleSourceAdapter.ts
@@ -47,15 +47,10 @@ export class BundleSourceAdapter extends MixedContentSourceAdapter {
    * @protected
    */
   protected populate(trigger: SourcePath, component?: SourceComponent): SourceComponent {
-    if (this.tree.isDirectory(trigger) && this.tree.readDirectory(trigger)?.length) {
-      // if we're populating from a populated directory (validLWC)
-      return super.populate(trigger, component);
-    } else if (!this.tree.isDirectory(trigger)) {
-      // we're populating from a path to a file (validLWC/myFoo.js)
-      return super.populate(trigger, component);
-    } else {
-      // we're populating from an empty dir (invalidLWC) do nothing
+    if (this.tree.isDirectory(trigger) && !this.tree.readDirectory(trigger)?.length) {
+      // if it's an empty directory, don't include it (lwc/invalidLWC)
       return;
     }
+    return super.populate(trigger, component);
   }
 }

--- a/src/resolve/adapters/bundleSourceAdapter.ts
+++ b/src/resolve/adapters/bundleSourceAdapter.ts
@@ -47,18 +47,15 @@ export class BundleSourceAdapter extends MixedContentSourceAdapter {
    * @protected
    */
   protected populate(trigger: SourcePath, component?: SourceComponent): SourceComponent {
-    // this.tree.readDirectory will throw an error if the trigger is a file - imagine the try/catch as an if/else
-    // we could be populating from a valid sourcepath lwc/validLWC/myFoo.js
-    try {
-      if (this.tree.readDirectory(trigger)) {
-        // if the directory is populated with files (validLWC)
-        return super.populate(trigger, component);
-      }
-      // else the directory is empty (invalidLWC) do nothing
-      return;
-    } catch (e) {
-      // potentially valid filepath (lwc/validLWC/myFoo.js)
+    if (this.tree.isDirectory(trigger) && this.tree.readDirectory(trigger)?.length) {
+      // if we're populating from a populated directory (validLWC)
       return super.populate(trigger, component);
+    } else if (!this.tree.isDirectory(trigger)) {
+      // we're populating from a path to a file (validLWC/myFoo.js)
+      return super.populate(trigger, component);
+    } else {
+      // we're populating from an empty dir (invalidLWC) do nothing
+      return;
     }
   }
 }

--- a/src/resolve/adapters/bundleSourceAdapter.ts
+++ b/src/resolve/adapters/bundleSourceAdapter.ts
@@ -30,17 +30,18 @@ export class BundleSourceAdapter extends MixedContentSourceAdapter {
   protected ownFolder = true;
 
   /**
-   * filters out empty directories pretending to be valid bundle types
+   * Excludes empty bundle directories.
+   *
    * e.g.
    * lwc/
-   * ├── validLWC/
+   * ├── myFoo/
    * |   ├── myFoo.js
    * |   ├── myFooStyle.css
    * |   ├── myFoo.html
    * |   ├── myFoo.js-meta.xml
-   * ├── invalidLWC/
+   * ├── emptyLWC/
    *
-   * so we shouldn't populate with the `invalidLWC` directory
+   * so we shouldn't populate with the `emptyLWC` directory
    *
    * @param trigger Path that `getComponent` was called with
    * @param component Component to populate properties on
@@ -48,7 +49,7 @@ export class BundleSourceAdapter extends MixedContentSourceAdapter {
    */
   protected populate(trigger: SourcePath, component?: SourceComponent): SourceComponent {
     if (this.tree.isDirectory(trigger) && !this.tree.readDirectory(trigger)?.length) {
-      // if it's an empty directory, don't include it (lwc/invalidLWC)
+      // if it's an empty directory, don't include it (e.g., lwc/emptyLWC)
       return;
     }
     return super.populate(trigger, component);

--- a/src/resolve/adapters/bundleSourceAdapter.ts
+++ b/src/resolve/adapters/bundleSourceAdapter.ts
@@ -51,10 +51,13 @@ export class BundleSourceAdapter extends MixedContentSourceAdapter {
     // we could be populating from a valid sourcepath lwc/validLWC/myFoo.js
     try {
       if (this.tree.readDirectory(trigger)) {
+        // if the directory is populated with files (validLWC)
         return super.populate(trigger, component);
       }
+      // else the directory is empty (invalidLWC) do nothing
+      return;
     } catch (e) {
-      // potentially valid filepath
+      // potentially valid filepath (lwc/validLWC/myFoo.js)
       return super.populate(trigger, component);
     }
   }

--- a/test/mock/registry/type-constants/bundleConstants.ts
+++ b/test/mock/registry/type-constants/bundleConstants.ts
@@ -39,3 +39,22 @@ export const COMPONENT = SourceComponent.createVirtualComponent(
     },
   ]
 );
+
+export const EMPTY_BUNDLE = SourceComponent.createVirtualComponent(
+  {
+    name: 'a',
+    type,
+    xml: XML_PATH,
+    content: CONTENT_PATH,
+  },
+  [
+    {
+      dirPath: TYPE_DIRECTORY,
+      children: [COMPONENT_NAME],
+    },
+    {
+      dirPath: CONTENT_PATH,
+      children: [],
+    },
+  ]
+);

--- a/test/resolve/adapters/bundleSourceAdapter.ts
+++ b/test/resolve/adapters/bundleSourceAdapter.ts
@@ -5,9 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { mockRegistry, bundle } from '../../mock/registry';
+import { mockRegistry, bundle, mockRegistryData } from '../../mock/registry';
 import { expect } from 'chai';
-import { BundleSourceAdapter } from '../../../src/resolve/adapters/bundleSourceAdapter';
+import { BundleSourceAdapter } from '../../../src/resolve/adapters';
+import { SourceComponent } from '../../../src';
+import { CONTENT_PATH, XML_PATH } from '../../mock/registry/type-constants/bundleConstants';
 
 describe('BundleSourceAdapter', () => {
   const adapter = new BundleSourceAdapter(
@@ -19,6 +21,24 @@ describe('BundleSourceAdapter', () => {
 
   it('Should return expected SourceComponent when given a root metadata xml path', () => {
     expect(adapter.getComponent(bundle.XML_PATH)).to.deep.equal(bundle.COMPONENT);
+  });
+
+  it('Should return expected SourceComponent when given a bundle directory', () => {
+    expect(adapter.getComponent(bundle.CONTENT_PATH)).to.deep.equal(bundle.COMPONENT);
+  });
+
+  it('Should exclude a directory without children', () => {
+    const invalidBundle = SourceComponent.createVirtualComponent(
+      {
+        name: 'a',
+        type: mockRegistryData.types.bundle,
+        xml: XML_PATH,
+        content: CONTENT_PATH,
+      },
+      []
+    );
+    // the invalid bundle shouldn't be in the result
+    expect(adapter.getComponent(invalidBundle.content)).to.deep.equal(bundle.COMPONENT);
   });
 
   it('Should return expected SourceComponent when given a source path', () => {

--- a/test/resolve/adapters/bundleSourceAdapter.ts
+++ b/test/resolve/adapters/bundleSourceAdapter.ts
@@ -5,11 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { mockRegistry, bundle, mockRegistryData } from '../../mock/registry';
+import { mockRegistry, bundle } from '../../mock/registry';
 import { expect } from 'chai';
 import { BundleSourceAdapter } from '../../../src/resolve/adapters';
-import { SourceComponent } from '../../../src';
-import { CONTENT_PATH, XML_PATH } from '../../mock/registry/type-constants/bundleConstants';
+import { CONTENT_PATH } from '../../mock/registry/type-constants/bundleConstants';
 
 describe('BundleSourceAdapter', () => {
   const adapter = new BundleSourceAdapter(
@@ -27,18 +26,14 @@ describe('BundleSourceAdapter', () => {
     expect(adapter.getComponent(bundle.CONTENT_PATH)).to.deep.equal(bundle.COMPONENT);
   });
 
-  it('Should exclude a directory without children', () => {
-    const invalidBundle = SourceComponent.createVirtualComponent(
-      {
-        name: 'a',
-        type: mockRegistryData.types.bundle,
-        xml: XML_PATH,
-        content: CONTENT_PATH,
-      },
-      []
+  it('Should exclude empty bundle directories', () => {
+    const emptyBundleAdapter = new BundleSourceAdapter(
+      bundle.EMPTY_BUNDLE.type,
+      mockRegistry,
+      undefined,
+      bundle.EMPTY_BUNDLE.tree
     );
-    // the invalid bundle shouldn't be in the result
-    expect(adapter.getComponent(invalidBundle.content)).to.deep.equal(bundle.COMPONENT);
+    expect(emptyBundleAdapter.getComponent(CONTENT_PATH)).to.be.undefined;
   });
 
   it('Should return expected SourceComponent when given a source path', () => {


### PR DESCRIPTION
### What does this PR do?

if a there was an empty top level directory for a bundle type, I'll use LWC as an example, it would cause deploy errors. I filter those out during the bundle adapter's `populate` method

so a `force:source:deploy -m LightningComponentBundle`
on a dir that looks like 
```   * lwc/
   * ├── validLWC/
   * |   ├── myFoo.js
   * |   ├── myFooStyle.css
   * |   ├── myFoo.html
   * |   ├── myFoo.js-meta.xml
   * ├── invalidLWC/
```

will only result in `validLWC` being deployed, and no errors
### What issues does this PR fix or reference?

#https://github.com/forcedotcom/cli/issues/1099, @W-9692466@

### Functionality Before
error on the server `An object 'withoutContent' of type LightningComponentBundle was named in package.xml, but was not found in zipped directory`
<insert gif and/or summary>

### Functionality After
deploys correctly
<insert gif and/or summary>
