### PR TITLE
fix: fix functions to function suffix

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -2378,7 +2378,7 @@
     "businessProcessGroup": "businessprocessgroup",
     "model": "discoveryaimodel",
     "goal": "discoverygoal",
-    "functions": "functionreference",
+    "function": "functionreference",
     "participantRole": "participantrole",
     "gatewayProviderPaymentMethodType": "gatewayproviderpaymentmethodtype",
     "careProviderSearchConfig": "careprovidersearchconfig",


### PR DESCRIPTION
### What does this PR do?
fixes the `FunctionsReference` type suffix it should be singular `function` but it was `functions` in the suffix object
### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
would resolve `FunctionReference` to `EmailServicesFunctions`
<insert gif and/or summary>

### Functionality After
will properly deploy a `FunctionReference`
<insert gif and/or summary>
