### PR TITLE
chore: add permissionSetLicenseDefinition to metadata registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -248,6 +248,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "permissionsetlicensedefinition": {
+      "id": "permissionsetlicensedefinition",
+      "name": "PermissionSetLicenseDefinition",
+      "suffix": "permissionSetLicenseDefinition",
+      "directoryName": "permissionSetLicenseDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "customobject": {
       "id": "customobject",
       "name": "CustomObject",


### PR DESCRIPTION
### What does this PR do?
Add support for [PermissionSetLicenseDefinition](https://codesearch.data.sfdc.net/source/xref/app_main_core/app/main/core/isv-licensing-udd/java/resources/udd/PermissionSetLicenseDefinition.type.xml) metadata type.

### What issues does this PR fix or reference?
[W-9498365](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PDiLYAW/view)

### Functionality Before
Did not allow deploy/retrieve of PermissionSetLicenseDefinition Entity.

### Functionality After
You can deploy/retrieve permissionSetLicenseDefintion:
sfdx force:source:retrieve -m PermissionSetLicenseDefinition
