### PR TITLE
fix: better support for non-nested inFolder types

### DIFF
--- a/src/resolve/manifestResolver.ts
+++ b/src/resolve/manifestResolver.ts
@@ -62,14 +62,15 @@ export class ManifestResolver {
 
     for (const typeMembers of packageTypeMembers) {
       const typeName = typeMembers.name;
-      let type = this.registry.getTypeByName(typeName);
+      const type = this.registry.getTypeByName(typeName);
       const parentType = type.folderType ? this.registry.getTypeByName(type.folderType) : undefined;
       for (const fullName of normalizeToArray(typeMembers.members)) {
+        let mdType = type;
         // if there is no / delimiter and it's a type in folders that aren't nestedType, infer folder component
         if (type.folderType && !fullName.includes('/') && parentType.folderType !== parentType.id) {
-          type = this.registry.getTypeByName(type.folderType);
+          mdType = this.registry.getTypeByName(type.folderType);
         }
-        components.push({ fullName, type });
+        components.push({ fullName, type: mdType });
       }
     }
 

--- a/test/mock/registry/manifestConstants.ts
+++ b/test/mock/registry/manifestConstants.ts
@@ -62,6 +62,20 @@ export const ONE_FOLDER_MEMBER: VirtualFile = {
 </Package>\n`),
 };
 
+export const IN_FOLDER_WITH_CONTENT: VirtualFile = {
+  name: 'in-folder-with-content.xml',
+  data: Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Test_Folder</members>
+        <members>Test_Folder/report1</members>
+        <members>Test_Folder/report2</members>
+        <name>${mixedcontentinfolder.name}</name>
+    </types>
+    <version>${mockRegistry.apiVersion}</version>
+</Package>\n`),
+};
+
 export const ONE_WILDCARD: VirtualFile = {
   name: 'one-wildcard.xml',
   data: Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
@@ -84,6 +98,7 @@ export const TREE = new VirtualTreeContainer([
       ONE_OF_EACH,
       ONE_WILDCARD,
       ONE_FOLDER_MEMBER,
+      IN_FOLDER_WITH_CONTENT,
     ],
   },
   {

--- a/test/resolve/manifestResolver.test.ts
+++ b/test/resolve/manifestResolver.test.ts
@@ -82,5 +82,26 @@ describe('ManifestResolver', () => {
 
       expect(result.components).to.deep.equal(expected);
     });
+
+    it('should resolve inFolder types with folder content', async () => {
+      const resolver = new ManifestResolver(mockManifests.TREE, mockRegistry);
+      const result = await resolver.resolve(mockManifests.IN_FOLDER_WITH_CONTENT.name);
+      const expected: MetadataComponent[] = [
+        {
+          fullName: 'Test_Folder',
+          type: mockRegistryData.types.mciffolder,
+        },
+        {
+          fullName: 'Test_Folder/report1',
+          type: mockRegistryData.types.mixedcontentinfolder,
+        },
+        {
+          fullName: 'Test_Folder/report2',
+          type: mockRegistryData.types.mixedcontentinfolder,
+        },
+      ];
+
+      expect(result.components).to.deep.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Reset the type after each manifest member entry.  Fixes the recent regression.  Note however that nested inFolder type metadata is still not supported properly but will be asap.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1165
https://github.com/forcedotcom/cli/issues/1180
@W-9882522@

### Functionality Before
Deploy Error:
An  object  'emailTemplateDir/emailTemplateName' of  type EmailTemplate was named in package.xml, but was not found in zipped  directory

### Functionality After
Successful convert and deploy
