### PR TITLE
Wr/aura under object main

### DIFF
--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -51,8 +51,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     mergeWith?: SourceComponent
   ): Promise<WriteInfo[]> {
     const writeInfos: WriteInfo[] = [];
-    const childrenOfMergeComponent =
-      mergeWith && component.ensureValidChildren(new ComponentSet([mergeWith]));
+    const childrenOfMergeComponent = mergeWith && mergeWith.ensureValidChildren();
     const { type, fullName: parentFullName } = component;
 
     let parentXmlObject: JsonMap;
@@ -143,27 +142,6 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
 
     return writeInfos;
   }
-
-  // // Ensures that the children of the provided SourceComponent are valid child
-  // // types before adding them to the returned ComponentSet. Invalid child types
-  // // can occur when projects are structured in an atypical way such as having
-  // // ApexClasses or Layouts within a CustomObject folder.
-  // private ensureValidChildren(component: SourceComponent, compSet?: ComponentSet): ComponentSet {
-  //   compSet = compSet || new ComponentSet([], this.registry);
-  //   const validChildTypes = Object.keys(component.type.children.types);
-  //   for (const child of component.getChildren()) {
-  //     // Ensure only valid child types are included with the parent.
-  //     if (!validChildTypes.includes(child.type?.id)) {
-  //       const filePath = child.xml || child.content;
-  //       throw new TypeInferenceError('error_unexpected_child_type', [
-  //         filePath,
-  //         component.type.name,
-  //       ]);
-  //     }
-  //     compSet.add(child);
-  //   }
-  //   return compSet;
-  // }
 
   private async getComposedMetadataEntries(component: SourceComponent): Promise<[string, any][]> {
     const composedMetadata = (await component.parseXml())[component.type.name];

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -51,7 +51,8 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     mergeWith?: SourceComponent
   ): Promise<WriteInfo[]> {
     const writeInfos: WriteInfo[] = [];
-    const childrenOfMergeComponent = mergeWith && mergeWith.ensureValidChildren();
+    const childrenOfMergeComponent =
+      mergeWith && mergeWith.ensureValidChildren(new ComponentSet([]), this.registry);
     const { type, fullName: parentFullName } = component;
 
     let parentXmlObject: JsonMap;

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -36,10 +36,12 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
         if (!state[fullName]) {
           state[fullName] = { component, children: new ComponentSet([], this.registry) };
         }
-        state[fullName].children = component.ensureValidChildren(
-          state[fullName].children,
-          this.registry
-        );
+        const children = component.getChildren();
+        if (children) {
+          children.map((child) => {
+            state[fullName].children.add(child);
+          });
+        }
       });
     }
     // noop since the finalizer will push the writes to the component writer
@@ -51,8 +53,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     mergeWith?: SourceComponent
   ): Promise<WriteInfo[]> {
     const writeInfos: WriteInfo[] = [];
-    const childrenOfMergeComponent =
-      mergeWith && mergeWith.ensureValidChildren(new ComponentSet([]), this.registry);
+    const childrenOfMergeComponent = new ComponentSet(mergeWith?.getChildren());
     const { type, fullName: parentFullName } = component;
 
     let parentXmlObject: JsonMap;

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -90,9 +90,6 @@ export class MetadataResolver {
       } else if (this.isMetadata(fsPath)) {
         const component = this.resolveComponent(fsPath, false);
         if (component) {
-          if (component.type?.children) {
-            component.ensureValidChildren();
-          }
           if (!inclusiveFilter || inclusiveFilter.has(component)) {
             components.push(component);
             ignore.add(component.content);

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -90,6 +90,7 @@ export class MetadataResolver {
       } else if (this.isMetadata(fsPath)) {
         const component = this.resolveComponent(fsPath, false);
         if (component) {
+          component.ensureValidChildren(inclusiveFilter, this.registry);
           if (!inclusiveFilter || inclusiveFilter.has(component)) {
             components.push(component);
             ignore.add(component.content);

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -95,6 +95,7 @@ export class MetadataResolver {
             ignore.add(component.content);
           } else {
             for (const child of component.getChildren()) {
+              component.ensureValidChildren(new ComponentSet([]), this.registry);
               if (inclusiveFilter.has(child)) {
                 components.push(child);
               }

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -90,7 +90,9 @@ export class MetadataResolver {
       } else if (this.isMetadata(fsPath)) {
         const component = this.resolveComponent(fsPath, false);
         if (component) {
-          component.ensureValidChildren(inclusiveFilter, this.registry);
+          if (component.type?.children) {
+            component.ensureValidChildren();
+          }
           if (!inclusiveFilter || inclusiveFilter.has(component)) {
             components.push(component);
             ignore.add(component.content);

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -95,7 +95,6 @@ export class MetadataResolver {
             ignore.add(component.content);
           } else {
             for (const child of component.getChildren()) {
-              component.ensureValidChildren(new ComponentSet([]), this.registry);
               if (inclusiveFilter.has(child)) {
                 components.push(child);
               }

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -93,16 +93,21 @@ export class SourceComponent implements MetadataComponent {
     }
     return {} as T;
   }
-  // Ensures that the children of the provided SourceComponent are valid child
-  // types before adding them to the returned ComponentSet. Invalid child types
-  // can occur when projects are structured in an atypical way such as having
-  // ApexClasses or Layouts within a CustomObject folder.
+
+  /**
+   * Ensures that the children of the provided SourceComponent are valid child
+   * types before adding them to the returned ComponentSet. Invalid child types
+   * can occur when projects are structured in an atypical way such as having
+   * ApexClasses or Layouts within a CustomObject folder.
+   * @param compSet a component set to add children to
+   * @param registry the metadata registry access
+   */
   public ensureValidChildren(
     compSet?: ComponentSet,
     registry: RegistryAccess = new RegistryAccess()
   ): ComponentSet {
     compSet = compSet || new ComponentSet([], registry);
-    const validChildTypes = this.type.children ? Object.keys(this.type.children?.types) : [];
+    const validChildTypes = this.type?.children ? Object.keys(this.type?.children?.types) : [];
     for (const child of this.getChildren()) {
       // Ensure only valid child types are included with the parent.
       if (!validChildTypes.includes(child.type?.id)) {

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -9,13 +9,11 @@ import { parse } from 'fast-xml-parser';
 import { ForceIgnore } from './forceIgnore';
 import { NodeFSTreeContainer, TreeContainer, VirtualTreeContainer } from './treeContainers';
 import { MetadataComponent, VirtualDirectory } from './types';
-import { baseName, normalizeToArray, parseMetadataXml } from '../utils';
+import { baseName, normalizeToArray, parseMetadataXml, trimUntil } from '../utils';
 import { DEFAULT_PACKAGE_ROOT_SFDX } from '../common';
 import { get, getString, JsonMap } from '@salesforce/ts-types';
 import { SfdxFileFormat } from '../convert';
-import { trimUntil } from '../utils/path';
-import { MetadataType, RegistryAccess } from '../registry';
-import { ComponentSet } from '../collections';
+import { MetadataType } from '../registry';
 import { TypeInferenceError } from '../errors';
 
 export type ComponentProperties = {
@@ -77,8 +75,10 @@ export class SourceComponent implements MetadataComponent {
     return sources;
   }
   /**
-   * Ensures that the children of SourceComponent are valid child
-   * types. Invalid child types can occur when projects are structured in an atypical way such as having
+   * returns the children of a parent SourceComponent
+   *
+   * Ensures that the children of SourceComponent are valid child types.
+   * Invalid child types can occur when projects are structured in an atypical way such as having
    * ApexClasses or Layouts within a CustomObject folder.
    *
    * @return SourceComponent[] containing valid children

--- a/test/resolve/adapters/decomposedSourceAdapter.ts
+++ b/test/resolve/adapters/decomposedSourceAdapter.ts
@@ -126,41 +126,4 @@ describe('DecomposedSourceAdapter', () => {
     const adapter = new DefaultSourceAdapter(type, mockRegistry);
     expect(adapter.getComponent(path)).to.be.undefined;
   });
-
-  it('should throw an Error when unexpected child type found in parent folder', () => {
-    // This is most likely an odd project structure such as metadata found within a CustomObject
-    // folder that is not a child type of CustomObject. E.g., Layout, SharingRules, ApexClass.
-    // This test adds an ApexClass to the equivalent of here:
-    // .../main/default/objects/MyObject/classes/MyApexClass.cls-meta.xml
-    // The actual ApexClass file path for the test is:
-    // path/to/decomposeds/a/classes/a.mcf-meta.xml
-    const { CONTENT_NAMES, XML_NAMES } = matchingContentFile;
-    const fsUnexpectedChild = [
-      {
-        dirPath: decomposed.DECOMPOSED_PATH,
-        children: [
-          decomposed.DECOMPOSED_CHILD_XML_NAME_1,
-          decomposed.DECOMPOSED_CHILD_DIR,
-          'classes',
-        ],
-      },
-      {
-        dirPath: decomposed.DECOMPOSED_CHILD_DIR_PATH,
-        children: [decomposed.DECOMPOSED_CHILD_XML_NAME_2],
-      },
-      {
-        dirPath: join(decomposed.DECOMPOSED_PATH, 'classes'),
-        children: [CONTENT_NAMES[0], XML_NAMES[0]],
-      },
-    ];
-    const tree = new VirtualTreeContainer(fsUnexpectedChild);
-    const adapter = new DecomposedSourceAdapter(type, mockRegistry, undefined, tree);
-    const fsPath = join(decomposed.DECOMPOSED_PATH, 'classes', XML_NAMES[0]);
-
-    assert.throws(
-      () => adapter.getComponent(fsPath, false),
-      TypeInferenceError,
-      nls.localize('error_unexpected_child_type', [fsPath, type.name])
-    );
-  });
 });

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { SourceComponent } from '../../src/resolve';
+import { SourceComponent, VirtualTreeContainer } from '../../src/resolve';
 import { RegistryTestUtil } from './registryTestUtil';
 import {
   xmlInFolder,
@@ -12,8 +12,9 @@ import {
   mixedContentDirectory,
   matchingContentFile,
   mockRegistryData,
+  mockRegistry,
 } from '../mock/registry';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { DECOMPOSED_COMPONENT } from '../mock/registry/type-constants/decomposedConstants';
 import { COMPONENT } from '../mock/registry/type-constants/matchingContentFileConstants';
 import {
@@ -25,6 +26,10 @@ import {
   MATCHING_RULES_COMPONENT,
 } from '../mock/registry/type-constants/nonDecomposedConstants';
 import { createSandbox } from 'sinon';
+import { join } from 'path';
+import { DecomposedSourceAdapter } from '../../src/resolve/adapters';
+import { TypeInferenceError } from '../../src/errors';
+import { nls } from '../../src/i18n';
 
 const env = createSandbox();
 
@@ -219,6 +224,43 @@ describe('SourceComponent', () => {
         []
       );
       expect(noXml.getChildren()).to.be.empty;
+    });
+
+    it('should throw an Error when unexpected child type found in parent folder - regardless of metadata type category', () => {
+      // This is most likely an odd project structure such as metadata found within a CustomObject
+      // folder that is not a child type of CustomObject. E.g., Layout, SharingRules, ApexClass.
+      // This test adds an ApexClass to the equivalent of here:
+      // .../main/default/objects/MyObject/classes/MyApexClass.cls-meta.xml
+      // The actual ApexClass file path for the test is:
+      // path/to/decomposeds/a/classes/a.mcf-meta.xml
+      const { CONTENT_NAMES, XML_NAMES } = matchingContentFile;
+      const fsUnexpectedChild = [
+        {
+          dirPath: decomposed.DECOMPOSED_PATH,
+          children: [
+            decomposed.DECOMPOSED_CHILD_XML_NAME_1,
+            decomposed.DECOMPOSED_CHILD_DIR,
+            'classes',
+          ],
+        },
+        {
+          dirPath: decomposed.DECOMPOSED_CHILD_DIR_PATH,
+          children: [decomposed.DECOMPOSED_CHILD_XML_NAME_2],
+        },
+        {
+          dirPath: join(decomposed.DECOMPOSED_PATH, 'classes'),
+          children: [CONTENT_NAMES[0], XML_NAMES[0]],
+        },
+      ];
+      const tree = new VirtualTreeContainer(fsUnexpectedChild);
+      const adapter = new DecomposedSourceAdapter(type, mockRegistry, undefined, tree);
+      const fsPath = join(decomposed.DECOMPOSED_PATH, 'classes', XML_NAMES[0]);
+
+      assert.throws(
+        () => adapter.getComponent(fsPath, false),
+        TypeInferenceError,
+        nls.localize('error_unexpected_child_type', [fsPath, type.name])
+      );
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
When an Aura's `.cmp-meta.xml` file was under a custom object it would throw a `Cannot read property 'id' of undefined` error. handle it by refactoring the `ensureValidChildren` method to the `SourceComponent` class and call in that scenario
### What issues does this PR fix or reference?

#https://github.com/forcedotcom/cli/issues/1148, @W-9800691@

### Functionality Before
`Cannot read property 'id' of undefined` 


### Functionality After

`Unexpected child metadata [/Users/william.ruemmele/projects/scratches/dreamhouse-lwc/force-app/main/default/objects/Broker__c/pageTemplate_2_7_3.cmp-meta.xml] found for parent type [CustomObject]`
