### PR TITLE
feat: adds support for destructive changes

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -25,6 +25,7 @@ import {
   FromManifestOptions,
   PackageManifestObject,
   FromSourceOptions,
+  DestructiveChangesType,
 } from './types';
 import { LazyCollection } from './lazyCollection';
 import { j2xParser } from 'fast-xml-parser';
@@ -64,6 +65,8 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
   // internal component maps used by this.getObject() when building manifests.
   private destructiveComponents = new Map<string, Map<string, SourceComponent>>();
   private manifestComponents = new Map<string, Map<string, SourceComponent>>();
+
+  private destructiveChangesType = DestructiveChangesType.POST;
 
   public constructor(components: Iterable<ComponentLike> = [], registry = new RegistryAccess()) {
     super();
@@ -422,6 +425,28 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
         }
       }
     }
+  }
+
+  /**
+   * If this `ComponentSet` has components marked for delete, this sets
+   * whether those components are deleted before any other changes are
+   * deployed (`destructiveChangesPre.xml`) or after changes are deployed
+   * (`destructiveChangesPost.xml`).
+   *
+   * @param type The type of destructive changes to make; i.e., pre or post deploy.
+   */
+  public setDestructiveChangesType(type: DestructiveChangesType): void {
+    this.destructiveChangesType = type;
+  }
+
+  /**
+   * If this `ComponentSet` has components marked for delete it will use this
+   * type to build the appropriate destructive changes manifest.
+   *
+   * @returns The type of destructive changes to make; i.e., pre or post deploy.
+   */
+  public getDestructiveChangesType(): DestructiveChangesType {
+    return this.destructiveChangesType;
   }
 
   /**

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -28,6 +28,7 @@ import {
 } from './types';
 import { LazyCollection } from './lazyCollection';
 import { j2xParser } from 'fast-xml-parser';
+import { Logger } from '@salesforce/core';
 import { RegistryAccess } from '../registry';
 
 export type DeploySetOptions = Omit<MetadataApiDeployOptions, 'components'>;
@@ -56,15 +57,26 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    */
   public sourceApiVersion: string;
   public fullName?: string;
+  private logger: Logger;
   private registry: RegistryAccess;
   private components = new Map<string, Map<string, SourceComponent>>();
+
+  // internal component maps used by this.getObject() when building manifests.
+  private destructiveComponents = new Map<string, Map<string, SourceComponent>>();
+  private manifestComponents = new Map<string, Map<string, SourceComponent>>();
 
   public constructor(components: Iterable<ComponentLike> = [], registry = new RegistryAccess()) {
     super();
     this.registry = registry;
     this.apiVersion = this.registry.apiVersion;
+    this.logger = Logger.childFromRoot(this.constructor.name);
+
     for (const component of components) {
-      this.add(component);
+      let asDeletion = false;
+      if (component instanceof SourceComponent) {
+        asDeletion = component.isMarkedForDelete();
+      }
+      this.add(component, asDeletion);
     }
   }
 
@@ -96,6 +108,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     let registry: RegistryAccess;
     let tree: TreeContainer;
     let inclusiveFilter: ComponentSet;
+    let fsDeletePaths: string[] = [];
 
     if (Array.isArray(input)) {
       fsPaths = input;
@@ -104,17 +117,22 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       registry = input.registry ?? registry;
       tree = input.tree ?? tree;
       inclusiveFilter = input.include;
+      fsDeletePaths = input.fsDeletePaths ?? fsDeletePaths;
     } else {
       fsPaths = [input];
     }
 
     const resolver = new MetadataResolver(registry, tree);
     const set = new ComponentSet([], registry);
-    for (const fsPath of fsPaths) {
-      for (const component of resolver.getComponentsFromPath(fsPath, inclusiveFilter)) {
-        set.add(component);
+    const buildComponents = (paths: string[], asDeletes: boolean): void => {
+      for (const path of paths) {
+        for (const component of resolver.getComponentsFromPath(path, inclusiveFilter)) {
+          set.add(component, asDeletes);
+        }
       }
-    }
+    };
+    buildComponents(fsPaths, false);
+    buildComponents(fsDeletePaths, true);
 
     return set;
   }
@@ -229,9 +247,21 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    *
    * @returns Object representation of a package manifest
    */
-  public getObject(): PackageManifestObject {
+  public getObject(forDestructiveChanges = false): PackageManifestObject {
+    // If this ComponentSet has components marked for delete, we need to
+    // only include those components in a destructiveChanges.xml and
+    // all other components in the regular manifest.
+    let components = this.components;
+    if (this.hasDeletes) {
+      if (forDestructiveChanges) {
+        components = this.destructiveComponents;
+      } else {
+        components = this.manifestComponents;
+      }
+    }
+
     const typeMap = new Map<string, string[]>();
-    for (const key of this.components.keys()) {
+    for (const key of components.keys()) {
       const [typeId, fullName] = key.split(ComponentSet.KEY_DELIMITER);
       let type = this.registry.getTypeByName(typeId);
 
@@ -261,17 +291,21 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
   }
 
   /**
-   * Create a manifest in xml format (package.xml) based on the set components.
+   * Create a manifest in xml format based on the set components and the
+   * type of manifest to create.
+   *
+   * E.g. package.xml or destructiveChanges.xml
    *
    * @param indentation Number of spaces to indent lines by.
+   * @param forDestructiveChanges Whether to build a manifest for destructive changes.
    */
-  public getPackageXml(indentation = 4): string {
+  public getPackageXml(indentation = 4, forDestructiveChanges = false): string {
     const j2x = new j2xParser({
       format: true,
       indentBy: new Array(indentation + 1).join(' '),
       ignoreAttributes: false,
     });
-    const toParse = this.getObject();
+    const toParse = this.getObject(forDestructiveChanges);
     toParse.Package[XML_NS_KEY] = XML_NS_URL;
     return XML_DECL.concat(j2x.parse(toParse));
   }
@@ -298,13 +332,29 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     >;
   }
 
-  public add(component: ComponentLike): void {
+  public add(component: ComponentLike, asDeletion?: boolean): void {
     const key = this.simpleKey(component);
     if (!this.components.has(key)) {
       this.components.set(key, new Map<string, SourceComponent>());
     }
     if (component instanceof SourceComponent) {
       this.components.get(key).set(this.sourceKey(component), component);
+
+      // Build maps of destructive components and regular components as they are added
+      // as an optimization when building manifests.
+      if (asDeletion) {
+        component.setMarkedForDelete(true);
+        this.logger.debug(`Marking component for delete: ${component.fullName}`);
+        if (!this.destructiveComponents.has(key)) {
+          this.destructiveComponents.set(key, new Map<string, SourceComponent>());
+        }
+        this.destructiveComponents.get(key).set(this.sourceKey(component), component);
+      } else {
+        if (!this.manifestComponents.has(key)) {
+          this.manifestComponents.set(key, new Map<string, SourceComponent>());
+        }
+        this.manifestComponents.get(key).set(this.sourceKey(component), component);
+      }
     }
   }
 
@@ -314,7 +364,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    * A pair is considered present in the set if one of the following criteria is met:
    *
    * - The pair is directly in the set
-   * - A wilcard component with the same `type` as the pair
+   * - A wildcard component with the same `type` as the pair
    * - If a parent is attached to the pair and the parent is directly in the set
    * - If a parent is attached to the pair, and a wildcard component's `type` matches the parent's `type`
    *
@@ -387,6 +437,13 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       size += collection.size === 0 ? 1 : collection.size;
     }
     return size;
+  }
+
+  /**
+   * Returns `true` if this `ComponentSet` contains components marked for deletion.
+   */
+  get hasDeletes(): boolean {
+    return this.destructiveComponents.size > 0;
   }
 
   private sourceKey(component: SourceComponent): string {

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -30,6 +30,10 @@ export interface FromSourceOptions extends OptionalTreeRegistryOptions {
    * Only resolve components contained in the given set
    */
   include?: ComponentSet;
+  /**
+   * File paths or directory paths of deleted components, i.e., destructive changes.
+   */
+  fsDeletePaths?: string[];
 }
 
 export interface FromManifestOptions extends OptionalTreeRegistryOptions {

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -21,6 +21,11 @@ export interface PackageManifestObject {
   };
 }
 
+export enum DestructiveChangesType {
+  POST = 'post',
+  PRE = 'pre',
+}
+
 export interface FromSourceOptions extends OptionalTreeRegistryOptions {
   /**
    * File paths or directory paths to resolve components against

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -30,6 +30,7 @@ import { RegistryAccess } from '../registry';
 
 export class MetadataConverter {
   public static readonly PACKAGE_XML_FILE = 'package.xml';
+  public static readonly DESTRUCTIVE_CHANGES_POST_XML_FILE = 'destructiveChangesPost.xml';
   public static readonly DEFAULT_PACKAGE_PREFIX = 'metadataPackage';
 
   private registry: RegistryAccess;
@@ -100,6 +101,16 @@ export class MetadataConverter {
           if (!isSource) {
             const manifestPath = join(packagePath, MetadataConverter.PACKAGE_XML_FILE);
             tasks.push(promises.writeFile(manifestPath, manifestContents));
+
+            // For deploying destructive changes
+            if (cs.hasDeletes) {
+              const destructiveManifestContents = cs.getPackageXml(undefined, true);
+              const destructiveManifestPath = join(
+                packagePath,
+                MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE
+              );
+              tasks.push(promises.writeFile(destructiveManifestPath, destructiveManifestContents));
+            }
           }
           break;
         case 'zip':
@@ -112,6 +123,15 @@ export class MetadataConverter {
           writer = new ZipWriter(packagePath);
           if (!isSource) {
             (writer as ZipWriter).addToZip(manifestContents, MetadataConverter.PACKAGE_XML_FILE);
+
+            // For deploying destructive changes
+            if (cs.hasDeletes) {
+              const destructiveManifestContents = cs.getPackageXml(undefined, true);
+              (writer as ZipWriter).addToZip(
+                destructiveManifestContents,
+                MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE
+              );
+            }
           }
           break;
         case 'merge':

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -11,6 +11,7 @@ import {
   DirectoryConfig,
   ZipConfig,
 } from './types';
+import { DestructiveChangesType } from '../collections/types';
 import { SourceComponent } from '../resolve';
 import { promises } from 'fs';
 import { dirname, join, normalize } from 'path';
@@ -31,6 +32,7 @@ import { RegistryAccess } from '../registry';
 export class MetadataConverter {
   public static readonly PACKAGE_XML_FILE = 'package.xml';
   public static readonly DESTRUCTIVE_CHANGES_POST_XML_FILE = 'destructiveChangesPost.xml';
+  public static readonly DESTRUCTIVE_CHANGES_PRE_XML_FILE = 'destructiveChangesPre.xml';
   public static readonly DEFAULT_PACKAGE_PREFIX = 'metadataPackage';
 
   private registry: RegistryAccess;
@@ -104,11 +106,9 @@ export class MetadataConverter {
 
             // For deploying destructive changes
             if (cs.hasDeletes) {
+              const manifestFileName = this.getDestructiveManifestFileName(cs);
               const destructiveManifestContents = cs.getPackageXml(undefined, true);
-              const destructiveManifestPath = join(
-                packagePath,
-                MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE
-              );
+              const destructiveManifestPath = join(packagePath, manifestFileName);
               tasks.push(promises.writeFile(destructiveManifestPath, destructiveManifestContents));
             }
           }
@@ -126,11 +126,9 @@ export class MetadataConverter {
 
             // For deploying destructive changes
             if (cs.hasDeletes) {
+              const manifestFileName = this.getDestructiveManifestFileName(cs);
               const destructiveManifestContents = cs.getPackageXml(undefined, true);
-              (writer as ZipWriter).addToZip(
-                destructiveManifestContents,
-                MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE
-              );
+              (writer as ZipWriter).addToZip(destructiveManifestContents, manifestFileName);
             }
           }
           break;
@@ -166,6 +164,16 @@ export class MetadataConverter {
     } catch (e) {
       throw new ConversionError(e);
     }
+  }
+
+  private getDestructiveManifestFileName(cs: ComponentSet): string {
+    let manifestFileName: string;
+    if (cs.getDestructiveChangesType() === DestructiveChangesType.POST) {
+      manifestFileName = MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE;
+    } else {
+      manifestFileName = MetadataConverter.DESTRUCTIVE_CHANGES_PRE_XML_FILE;
+    }
+    return manifestFileName;
   }
 
   private getPackagePath(outputConfig: DirectoryConfig | ZipConfig): SourcePath | undefined {

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -35,6 +35,7 @@ export class SourceComponent implements MetadataComponent {
   public content?: string;
   private _tree: TreeContainer;
   private forceIgnore: ForceIgnore;
+  private markedForDelete = false;
 
   constructor(
     props: ComponentProperties,
@@ -115,6 +116,17 @@ export class SourceComponent implements MetadataComponent {
       return join(DEFAULT_PACKAGE_ROOT_SFDX, relativePath);
     }
     return relativePath;
+  }
+
+  /**
+   * @returns whether this component should be part of destructive changes.
+   */
+  public isMarkedForDelete(): boolean {
+    return this.markedForDelete;
+  }
+
+  public setMarkedForDelete(asDeletion: boolean): void {
+    this.markedForDelete = asDeletion;
   }
 
   private parse<T = JsonMap>(contents: string): T {

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -179,6 +179,29 @@ describe('Streams', () => {
       });
     });
 
+    it('should not transform source that is marked for delete', (done) => {
+      const myComp = new SourceComponent({
+        name: component.name,
+        type: component.type,
+        xml: component.xml,
+      });
+      myComp.setMarkedForDelete(true);
+      const converter = new streams.ComponentConverter('source', mockRegistry);
+
+      converter._transform(myComp, '', async (err: Error, data: WriterFormat) => {
+        try {
+          expect(err).to.be.undefined;
+          expect(data).to.deep.equal({
+            component: myComp,
+            writeInfos: [],
+          });
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+
     describe('Transaction Finalizers', () => {
       let converter: streams.ComponentConverter;
 

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -33,6 +33,17 @@ describe('SourceComponent', () => {
     expect(DECOMPOSED_COMPONENT.fullName).to.equal(DECOMPOSED_COMPONENT.name);
   });
 
+  it('should return correct markedForDelete status', () => {
+    expect(COMPONENT.isMarkedForDelete()).to.be.false;
+    try {
+      COMPONENT.setMarkedForDelete(true);
+      expect(COMPONENT.isMarkedForDelete()).to.be.true;
+    } finally {
+      COMPONENT.setMarkedForDelete(false);
+      expect(COMPONENT.isMarkedForDelete()).to.be.false;
+    }
+  });
+
   describe('parseXml', () => {
     afterEach(() => env.restore());
 


### PR DESCRIPTION
What does this PR do?
Adds support to the library for building ComponentSets that contain components marked for delete. Deploying these ComponentSets will build a destructive changes manifest so they are deleted in the org. If any components not marked for delete are included they are deployed as well.

What issues does this PR fix or reference?
@W-9478450@

Functionality Before
unsupported

Functionality After
ComponentSets can be created with a set of components marked for delete, or a mix of regular components and components to be deleted. This ComponentSet can then be deployed as usual and metadata can be deleted.

```javascript
ComponentSet.fromSource({
  fsPaths: [path/to/changed/files],
  fsDeletedPaths: [path/to/deleted/files]
}).deploy();

const components = MetadataResolver.getComponentsFromPath('path/to/deleted/file');
const asDelete = true;
ComponentSet.add(components[0], asDelete);
```