### PR TITLE
fix: metadata suffix

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -2184,7 +2184,7 @@
     "industriesmanufacturingsettings": {
       "id": "industriesmanufacturingsettings",
       "name": "IndustriesManufacturingSettings",
-      "suffix": "settings",
+      "suffix": "industriesManufacturingSettings",
       "directoryName": "IndustriesManufacturingSettings",
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?
Fix metadata suffix for `industriesmanufacturingsettings` metadata type

### What issues does this PR fix or reference?
@W-9628798@