### PR TITLE
Sh/exclude custom field translations

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -289,7 +289,9 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       const componentMap = components.get(key);
       for (const comp of componentMap.values()) {
         for (const child of comp.getChildren()) {
-          addToTypeMap(child.type.name, child.fullName);
+          if (child.isAddressable) {
+            addToTypeMap(child.type.name, child.fullName);
+          }
         }
       }
     }

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -283,7 +283,9 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       if (type.folderContentType) {
         type = this.registry.getTypeByName(type.folderContentType);
       }
-      addToTypeMap(type.name, fullName);
+      if (type.isAddressable !== false) {
+        addToTypeMap(type.name, fullName);
+      }
 
       // Add children
       const componentMap = components.get(key);

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -775,7 +775,8 @@
             "id": "customfieldtranslation",
             "name": "CustomFieldTranslation",
             "directoryName": "fields",
-            "suffix": "fieldTranslation"
+            "suffix": "fieldTranslation",
+            "isAddressable": false
           }
         },
         "suffixes": {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -84,6 +84,10 @@ export interface MetadataType {
    */
   uniqueIdElement?: string;
   /**
+   * Whether the component is supported by the Metadata API and therefore should be included within a manifest.
+   */
+  isAddressable?: boolean;
+  /**
    * Type definitions for child types, if the type has any.
    *
    * __Examples:__ `CustomField` and `CompactLayout` on `CustomObject`

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -242,4 +242,18 @@ export class SourceComponent implements MetadataComponent {
   get tree(): TreeContainer {
     return this._tree;
   }
+
+  /**
+   * Returns whether this component type is supported by the Metadata API
+   * and therefore should have an entry added to the manifest.
+   *
+   * This is defined on the type in the registry. The type is required to
+   * be in the registry for proper classification and for possible use in
+   * decomposition/recomposition.
+   *
+   * E.g., CustomFieldTranslation.
+   */
+  get isAddressable(): boolean {
+    return this.type.isAddressable;
+  }
 }

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -251,9 +251,12 @@ export class SourceComponent implements MetadataComponent {
    * be in the registry for proper classification and for possible use in
    * decomposition/recomposition.
    *
+   * Default value is true, so the only way to return false is to explicitly
+   * set it in the registry as false.
+   *
    * E.g., CustomFieldTranslation.
    */
   get isAddressable(): boolean {
-    return this.type.isAddressable;
+    return this.type.isAddressable !== false;
   }
 }

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -25,12 +25,29 @@ import {
   MATCHING_RULES_COMPONENT,
 } from '../mock/registry/type-constants/nonDecomposedConstants';
 import { createSandbox } from 'sinon';
+import { MetadataType } from '../../src';
 
 const env = createSandbox();
 
 describe('SourceComponent', () => {
   it('should return correct fullName for components without a parent', () => {
     expect(DECOMPOSED_COMPONENT.fullName).to.equal(DECOMPOSED_COMPONENT.name);
+  });
+
+  it('should return whether the type is addressable', () => {
+    const type: MetadataType = {
+      id: 'customfieldtranslation',
+      name: 'CustomFieldTranslation',
+      directoryName: 'fields',
+      suffix: 'fieldTranslation',
+    };
+    expect(new SourceComponent({ name: type.name, type }).isAddressable).to.equal(true);
+    type.isAddressable = false;
+    expect(new SourceComponent({ name: type.name, type }).isAddressable).to.equal(false);
+    type.isAddressable = true;
+    expect(new SourceComponent({ name: type.name, type }).isAddressable).to.equal(true);
+    type.isAddressable = undefined;
+    expect(new SourceComponent({ name: type.name, type }).isAddressable).to.equal(true);
   });
 
   it('should return correct markedForDelete status', () => {


### PR DESCRIPTION
### What does this PR do?
Adds the ability to prevent metadata type entries from being written to the manifest.  These are special cases where the type must be defined in the registry so it can be identified and possibly decomposed/recomposed, but they are not supported by the Metadata API.

Example type: CustomFieldTranslation

### What issues does this PR fix or reference?
@W-9831738@

### Functionality Before
The type entry was added to the manifest and the deploy or retrieve request would fail with an error like this:
`Unknown type name 'CustomFieldTranslation' specified in package.xml`

### Functionality After
Successful deploy/retrieve because the type is not added to the manifest.
