### PR TITLE
Wr/destructive changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -35,9 +35,11 @@ export interface FromSourceOptions extends OptionalTreeRegistryOptions {
    * Only resolve components contained in the given set
    */
   include?: ComponentSet;
+  // TODO: decide if there's a non-breaking change possible here
   /**
    * File paths or directory paths of deleted components, i.e., destructive changes.
    */
+  fsDeletePathsPre?: string[];
   fsDeletePaths?: string[];
 }
 
@@ -62,4 +64,7 @@ export interface FromManifestOptions extends OptionalTreeRegistryOptions {
    * conditions.
    */
   forceAddWildcards?: boolean;
+
+  destructivePre?: string;
+  destructivePost?: string;
 }

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -35,11 +35,9 @@ export interface FromSourceOptions extends OptionalTreeRegistryOptions {
    * Only resolve components contained in the given set
    */
   include?: ComponentSet;
-  // TODO: decide if there's a non-breaking change possible here
   /**
    * File paths or directory paths of deleted components, i.e., destructive changes.
    */
-  fsDeletePathsPre?: string[];
   fsDeletePaths?: string[];
 }
 
@@ -65,6 +63,12 @@ export interface FromManifestOptions extends OptionalTreeRegistryOptions {
    */
   forceAddWildcards?: boolean;
 
+  /**
+   * path to a `destructiveChangesPre.xml` file in XML format
+   */
   destructivePre?: string;
+  /**
+   * path to a `destructiveChangesPost.xml` file in XML format
+   */
   destructivePost?: string;
 }

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -103,11 +103,10 @@ export class MetadataConverter {
           if (!isSource) {
             const manifestPath = join(packagePath, MetadataConverter.PACKAGE_XML_FILE);
             tasks.push(promises.writeFile(manifestPath, manifestContents));
-
             // For deploying destructive changes
             if (cs.hasDeletes) {
-              const destructiveChangesTypes = cs.getDestructiveChangesTypes();
-              destructiveChangesTypes.map((destructiveChangesType: DestructiveChangesType) => {
+              const destructiveChangesTypes = cs.getIncludedDestructiveChanges();
+              destructiveChangesTypes.map((destructiveChangesType) => {
                 const file = this.convertTypeToManifest(destructiveChangesType);
                 const destructiveManifestContents = cs.getPackageXml(
                   undefined,
@@ -132,13 +131,10 @@ export class MetadataConverter {
           writer = new ZipWriter(packagePath);
           if (!isSource) {
             (writer as ZipWriter).addToZip(manifestContents, MetadataConverter.PACKAGE_XML_FILE);
-
             // For deploying destructive changes
             if (cs.hasDeletes) {
-              const destructiveChangesTypes = cs.getDestructiveChangesTypes();
-              console.log('change types', destructiveChangesTypes);
+              const destructiveChangesTypes = cs.getIncludedDestructiveChanges();
               destructiveChangesTypes.map((destructiveChangeType) => {
-                console.log('type', destructiveChangeType);
                 const file = this.convertTypeToManifest(destructiveChangeType);
                 const destructiveManifestContents = cs.getPackageXml(
                   undefined,
@@ -185,16 +181,6 @@ export class MetadataConverter {
     }
   }
 
-  // private getDestructiveManifestFileName(cs: ComponentSet): string[] {
-  //   let manifestFileName: string;
-  //   if (cs.getDestructiveChangesType() === DestructiveChangesType.POST) {
-  //     manifestFileName = MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE;
-  //   } else {
-  //     manifestFileName = MetadataConverter.DESTRUCTIVE_CHANGES_PRE_XML_FILE;
-  //   }
-  //   return manifestFileName;
-  // }
-
   private getPackagePath(outputConfig: DirectoryConfig | ZipConfig): SourcePath | undefined {
     let packagePath: SourcePath;
     const { genUniqueDir = true, outputDirectory, packageName, type } = outputConfig;
@@ -224,9 +210,10 @@ export class MetadataConverter {
 
   private convertTypeToManifest(manifestFileName: DestructiveChangesType): string {
     if (manifestFileName === DestructiveChangesType.POST) {
-      console.log(manifestFileName);
       return MetadataConverter.DESTRUCTIVE_CHANGES_POST_XML_FILE;
+    } else if (manifestFileName === DestructiveChangesType.PRE) {
+      return MetadataConverter.DESTRUCTIVE_CHANGES_PRE_XML_FILE;
     }
-    return MetadataConverter.DESTRUCTIVE_CHANGES_PRE_XML_FILE;
+    return MetadataConverter.PACKAGE_XML_FILE;
   }
 }

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -109,11 +109,7 @@ export class MetadataConverter {
               const destructiveChangesTypes = cs.getTypesOfDestructiveChanges();
               destructiveChangesTypes.map((destructiveChangesType) => {
                 const file = this.convertTypeToManifest(destructiveChangesType);
-                const destructiveManifestContents = cs.getPackageXml(
-                  4,
-                  true,
-                  destructiveChangesType
-                );
+                const destructiveManifestContents = cs.getPackageXml(4, destructiveChangesType);
                 const destructiveManifestPath = join(packagePath, file);
                 tasks.push(
                   promises.writeFile(destructiveManifestPath, destructiveManifestContents)
@@ -139,11 +135,7 @@ export class MetadataConverter {
               // to each manifest
               destructiveChangesTypes.map((destructiveChangeType) => {
                 const file = this.convertTypeToManifest(destructiveChangeType);
-                const destructiveManifestContents = cs.getPackageXml(
-                  4,
-                  true,
-                  destructiveChangeType
-                );
+                const destructiveManifestContents = cs.getPackageXml(4, destructiveChangeType);
                 (writer as ZipWriter).addToZip(destructiveManifestContents, file);
               });
             }

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -11,7 +11,6 @@ import {
   SfdxFileFormat,
   ZipConfig,
 } from './types';
-import { DestructiveChangesType } from '../collections/types';
 import { SourceComponent } from '../resolve';
 import { promises } from 'fs';
 import { dirname, join, normalize } from 'path';
@@ -26,7 +25,7 @@ import {
 } from './streams';
 import { ConversionError, LibraryError } from '../errors';
 import { SourcePath } from '../common';
-import { ComponentSet } from '../collections';
+import { ComponentSet, DestructiveChangesType } from '../collections';
 import { RegistryAccess } from '../registry';
 
 export class MetadataConverter {
@@ -105,11 +104,13 @@ export class MetadataConverter {
             tasks.push(promises.writeFile(manifestPath, manifestContents));
             // For deploying destructive changes
             if (cs.hasDeletes) {
-              const destructiveChangesTypes = cs.getIncludedDestructiveChanges();
+              // for each of the destructive changes in the component set, convert and write the correct metadata
+              // to each manifest
+              const destructiveChangesTypes = cs.getTypesOfDestructiveChanges();
               destructiveChangesTypes.map((destructiveChangesType) => {
                 const file = this.convertTypeToManifest(destructiveChangesType);
                 const destructiveManifestContents = cs.getPackageXml(
-                  undefined,
+                  4,
                   true,
                   destructiveChangesType
                 );
@@ -133,11 +134,13 @@ export class MetadataConverter {
             (writer as ZipWriter).addToZip(manifestContents, MetadataConverter.PACKAGE_XML_FILE);
             // For deploying destructive changes
             if (cs.hasDeletes) {
-              const destructiveChangesTypes = cs.getIncludedDestructiveChanges();
+              const destructiveChangesTypes = cs.getTypesOfDestructiveChanges();
+              // for each of the destructive changes in the component set, convert and write the correct metadata
+              // to each manifest
               destructiveChangesTypes.map((destructiveChangeType) => {
                 const file = this.convertTypeToManifest(destructiveChangeType);
                 const destructiveManifestContents = cs.getPackageXml(
-                  undefined,
+                  4,
                   true,
                   destructiveChangeType
                 );

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { join, basename, sep } from 'path';
+import { basename, join, sep } from 'path';
 import { parse } from 'fast-xml-parser';
 import { ForceIgnore } from './forceIgnore';
 import { NodeFSTreeContainer, TreeContainer, VirtualTreeContainer } from './treeContainers';
@@ -15,6 +15,7 @@ import { get, getString, JsonMap } from '@salesforce/ts-types';
 import { SfdxFileFormat } from '../convert';
 import { MetadataType } from '../registry';
 import { TypeInferenceError } from '../errors';
+import { DestructiveChangesType } from '../collections';
 
 export type ComponentProperties = {
   name: string;
@@ -38,6 +39,7 @@ export class SourceComponent implements MetadataComponent {
   private _tree: TreeContainer;
   private forceIgnore: ForceIgnore;
   private markedForDelete = false;
+  private destructiveChangesType: DestructiveChangesType;
 
   constructor(
     props: ComponentProperties,
@@ -131,8 +133,16 @@ export class SourceComponent implements MetadataComponent {
     return this.markedForDelete;
   }
 
-  public setMarkedForDelete(asDeletion: boolean): void {
+  public getDestructiveChangesType(): DestructiveChangesType {
+    return this.destructiveChangesType;
+  }
+
+  public setMarkedForDelete(
+    asDeletion: boolean,
+    destructiveChangeType = DestructiveChangesType.POST
+  ): void {
     this.markedForDelete = asDeletion;
+    this.destructiveChangesType = destructiveChangeType;
   }
 
   private calculateRelativePath(fsPath: string): string {

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -137,12 +137,19 @@ export class SourceComponent implements MetadataComponent {
     return this.destructiveChangesType;
   }
 
-  public setMarkedForDelete(
-    asDeletion: boolean,
-    destructiveChangeType = DestructiveChangesType.POST
-  ): void {
-    this.markedForDelete = asDeletion;
-    this.destructiveChangesType = destructiveChangeType;
+  public setMarkedForDelete(destructiveChangeType?: DestructiveChangesType | boolean): void {
+    if (
+      destructiveChangeType === DestructiveChangesType.PRE ||
+      destructiveChangeType === DestructiveChangesType.POST ||
+      destructiveChangeType === true ||
+      destructiveChangeType === undefined
+    ) {
+      this.markedForDelete = true;
+      this.destructiveChangesType =
+        (destructiveChangeType as DestructiveChangesType) || DestructiveChangesType.POST;
+    } else {
+      this.markedForDelete = false;
+    }
   }
 
   private calculateRelativePath(fsPath: string): string {

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -11,23 +11,26 @@ import { join } from 'path';
 import { createSandbox, SinonStub } from 'sinon';
 import {
   ComponentSet,
+  DestructiveChangesType,
+  ManifestResolver,
   MetadataApiDeploy,
   MetadataApiRetrieve,
   MetadataComponent,
+  MetadataMember,
   MetadataResolver,
   MetadataType,
   RegistryAccess,
+  SourceComponent,
 } from '../../src';
 import { ComponentSetError } from '../../src/errors';
 import { nls } from '../../src/i18n';
-import { ManifestResolver, MetadataMember, SourceComponent } from '../../src/resolve';
 import { mockConnection } from '../mock/client';
 import {
-  mockRegistry,
-  mockRegistryData,
-  mixedContentSingleFile,
   decomposedtoplevel,
   matchingContentFile,
+  mixedContentSingleFile,
+  mockRegistry,
+  mockRegistryData,
 } from '../mock/registry';
 import { MATCHING_RULES_COMPONENT } from '../mock/registry/type-constants/nonDecomposedConstants';
 import * as manifestFiles from '../mock/registry/manifestConstants';
@@ -108,7 +111,7 @@ describe('ComponentSet', () => {
         const mdResolver = new MetadataResolver(mockRegistry, manifestFiles.TREE);
         const expected = mdResolver.getComponentsFromPath('mixedSingleFiles');
         mdResolver.getComponentsFromPath('decomposedTopLevels').forEach((comp) => {
-          comp.setMarkedForDelete(true);
+          comp.setMarkedForDelete();
           expected.push(comp);
         });
 
@@ -327,7 +330,7 @@ describe('ComponentSet', () => {
         tree: manifestFiles.TREE,
         fsDeletePaths: ['.'],
       });
-      expect(set.getObject(true)).to.deep.equal({
+      expect(set.getObject(DestructiveChangesType.POST)).to.deep.equal({
         Package: {
           fullName: undefined,
           types: [
@@ -532,7 +535,9 @@ describe('ComponentSet', () => {
         tree: manifestFiles.TREE,
         fsDeletePaths: ['.'],
       });
-      expect(set.getPackageXml(4, true)).to.equal(manifestFiles.BASIC.data.toString());
+      expect(set.getPackageXml(4, DestructiveChangesType.POST)).to.equal(
+        manifestFiles.BASIC.data.toString()
+      );
     });
   });
 
@@ -757,11 +762,34 @@ describe('ComponentSet', () => {
         type: mixedContentSingleFile.COMPONENT.type,
         xml: mixedContentSingleFile.COMPONENT.xml,
       });
-      set.add(component, true);
+      set.add(component, DestructiveChangesType.POST);
 
       expect(set.hasDeletes).to.be.true;
       expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
       expect(set.has(component)).to.be.true;
+    });
+
+    it('should delete metadata from package components, if its present in destructive changes', async () => {
+      const set = new ComponentSet(undefined, mockRegistry);
+      expect(set.hasDeletes).to.be.false;
+
+      const component = new SourceComponent({
+        name: mixedContentSingleFile.COMPONENT.name,
+        type: mixedContentSingleFile.COMPONENT.type,
+        xml: mixedContentSingleFile.COMPONENT.xml,
+      });
+      set.add(component, DestructiveChangesType.POST);
+
+      expect(set.hasDeletes).to.be.true;
+      expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.POST);
+      expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
+
+      set.add(component);
+      set.setDestructiveChangesType(DestructiveChangesType.PRE);
+      expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.PRE);
+      expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
+      expect(set.has(component)).to.be.true;
+      expect(set.getSourceComponents().toArray().length).to.equal(1);
     });
   });
 

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -5,21 +5,25 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { createSandbox, SinonStub } from 'sinon';
-import { xmlInFolder, mockRegistry } from '../mock/registry';
+import { mockRegistry, xmlInFolder } from '../mock/registry';
 import * as streams from '../../src/convert/streams';
 import * as fs from 'fs';
 import * as fsUtil from '../../src/utils/fileSystemHandler';
 import { dirname, join } from 'path';
-import { expect, assert } from 'chai';
+import { assert, expect } from 'chai';
 import { ConversionError, LibraryError } from '../../src/errors';
 import { COMPONENTS } from '../mock/registry/type-constants/mixedContentInFolderConstants';
 import { fail } from 'assert';
-import { ComponentSet, MetadataConverter, SourceComponent } from '../../src';
+import {
+  ComponentSet,
+  DestructiveChangesType,
+  MetadataConverter,
+  SourceComponent,
+} from '../../src';
 import {
   DECOMPOSED_CHILD_COMPONENT_1,
   DECOMPOSED_CHILD_COMPONENT_2,
 } from '../mock/registry/type-constants/decomposedConstants';
-import { DestructiveChangesType } from '../../src/collections/types';
 
 const env = createSandbox();
 
@@ -207,15 +211,14 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true);
+      component1.setMarkedForDelete(true, DestructiveChangesType.PRE);
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
-      const compSet = new ComponentSet([component2], mockRegistry);
+      const compSet = new ComponentSet([component1, component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
-      compSet.add(component1, true);
       const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
       const expectedContents = compSet.getPackageXml();
 
@@ -398,15 +401,14 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true);
+      component1.setMarkedForDelete(true, DestructiveChangesType.PRE);
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
-      const compSet = new ComponentSet([component2], mockRegistry);
+      const compSet = new ComponentSet([component1, component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
-      compSet.add(component1, true);
       const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
       const expectedContents = compSet.getPackageXml();
       const addToZipStub = env.stub(streams.ZipWriter.prototype, 'addToZip');

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -176,14 +176,17 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true);
+      component1.setMarkedForDelete(DestructiveChangesType.POST);
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
       const compSet = new ComponentSet([component1, component2], mockRegistry);
-      const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
+      const expectedDestructiveContents = compSet.getPackageXml(
+        undefined,
+        DestructiveChangesType.POST
+      );
       const expectedContents = compSet.getPackageXml();
 
       await converter.convert(compSet, 'metadata', { type: 'directory', outputDirectory });
@@ -211,7 +214,7 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true, DestructiveChangesType.PRE);
+      component1.setMarkedForDelete(DestructiveChangesType.PRE);
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
@@ -219,7 +222,10 @@ describe('MetadataConverter', () => {
       });
       const compSet = new ComponentSet([component1, component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
-      const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
+      const expectedDestructiveContents = compSet.getPackageXml(
+        undefined,
+        DestructiveChangesType.PRE
+      );
       const expectedContents = compSet.getPackageXml();
 
       await converter.convert(compSet, 'metadata', { type: 'directory', outputDirectory });
@@ -371,14 +377,17 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true);
+      component1.setMarkedForDelete();
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
       const compSet = new ComponentSet([component1, component2], mockRegistry);
-      const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
+      const expectedDestructiveContents = compSet.getPackageXml(
+        undefined,
+        DestructiveChangesType.POST
+      );
       const expectedContents = compSet.getPackageXml();
       const addToZipStub = env.stub(streams.ZipWriter.prototype, 'addToZip');
 
@@ -395,13 +404,13 @@ describe('MetadataConverter', () => {
       ]);
     });
 
-    it('should write destructive changes pre manifest when ComponentSet has deletes', async () => {
+    it('should write destructive changes pre manifest when ComponentSet has deletes marked for pre', async () => {
       const component1 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_1.name,
         type: DECOMPOSED_CHILD_COMPONENT_1.type,
         xml: DECOMPOSED_CHILD_COMPONENT_1.xml,
       });
-      component1.setMarkedForDelete(true, DestructiveChangesType.PRE);
+      component1.setMarkedForDelete(DestructiveChangesType.PRE);
       const component2 = new SourceComponent({
         name: DECOMPOSED_CHILD_COMPONENT_2.name,
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
@@ -409,7 +418,7 @@ describe('MetadataConverter', () => {
       });
       const compSet = new ComponentSet([component1, component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
-      const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
+      const expectedDestructiveContents = compSet.getPackageXml(4, DestructiveChangesType.PRE);
       const expectedContents = compSet.getPackageXml();
       const addToZipStub = env.stub(streams.ZipWriter.prototype, 'addToZip');
 

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -213,8 +213,9 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
-      const compSet = new ComponentSet([component1, component2], mockRegistry);
+      const compSet = new ComponentSet([component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
+      compSet.add(component1, true);
       const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
       const expectedContents = compSet.getPackageXml();
 
@@ -403,8 +404,9 @@ describe('MetadataConverter', () => {
         type: DECOMPOSED_CHILD_COMPONENT_2.type,
         xml: DECOMPOSED_CHILD_COMPONENT_2.xml,
       });
-      const compSet = new ComponentSet([component1, component2], mockRegistry);
+      const compSet = new ComponentSet([component2], mockRegistry);
       compSet.setDestructiveChangesType(DestructiveChangesType.PRE);
+      compSet.add(component1, true);
       const expectedDestructiveContents = compSet.getPackageXml(undefined, true);
       const expectedContents = compSet.getPackageXml();
       const addToZipStub = env.stub(streams.ZipWriter.prototype, 'addToZip');

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -185,7 +185,7 @@ describe('Streams', () => {
         type: component.type,
         xml: component.xml,
       });
-      myComp.setMarkedForDelete(true);
+      myComp.setMarkedForDelete();
       const converter = new streams.ComponentConverter('source', mockRegistry);
 
       converter._transform(myComp, '', async (err: Error, data: WriterFormat) => {

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -60,7 +60,7 @@ describe('SourceComponent', () => {
   it('should return correct markedForDelete status', () => {
     expect(COMPONENT.isMarkedForDelete()).to.be.false;
     try {
-      COMPONENT.setMarkedForDelete(true);
+      COMPONENT.setMarkedForDelete();
       expect(COMPONENT.isMarkedForDelete()).to.be.true;
     } finally {
       COMPONENT.setMarkedForDelete(false);


### PR DESCRIPTION
### What does this PR do?
adds pre/post destructive change support to `ComponentSet.fromManifest`

### What issues does this PR fix or reference?
@W-9892375@

### Functionality Before
destructive component sets were limited to a single type (pre/post)
<insert gif and/or summary>

### Functionality After
you can now specify which type of deletion per `SourceComponent`
<insert gif and/or summary>
