### PR TITLE
chore: add InboundCertificate to metadata registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1831,6 +1831,17 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "inboundcertificate": {
+      "id": "inboundcertificate",
+      "name": "InboundCertificate",
+      "suffix": "inboundCertificate",
+      "directoryName": "inboundCertificates",
+      "inFolder": false,
+      "strictDirectoryName": false,
+      "strategies": {
+        "adapter": "matchingContentFile"
+      }
+    },
     "mutingpermissionset": {
       "id": "mutingpermissionset",
       "name": "MutingPermissionSet",
@@ -2534,6 +2545,7 @@
     "emailFolder": "emailfolder",
     "inboundNetworkConnection": "inboundnetworkconnection",
     "outboundNetworkConnection": "outboundnetworkconnection",
+    "inboundCertificate": "inboundcertificate",
     "mutingpermissionset": "mutingpermissionset",
     "myDomainDiscoverableLogin": "mydomaindiscoverablelogin",
     "blacklistedConsumer": "blacklistedconsumer",


### PR DESCRIPTION
### What does this PR do?
Add support for [InboundCertificate](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_inboundcertificate.htm) metadata type.

### What issues does this PR fix or reference?

Fixes: https://github.com/forcedotcom/cli/issues/995
@W-9190729@

### Functionality Before
`InboundCertificate` wasn't able to be deployed/retrieved.

### Functionality After
You can deploy/retrieve an inbound cert:
`sfdx force:source:retrieve -m InboundCertificate`
