### PR TITLE
fix: getComponent won't throw when parent is ignored

### DIFF
--- a/src/resolve/adapters/baseSourceAdapter.ts
+++ b/src/resolve/adapters/baseSourceAdapter.ts
@@ -54,7 +54,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
 
     let component: SourceComponent;
     if (rootMetadata) {
-      const componentName = this.type.inFolder
+      const componentName = this.type.folderType
         ? `${parentName(rootMetadata.path)}/${rootMetadata.fullName}`
         : rootMetadata.fullName;
       component = new SourceComponent(
@@ -85,7 +85,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
    *
    * @param path File path of a metadata component
    */
-  private parseAsRootMetadataXml(path: SourcePath): MetadataXml {
+  protected parseAsRootMetadataXml(path: SourcePath): MetadataXml {
     const metaXml = parseMetadataXml(path);
     if (metaXml) {
       let isRootMetadataXml = false;

--- a/test/resolve/adapters/decomposedSourceAdapter.ts
+++ b/test/resolve/adapters/decomposedSourceAdapter.ts
@@ -4,16 +4,19 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { DecomposedSourceAdapter } from '../../../src/resolve/adapters/decomposedSourceAdapter';
+import { DecomposedSourceAdapter, DefaultSourceAdapter } from '../../../src/resolve/adapters';
 import {
   mockRegistry,
   decomposed,
   decomposedtoplevel,
   mockRegistryData,
+  xmlInFolder,
 } from '../../mock/registry';
 import { expect } from 'chai';
-import { VirtualTreeContainer } from '../../../src/resolve/treeContainers';
-import { SourceComponent } from '../../../src/resolve';
+import { VirtualTreeContainer, SourceComponent } from '../../../src';
+import { RegistryTestUtil } from '../registryTestUtil';
+import { join } from 'path';
+import { META_XML_SUFFIX } from '../../../src/common';
 
 describe('DecomposedSourceAdapter', () => {
   const type = mockRegistryData.types.decomposed;
@@ -71,5 +74,53 @@ describe('DecomposedSourceAdapter', () => {
     expect(adapter.getComponent(decomposedtoplevel.DECOMPOSED_TOP_LEVEL_XML_PATH)).to.deep.equal(
       component
     );
+  });
+
+  it('should defer parsing metadata xml to child adapter if path is not a root metadata xml', () => {
+    const component = decomposed.DECOMPOSED_CHILD_COMPONENT_1;
+    const result = adapter.getComponent(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
+
+    expect(result).to.deep.equal(component);
+  });
+
+  it('should NOT throw an error if a parent metadata xml file is forceignored', () => {
+    let testUtil;
+    try {
+      const path = join(
+        'path',
+        'to',
+        type.directoryName,
+        `My_Test.${type.suffix}${META_XML_SUFFIX}`
+      );
+
+      testUtil = new RegistryTestUtil();
+
+      const forceIgnore = testUtil.stubForceIgnore({
+        seed: path,
+        deny: [path],
+      });
+      const adapter = new DecomposedSourceAdapter(type, mockRegistry, forceIgnore, tree);
+      const result = adapter.getComponent(path);
+      expect(result).to.not.be.undefined;
+    } catch (e) {
+      expect(e).to.be.undefined;
+    } finally {
+      testUtil.restore();
+    }
+  });
+
+  it('should resolve a folder component in metadata format', () => {
+    const component = xmlInFolder.FOLDER_COMPONENT_MD_FORMAT;
+    const adapter = new DefaultSourceAdapter(component.type, mockRegistry);
+
+    expect(adapter.getComponent(component.xml)).to.deep.equal(component);
+  });
+
+  it('should not recognize an xml only component in metadata format when in the wrong directory', () => {
+    // not in the right type directory
+    const path = join('path', 'to', 'something', 'My_Test.xif');
+    const type = mockRegistryData.types.xmlinfolder;
+    const adapter = new DefaultSourceAdapter(type, mockRegistry);
+    expect(adapter.getComponent(path)).to.be.undefined;
   });
 });


### PR DESCRIPTION
### What does this PR do?
the `decomposedSourceAdapter` was calling `baseSourceAdapter.getComponents` which was throwing an error when a parent xml file wasn't found or was .forceignore'd

this wasn't working for decomposed types because the parent isn't required... and so it was throwing when it shouldn't - blocking functionality. 

I overrode  the `getComponents` in the `decomposedSourceAdapter` adapter so that it wouldn't throw an error in that scenario

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1110, https://github.com/forcedotcom/cli/issues/1106, @W-9720135@

### Functionality Before
```
Metadata xml file /Users/william.ruemmele/projects/scratches/SFDXCLI-Issues/CLIIssues/force-app/main/default/objects/hed__Term__c/hed__Term__c.object-meta.xml is forceignored but is required for /Users/william.ruemmele/projects/scratches/SFDXCLI-Issues/CLIIssues/force-app/main/default/objects/hed__Term__c/fields/Term_Title__c.field-meta.xml
```
<insert gif and/or summary>

### Functionality After
`Source was successfully converted to Metadata API format`
<insert gif and/or summary>
