### PR TITLE
childComponent xml data is not parsed correctly

### DIFF
--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -168,7 +168,10 @@ export class SourceComponent implements MetadataComponent {
       return parsed;
     } else if (this.parent) {
       const children = normalizeToArray(
-        get(parsed, `${this.parent.type.name}.${this.type.directoryName}`)
+        get(
+          parsed,
+          `${this.parent.type.name}.${this.type.xmlElementName || this.type.directoryName}`
+        )
       ) as T[];
       return children.find((c) => getString(c, this.type.uniqueIdElement) === this.name);
     } else {

--- a/test/convert/convertContext.test.ts
+++ b/test/convert/convertContext.test.ts
@@ -156,7 +156,7 @@ describe('Convert Transaction Constructs', () => {
                 source: new JsToXml({
                   nondecomposedparent: {
                     [XML_NS_KEY]: XML_NS_URL,
-                    nondecomposed: [nonDecomposed.CHILD_1_XML, nonDecomposed.CHILD_2_XML],
+                    nondecomposeddir: [nonDecomposed.CHILD_1_XML, nonDecomposed.CHILD_2_XML],
                   },
                 }),
                 output: join('nondecomposed', 'nondecomposedparent.nondecomposed'),

--- a/test/mock/registry/mockRegistry.ts
+++ b/test/mock/registry/mockRegistry.ts
@@ -128,7 +128,7 @@ export const mockRegistryData = {
             xmlElementName: 'nondecomposed',
             ignoreParentName: true,
             uniqueIdElement: 'id',
-            directoryName: 'nondecomposed',
+            directoryName: 'nondecomposeddir',
             suffix: 'nondecomposed',
           },
         },

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -105,6 +105,29 @@ describe('SourceComponent', () => {
       });
     });
 
+    it('should parse the child components xml content to js object', async () => {
+      const component = new SourceComponent({
+        name: 'nondecomposedchild',
+        type: mockRegistryData.types.nondecomposed.children.types.nondecomposedchild,
+        xml: COMPONENT_1_XML_PATH,
+        parent: new SourceComponent({
+          name: 'nondecomposed',
+          type: mockRegistryData.types.nondecomposed,
+        }),
+      });
+      env
+        .stub(component.tree, 'readFile')
+        .resolves(
+          Buffer.from(
+            '<nondecomposedparent><nondecomposed><id>nondecomposedchild</id><content>something</content></nondecomposed></nondecomposedparent>'
+          )
+        );
+      expect(await component.parseXml()).to.deep.equal({
+        content: 'something',
+        id: 'nondecomposedchild',
+      });
+    });
+
     it('should return empty object if component does not have an xml', async () => {
       const component = new SourceComponent({
         name: 'a',


### PR DESCRIPTION
### What does this PR do?

fix `sourceComponent.parseXml()` for childComponents

### What issues does this PR fix or reference?
@W-10031154@

### Functionality Before

`sourceComponent.parseXml()` returns full xml content of the parentComponent for childComponents

### Functionality After

`sourceComponent.parseXml()` returns only childComponent xml content
