### PR TITLE
fix: remove XML_NS_KEY from children when written in metadata format

### DIFF
--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -84,6 +84,12 @@ class RecompositionFinalizer extends ConvertTransactionFinalizer<RecompositionSt
         parentXmlObj[parentName] = { [XML_NS_KEY]: XML_NS_URL };
       }
 
+      // type safe way of checking childContents for the key
+      if (getString(childContents, XML_NS_KEY)) {
+        // child don't need to be written with `xmlns="http://soap.sforce.com/2006/04/metadata"` attribute
+        delete (childContents as JsonMap)[XML_NS_KEY];
+      }
+
       const parent = parentXmlObj[parentName] as JsonMap;
 
       if (!parent[groupName]) {

--- a/test/convert/convertContext.test.ts
+++ b/test/convert/convertContext.test.ts
@@ -14,15 +14,13 @@ const { expect } = chai;
 import { join } from 'path';
 import { createSandbox, match } from 'sinon';
 import { Readable } from 'stream';
-import { SourceComponent } from '../../src';
-import { ComponentSet } from '../../src/collections';
+import { SourceComponent, ComponentSet, WriterFormat } from '../../src';
 import {
   DEFAULT_PACKAGE_ROOT_SFDX,
   META_XML_SUFFIX,
   XML_NS_KEY,
   XML_NS_URL,
 } from '../../src/common';
-import { WriterFormat } from '../../src/convert';
 import { ConvertContext } from '../../src/convert/convertContext';
 import { JsToXml } from '../../src/convert/streams';
 import { matchingContentFile, mockRegistry, decomposed, nonDecomposed } from '../mock/registry';
@@ -57,7 +55,7 @@ describe('Convert Transaction Constructs', () => {
     });
 
     describe('Recomposition', () => {
-      it('should return a WriterFormat with recomposed data', async () => {
+      it('should return a WriterFormat with recomposed data and remove XML_NS_KEY from child components', async () => {
         const component = decomposed.DECOMPOSED_COMPONENT;
         const context = new ConvertContext();
         context.recomposition.setState((state) => {

--- a/test/mock/registry/type-constants/decomposedConstants.ts
+++ b/test/mock/registry/type-constants/decomposedConstants.ts
@@ -34,7 +34,10 @@ export const DECOMPOSED_VIRTUAL_FS: VirtualDirectory[] = [
         name: DECOMPOSED_XML_NAME,
         data: Buffer.from(`<Decomposed xmlns="${XML_NS_URL}"><fullName>a</fullName></Decomposed>`),
       },
-      { name: DECOMPOSED_CHILD_XML_NAME_1, data: Buffer.from('<Y><test>child1</test></Y>') },
+      {
+        name: DECOMPOSED_CHILD_XML_NAME_1,
+        data: Buffer.from('<Y xmlns="${XML_NS_URL}"><test>child1</test></Y>'),
+      },
       DECOMPOSED_CHILD_DIR,
     ],
   },


### PR DESCRIPTION
### What does this PR do?
previously, child types would be written with `xmlns="http://soap.sforce.com/2006/04/metadata"` attribute in metadata format, this was unnecessary and made the xml harder to read

### What issues does this PR fix or reference?
mdapi-convereted files won't write child types with that attribute

https://github.com/forcedotcom/cli/issues/1142, @W-9803903@

### Functionality Before

<insert gif and/or summary>
```
    <compactLayouts xmlns="http://soap.sforce.com/2006/04/metadata">
        <fullName>Broker_Compact</fullName>
        <fields>Name</fields>
        <fields>Title__c</fields>
        <fields>Phone__c</fields>
        <fields>Mobile_Phone__c</fields>
        <fields>Email__c</fields>
        <label>Broker Compact</label>
    </compactLayouts>
```
### Functionality After
in dreamhouse-lwc, `sfdx force:source:convert -d output -m CustomObject` 
check `output/objects/Broker__c.object`
```
    <compactLayouts>
        <fullName>Broker_Compact</fullName>
        <fields>Name</fields>
        <fields>Title__c</fields>
        <fields>Phone__c</fields>
        <fields>Mobile_Phone__c</fields>
        <fields>Email__c</fields>
        <label>Broker Compact</label>
    </compactLayouts>
