### PR TITLE
fix(registry.json): registry update for ManagedTopics

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -1381,8 +1381,6 @@
           "managedtopic": {
             "id": "managedtopic",
             "name": "ManagedTopic",
-            "xmlElementName": "managedTopic",
-            "uniqueIdElement": "fullName",
             "directoryName": "managedTopics",
             "suffix": "managedTopic"
           }


### PR DESCRIPTION
### What does this PR do?
Updates the registry for ManagedTopics so that ManagedTopic children will not be included in the manifest during a source convert.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1192
@W-9910605@

### Functionality Before
errors with: `An object 'topicName' of type ManagedTopic was named in package.xml, but was not found in zipped directory.`

### Functionality After
success
