### PR TITLE
chore: add service catalog 53.0 entities to registry

### DIFF
--- a/src/registry/registry.json
+++ b/src/registry/registry.json
@@ -11,11 +11,11 @@
     "customlabels": {
       "id": "customlabels",
       "name": "CustomLabels",
-      "ignoreParsedFullName": true,
       "suffix": "labels",
       "directoryName": "labels",
       "inFolder": false,
       "strictDirectoryName": false,
+      "ignoreParsedFullName": true,
       "children": {
         "types": {
           "customlabel": {
@@ -28,10 +28,12 @@
           }
         },
         "suffixes": {
-          "customLabel": "labels"
+          "customLabel": "labels",
+          "labels": "customlabel"
         },
         "directories": {
-          "customLabels": "labels"
+          "customLabels": "labels",
+          "labels": "customlabel"
         }
       },
       "strategies": {
@@ -199,7 +201,8 @@
       "name": "Territory",
       "suffix": "territory",
       "directoryName": "territories",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "group": {
       "id": "group",
@@ -796,7 +799,8 @@
       "name": "Translations",
       "suffix": "translation",
       "directoryName": "translations",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "globalvaluesettranslation": {
       "id": "globalvaluesettranslation",
@@ -961,35 +965,40 @@
       "name": "ServiceChannel",
       "suffix": "serviceChannel",
       "directoryName": "serviceChannels",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "queueroutingconfig": {
       "id": "queueroutingconfig",
       "name": "QueueRoutingConfig",
       "suffix": "queueRoutingConfig",
       "directoryName": "queueRoutingConfigs",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "servicepresencestatus": {
       "id": "servicepresencestatus",
       "name": "ServicePresenceStatus",
       "suffix": "servicePresenceStatus",
       "directoryName": "servicePresenceStatuses",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "presencedeclinereason": {
       "id": "presencedeclinereason",
       "name": "PresenceDeclineReason",
       "suffix": "presenceDeclineReason",
       "directoryName": "presenceDeclineReasons",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "presenceuserconfig": {
       "id": "presenceuserconfig",
       "name": "PresenceUserConfig",
       "suffix": "presenceUserConfig",
       "directoryName": "presenceUserConfigs",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "authprovider": {
       "id": "authprovider",
@@ -1163,7 +1172,8 @@
         },
         "directories": {
           "sharingOwnerRules": "sharingownerrule",
-          "sharingCriteriaRules": "sharingcriteriarule"
+          "sharingCriteriaRules": "sharingcriteriarule",
+          "sharingTerritoryRules": "sharingterritoryrule"
         }
       }
     },
@@ -1418,7 +1428,8 @@
       "name": "CampaignInfluenceModel",
       "suffix": "campaignInfluenceModel",
       "directoryName": "campaignInfluenceModels",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "samlssoconfig": {
       "id": "samlssoconfig",
@@ -1456,7 +1467,8 @@
       "name": "LicenseDefinition",
       "suffix": "licenseDefinition",
       "directoryName": "licenseDefinitions",
-      "inFolder": false
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "transactionsecuritypolicy": {
       "id": "transactionsecuritypolicy",
@@ -2058,6 +2070,7 @@
       "name": "RestrictionRule",
       "suffix": "rule",
       "directoryName": "restrictionRules",
+      "inFolder": false,
       "strictDirectoryName": false
     },
     "functionreference": {
@@ -2325,6 +2338,38 @@
       "suffix": "connectedSystem",
       "directoryName": "ConnectedSystem",
       "strictDirectoryName": false
+    },
+    "fieldrestrictionrule": {
+      "id": "fieldrestrictionrule",
+      "name": "FieldRestrictionRule",
+      "suffix": "rule",
+      "directoryName": "fieldRestrictionRules",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "svccatalogcategory": {
+      "id": "svccatalogcategory",
+      "name": "SvcCatalogCategory",
+      "suffix": "category",
+      "directoryName": "svcCatalogCategories",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "svccatalogfulfillmentflow": {
+      "id": "svccatalogfulfillmentflow",
+      "name": "SvcCatalogFulfillmentFlow",
+      "suffix": "fulfillmentFlow",
+      "directoryName": "svcCatalogFulfillmentFlows",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "svccatalogitemdef": {
+      "id": "svccatalogitemdef",
+      "name": "SvcCatalogItemDef",
+      "suffix": "catalogItem",
+      "directoryName": "svcCatalogItems",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -2478,7 +2523,7 @@
     "managedTopics": "managedtopics",
     "keywords": "keywordlist",
     "userCriteria": "usercriteria",
-    "rule": "moderationrule",
+    "rule": "fieldrestrictionrule",
     "territory2Type": "territory2type",
     "territory2Model": "territory2model",
     "territory2Rule": "territory2rule",
@@ -2555,7 +2600,11 @@
     "timeSheetTemplate": "timesheettemplate",
     "accountRelationshipShareRule": "accountrelationshipsharerule",
     "IPAddressRange": "ipaddressrange",
-    "xml": "emailservicesfunction"
+    "xml": "emailservicesfunction",
+    "document": "document",
+    "category": "svccatalogcategory",
+    "fulfillmentFlow": "svccatalogfulfillmentflow",
+    "catalogItem": "svccatalogitemdef"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",
@@ -2596,5 +2645,5 @@
     "botversion": "bot",
     "customfieldtranslation": "customobjecttranslation"
   },
-  "apiVersion": "52.0"
+  "apiVersion": "53.0"
 }


### PR DESCRIPTION
### What does this PR do?

Updates registry for 53.0.  Primarily with service catalog objects

### What issues does this PR fix or reference?

# @W-9799566@

### Functionality Before

Lacking support for force:source:deploy/retrieve

### Functionality After

Includes support for force:source:deploy/retrieve