### PR TITLE
fix: force RestrictionRule to a strict directory

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -2069,7 +2069,7 @@
       "name": "RestrictionRule",
       "suffix": "rule",
       "directoryName": "restrictionRules",
-      "strictDirectoryName": false
+      "strictDirectoryName": true
     },
     "functionreference": {
       "id": "functionreference",
@@ -2579,7 +2579,8 @@
     "bots": "bot",
     "objectTranslations": "customobjecttranslation",
     "staticresources": "staticresource",
-    "sites": "customsite"
+    "sites": "customsite",
+    "restrictionRules": "restrictionrule"
   },
   "childTypes": {
     "customlabel": "customlabels",


### PR DESCRIPTION
### What does this PR do?
Updates the registry to define a strictDirectoryName for the RestrictionRule type since the suffix ("rule") is also used by the ModerationRule type.

### What issues does this PR fix or reference?
 https://github.com/forcedotcom/cli/issues/1158
@W-9833678@

### Functionality Before
Source is converted to metadata API format with a moderation folder instead of restrictionRules. The package.xml file also defines the metadata type as ModerationRule instead of RestrictionRule.

### Functionality After
Source is converted to metadata API format with a restrictionRules folder and the package.xml should reference the RestrictionRule metadata type.
