### PR TITLE
fix: use parent xml to parse child

### DIFF
--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -20,7 +20,9 @@ import { COMPONENT } from '../mock/registry/type-constants/matchingContentFileCo
 import {
   COMPONENT_1,
   CHILD_1_NAME,
+  CHILD_1_XML,
   VIRTUAL_DIR,
+  COMPONENT_1_XML,
   COMPONENT_1_XML_PATH,
   CHILD_2_NAME,
   MATCHING_RULES_TYPE,
@@ -332,6 +334,12 @@ describe('SourceComponent', () => {
 
     it('should return correct fullName', () => {
       expect(expectedChild.fullName).to.equal(expectedChild.name);
+    });
+
+    it('should parse child xml from parent xml', () => {
+      const childXml = expectedChild.parseFromParentXml(COMPONENT_1_XML);
+      expect(childXml).to.deep.equal(CHILD_1_XML);
+      expect(COMPONENT_1.parseFromParentXml(COMPONENT_1_XML)).to.deep.equal(COMPONENT_1_XML);
     });
 
     // https://github.com/forcedotcom/salesforcedx-vscode/issues/3210


### PR DESCRIPTION
### What does this PR do?
Reuses the parsed custom labels file when parsing the children to improve conversion performance.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1194
@W-9990964@

### Functionality Before
converting CustomLabels would take a long time since it would read and parse the CustomLabels.labels file for each label (child) within the file.

### Functionality After
The CustomLabels.labels file is read and parsed once, then reused to parse the children.

Testing Notes:

- Run the source plugin label NUTs with this branch linked and ensure everything passes.
- Manually test conversion (force:source:convert) of all custom labels using sourcepath, metadata, and manifest flags.  Use a project with lots of labels and multiple package directories.  Ensure the converted file contents and package.xml looks correct.
- Test converting individual labels, both from within the same package directory and within multiple package dirs.  Ensure the converted file contents and package.xml looks correct.
- Test converting CustomObjects and ensure nothing has regressed
- Test converting other non-decomposed types with children such as Workflows or AssignmentRules

