### PR TITLE
fix: use matching content file strategy

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -99,7 +99,10 @@
       "suffix": "scf",
       "directoryName": "scontrols",
       "inFolder": false,
-      "strictDirectoryName": false
+      "strictDirectoryName": false,
+      "strategies": {
+        "adapter": "matchingContentFile"
+      }
     },
     "experiencebundle": {
       "id": "experiencebundle",
@@ -1085,7 +1088,10 @@
       "suffix": "geodata",
       "directoryName": "eclair",
       "inFolder": false,
-      "strictDirectoryName": false
+      "strictDirectoryName": false,
+      "strategies": {
+        "adapter": "matchingContentFile"
+      }
     },
     "wavelens": {
       "id": "wavelens",


### PR DESCRIPTION
### What does this PR do?
Updates the EclairGeoData metadata registry entry to use the matchingContentFile adapter strategy.

### What issues does this PR fix or reference?
@W-10010404@

### Functionality Before
Component conversion failed: .../force-app/main/default/eclair/MyGeoData.geodat: Could not infer a metadata type

### Functionality After
Successful source conversion
