### PR TITLE
fix: support mixed wildcards and names in manifests

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -280,8 +280,8 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
           // if the type doesn't support mixed wildcards and specific names, overwrite the names to be a wildcard
           typeMap.set(typeName, [fullName]);
         } else if (
-          type.supportsWildcardAndName ||
-          (!typeEntry.includes(fullName) && !typeEntry.includes(ComponentSet.WILDCARD))
+          !typeEntry.includes(fullName) &&
+          (!typeEntry.includes(ComponentSet.WILDCARD) || type.supportsWildcardAndName)
         ) {
           // if the type supports both wildcards and names, add them regardless
           typeMap.get(typeName).push(fullName);

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -13,19 +13,19 @@ import {
 import { XML_DECL, XML_NS_KEY, XML_NS_URL } from '../common';
 import { ComponentSetError } from '../errors';
 import {
-  MetadataResolver,
+  ComponentLike,
   ManifestResolver,
+  MetadataComponent,
+  MetadataResolver,
   SourceComponent,
   TreeContainer,
-  MetadataComponent,
-  ComponentLike,
 } from '../resolve';
 import {
-  PackageTypeMembers,
-  FromManifestOptions,
-  PackageManifestObject,
-  FromSourceOptions,
   DestructiveChangesType,
+  FromManifestOptions,
+  FromSourceOptions,
+  PackageManifestObject,
+  PackageTypeMembers,
 } from './types';
 import { LazyCollection } from './lazyCollection';
 import { j2xParser } from 'fast-xml-parser';
@@ -276,12 +276,15 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
           typeMap.set(typeName, []);
         }
         const typeEntry = typeMap.get(typeName);
-        if (fullName === ComponentSet.WILDCARD) {
+        if (fullName === ComponentSet.WILDCARD && !type.supportsWildcardAndName) {
+          // if the type doesn't support mixed wildcards and specific names, overwrite the names to be a wildcard
           typeMap.set(typeName, [fullName]);
-        } else {
-          if (!typeEntry.includes(fullName) && !typeEntry.includes(ComponentSet.WILDCARD)) {
-            typeMap.get(typeName).push(fullName);
-          }
+        } else if (
+          type.supportsWildcardAndName ||
+          (!typeEntry.includes(fullName) && !typeEntry.includes(ComponentSet.WILDCARD))
+        ) {
+          // if the type supports both wildcards and names, add them regardless
+          typeMap.get(typeName).push(fullName);
         }
       }
     };

--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -254,6 +254,7 @@
       "suffix": "object",
       "directoryName": "objects",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": true,
       "children": {
         "types": {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -91,6 +91,17 @@ export interface MetadataType {
    * Whether the component is supported by the Metadata API and therefore should be included within a manifest.
    */
   isAddressable?: boolean;
+
+  /**
+   * Whether or not components of the same type can be can be specified with the wildcard character, and by name in a manifest
+   *
+   ```
+   <members>*</members>
+   <members>Account</members>
+   <name>CustomObject</name>
+   ```
+   */
+  supportsWildcardAndName?: boolean;
   /**
    * Type definitions for child types, if the type has any.
    *

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -451,6 +451,7 @@ describe('ComponentSet', () => {
       set.add(new SourceComponent({ name: 'myType', type }));
       set.add(new SourceComponent({ name: '*', type }));
       set.add(new SourceComponent({ name: 'myType2', type }));
+      set.add(new SourceComponent({ name: 'myType', type }));
       expect(set.getObject().Package.types).to.deep.equal([
         { members: ['myType', '*', 'myType2'], name: 'CustomObject' },
       ]);
@@ -466,6 +467,7 @@ describe('ComponentSet', () => {
       set.add(new SourceComponent({ name: 'myType', type }));
       set.add(new SourceComponent({ name: '*', type }));
       set.add(new SourceComponent({ name: 'myType2', type }));
+      set.add(new SourceComponent({ name: 'myType', type }));
       expect(set.getObject().Package.types).to.deep.equal([{ members: ['*'], name: 'ApexClass' }]);
     });
 

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -23,11 +23,11 @@ import { nls } from '../../src/i18n';
 import { ManifestResolver, MetadataMember, SourceComponent } from '../../src/resolve';
 import { mockConnection } from '../mock/client';
 import {
-  mockRegistry,
-  mockRegistryData,
-  mixedContentSingleFile,
   decomposedtoplevel,
   matchingContentFile,
+  mixedContentSingleFile,
+  mockRegistry,
+  mockRegistryData,
 } from '../mock/registry';
 import { MATCHING_RULES_COMPONENT } from '../mock/registry/type-constants/nonDecomposedConstants';
 import * as manifestFiles from '../mock/registry/manifestConstants';
@@ -439,6 +439,34 @@ describe('ComponentSet', () => {
       const set = new ComponentSet();
       set.add(new SourceComponent({ name: type.name, type }));
       expect(set.getObject().Package.types).to.deep.equal([]);
+    });
+
+    it('should write wildcards and names of types with supportsWildcardAndName=true, regardless of order', () => {
+      const type: MetadataType = {
+        id: 'customobject',
+        name: 'CustomObject',
+        supportsWildcardAndName: true,
+      };
+      const set = new ComponentSet();
+      set.add(new SourceComponent({ name: 'myType', type }));
+      set.add(new SourceComponent({ name: '*', type }));
+      set.add(new SourceComponent({ name: 'myType2', type }));
+      expect(set.getObject().Package.types).to.deep.equal([
+        { members: ['myType', '*', 'myType2'], name: 'CustomObject' },
+      ]);
+    });
+
+    it('should overwrite a singular name with wildcard when supportsWildcardAndName=false', () => {
+      const type: MetadataType = {
+        id: 'apexclass',
+        name: 'ApexClass',
+        supportsWildcardAndName: false,
+      };
+      const set = new ComponentSet();
+      set.add(new SourceComponent({ name: 'myType', type }));
+      set.add(new SourceComponent({ name: '*', type }));
+      set.add(new SourceComponent({ name: 'myType2', type }));
+      expect(set.getObject().Package.types).to.deep.equal([{ members: ['*'], name: 'ApexClass' }]);
     });
 
     it('should exclude child components that are not addressable as defined in the registry', () => {


### PR DESCRIPTION
### What does this PR do?
prior, `sObjects` and `CustomObjects` weren't able to be retrieved because the defined `sObject` would be overwritten by a wildcard

now manifests can contain wildcards and named elements for types that support it with the new registry option. Which is only `CustomObjects` for now

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1205, @W-9960907@

### Functionality Before
```
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">;
    <types>
        <members>Account</members>
        <name>CustomObject</name>
    </types>
    <types>
        <members>*</members>
        <name>CustomObject</name>
    </types>
    <version>53.0</version>
</Package>
```
would only retrieve the `CustomObjects`

### Functionality After

retrieves all `CustomObjects` and the sObject `Account`
