### PR TITLE
fix: resolve folderContentTypes in mdapi format for windows

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -263,7 +263,7 @@ export class MetadataResolver {
         // check if the path contains a folder content name as a directory
         // e.g., `/reports/` and if it does return that folder name.
         folderContentTypesDirs.some((dirName) => {
-          if (fsPath.includes(`/${dirName}/`)) {
+          if (fsPath.includes(`${sep}${dirName}${sep}`)) {
             folderName = dirName;
           }
         });

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { assert, expect } from 'chai';
-import { MetadataResolver, SourceComponent, VirtualTreeContainer } from '../../src/resolve';
+import {
+  MetadataResolver,
+  SourceComponent,
+  VirtualDirectory,
+  VirtualTreeContainer,
+} from '../../src/resolve';
 import { nls } from '../../src/i18n';
 import {
   mockRegistry,
@@ -38,7 +43,7 @@ import {
   MIXED_CONTENT_DIRECTORY_VIRTUAL_FS,
   MIXED_CONTENT_DIRECTORY_XML_PATHS,
 } from '../mock/registry/type-constants/mixedContentDirectoryConstants';
-import { ComponentSet } from '../../src';
+import { ComponentSet, RegistryAccess } from '../../src';
 
 const testUtil = new RegistryTestUtil();
 
@@ -179,6 +184,21 @@ describe('MetadataResolver', () => {
           },
         ]);
         expect(access.getComponentsFromPath(path)).to.deep.equal([xmlInFolder.FOLDER_COMPONENT]);
+      });
+
+      it('should resolve folderContentTypes (e.g. reportFolder, emailFolder) in mdapi format', () => {
+        const registryAccess = new RegistryAccess();
+        const reportFolderDir = join('unpackaged', 'reports', 'foo');
+        const virtualFS: VirtualDirectory[] = [
+          { dirPath: reportFolderDir, children: ['bar-meta.xml'] },
+        ];
+        const tree = new VirtualTreeContainer(virtualFS);
+        const mdResolver = new MetadataResolver(registryAccess, tree);
+        const reportFolderPath = join(reportFolderDir, 'bar-meta.xml');
+        const comp = mdResolver.getComponentsFromPath(reportFolderPath);
+        expect(comp).to.be.an('array').with.lengthOf(1);
+        expect(comp[0]).to.have.property('name', 'foo/bar');
+        expect(comp[0]).to.have.deep.property('type', registryAccess.getTypeByName('ReportFolder'));
       });
 
       it('Should not mistake folder component of a mixed content type as that type', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug with resolving in-folder folder types on windows in mdapi format.

### What issues does this PR fix or reference?
@W-9739746@

### Functionality Before
In-folder folder types (reportFolder, emailFolder, etc.) would resolve to emailServices on Windows

### Functionality After
In-folder folder types resolve to the proper type on Windows.
