### PR TITLE
fix: fix node 16 error parsing issue

### DIFF
--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -141,15 +141,15 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
   }
 
   private async getContentType(component: SourceComponent): Promise<string> {
-    try {
-      return ((await component.parseXml()).StaticResource as JsonMap).contentType as string;
-    } catch (e) {
-      if ((e as Error).message.includes("Cannot read property 'contentType' of undefined")) {
-        throw new LibraryError('error_static_resource_missing_resource_file', [
-          join('staticresources', component.name),
-        ]);
-      }
+    const resource = (await component.parseXml()).StaticResource as JsonMap;
+
+    if (!resource || !resource.hasOwnProperty('contentType')) {
+      throw new LibraryError('error_static_resource_missing_resource_file', [
+        join('staticresources', component.name),
+      ]);
     }
+
+    return resource.contentType as string;
   }
 
   private getExtensionFromType(contentType: string): string {


### PR DESCRIPTION
### What does this PR do?
fixes an Error message parsing issue with differences between `node 14` and `node 16`

### What issues does this PR fix or reference?

### Functionality Before
`Cannot read properties of undefined (reading 'contentType')`

### Functionality After
`A StaticResource must have an associated .resource file, missing staticresources/a.resource-meta.xml`
