### PR TITLE
fix: write children to manifest

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -268,6 +268,14 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     }
 
     const typeMap = new Map<string, string[]>();
+
+    const addToTypeMap = (typeName: string, fullName: string): void => {
+      if (!typeMap.has(typeName)) {
+        typeMap.set(typeName, []);
+      }
+      typeMap.get(typeName).push(fullName);
+    };
+
     for (const key of components.keys()) {
       const [typeId, fullName] = key.split(ComponentSet.KEY_DELIMITER);
       let type = this.registry.getTypeByName(typeId);
@@ -275,12 +283,15 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       if (type.folderContentType) {
         type = this.registry.getTypeByName(type.folderContentType);
       }
+      addToTypeMap(type.name, fullName);
 
-      if (!typeMap.has(type.name)) {
-        typeMap.set(type.name, []);
+      // Add children
+      const componentMap = components.get(key);
+      for (const comp of componentMap.values()) {
+        for (const child of comp.getChildren()) {
+          addToTypeMap(child.type.name, child.fullName);
+        }
       }
-
-      typeMap.get(type.name).push(fullName);
     }
 
     const typeMembers: PackageTypeMembers[] = [];

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -305,6 +305,10 @@ describe('ComponentSet', () => {
               members: ['a'],
             },
             {
+              name: 'G',
+              members: ['a.child1', 'a.child2'],
+            },
+            {
               name: 'MixedContentSingleFile',
               members: ['b', 'c'],
             },
@@ -328,6 +332,10 @@ describe('ComponentSet', () => {
             {
               name: 'DecomposedTopLevel',
               members: ['a'],
+            },
+            {
+              name: 'G',
+              members: ['a.child1', 'a.child2'],
             },
             {
               name: 'MixedContentSingleFile',
@@ -355,6 +363,10 @@ describe('ComponentSet', () => {
               members: ['a'],
             },
             {
+              name: 'G',
+              members: ['a.child1', 'a.child2'],
+            },
+            {
               name: 'MixedContentSingleFile',
               members: ['b', 'c'],
             },
@@ -378,6 +390,10 @@ describe('ComponentSet', () => {
             {
               name: 'DecomposedTopLevel',
               members: ['a'],
+            },
+            {
+              name: 'G',
+              members: ['a.child1', 'a.child2'],
             },
             {
               name: 'MixedContentSingleFile',

--- a/test/mock/registry/manifestConstants.ts
+++ b/test/mock/registry/manifestConstants.ts
@@ -21,6 +21,11 @@ export const BASIC: VirtualFile = {
         <name>${decomposedtoplevel.name}</name>
     </types>
     <types>
+        <members>a.child1</members>
+        <members>a.child2</members>
+        <name>G</name>
+    </types>
+    <types>
         <members>b</members>
         <members>c</members>
         <name>${mixedcontentsinglefile.name}</name>

--- a/test/resolve/manifestResolver.test.ts
+++ b/test/resolve/manifestResolver.test.ts
@@ -48,6 +48,14 @@ describe('ManifestResolver', () => {
           type: mockRegistryData.types.decomposedtoplevel,
         },
         {
+          fullName: 'a.child1',
+          type: mockRegistryData.types.decomposedtoplevel.children.types.g,
+        },
+        {
+          fullName: 'a.child2',
+          type: mockRegistryData.types.decomposedtoplevel.children.types.g,
+        },
+        {
           fullName: 'b',
           type: mockRegistryData.types.mixedcontentsinglefile,
         },


### PR DESCRIPTION
### What does this PR do?
Children were not being written to the manifest during package creation, which wasn't an issue when
deploying to non-packaging orgs, but failed to deploy to packaging orgs.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1115
@W-9762933@

### Functionality Before
Deploy failure

### Functionality After
Deploy success
