### PR TITLE
feat: adding changes on registry

### DIFF
--- a/contributing/developing.md
+++ b/contributing/developing.md
@@ -89,7 +89,7 @@ The completeness is checked by comparing the registry to the metadata coverage r
 
 ### Adding new types to the registry
 
-You can manually edit types in registry.json. To simplify that work, there's a registry-building script
+You can manually edit types in metadataRegistry.json. To simplify that work, there's a registry-building script - the script is, currently, unreliable
 
 1. looks for missing types (similar to the completeness test)
 2. For missing types, generate a project and scratch org that includes the Features/Settings

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2076,6 +2076,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "userprofilesearchscope": {
+      "id": "userprofilesearchscope",
+      "name": "UserProfileSearchScope",
+      "suffix": "userProfileSearchScope",
+      "directoryName": "userProfileSearchScopes",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "workskillrouting": {
       "id": "workskillrouting",
       "name": "WorkSkillRouting",
@@ -2866,6 +2874,7 @@
     "audience": "audience",
     "cmsConnectSource": "cmsconnectsource",
     "platformEventSubscriberConfig": "platformeventsubscriberconfig",
+    "userProfileSearchScope": "userprofilesearchscope",
     "workSkillRouting": "workskillrouting",
     "timeSheetTemplate": "timesheettemplate",
     "accountRelationshipShareRule": "accountrelationshipsharerule",


### PR DESCRIPTION
### What does this PR do?
This change is waiting for https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000008qw05YAA/view to be closed. This PR adds the userProfileSearchScope as below
   {
        "directoryName": "userProfileSearchScopes",
        "inFolder": false,
        "metaFile": false,
        "suffix": "userProfileSearchScope",
        "xmlName": "UserProfileSearchScope"
      },

### What issues does this PR fix or reference?
No issues, is a feature addition

<https://github.com/salesforcecli/toolbelt/pull/167,>, @W-9921473@

### Functionality Before
userProfileSearchScope was not exposed on CLI


### Functionality After
userProfileSearchScope is now exposed on CLI
