### PR TITLE
fix: unconfuse sitedotcom vs site

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1344,7 +1344,7 @@
       "suffix": "site",
       "directoryName": "siteDotComSites",
       "inFolder": false,
-      "strictDirectoryName": false,
+      "strictDirectoryName": true,
       "strategies": {
         "adapter": "matchingContentFile"
       }
@@ -2985,7 +2985,8 @@
     "ObjectHierarchyRelationship": "objecthierarchyrelationship",
     "IndustriesManufacturingSettings": "industriesmanufacturingsettings",
     "dataMappingObjectDefinitions": "datamappingobjectdefinition",
-    "fieldRestrictionRules": "fieldrestrictionrule"
+    "fieldRestrictionRules": "fieldrestrictionrule",
+    "siteDotComSites": "sitedotcom"
   },
   "childTypes": {
     "customlabel": "customlabels",

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -10,6 +10,7 @@ import { extName, parentName, parseMetadataXml } from '../utils';
 import { RegistryAccess } from '../registry/registryAccess';
 import { ComponentSet } from '../collections';
 import { MetadataType } from '../registry';
+import { META_XML_SUFFIX } from '../common';
 import { SourceAdapterFactory } from './adapters/sourceAdapterFactory';
 import { ForceIgnore } from './forceIgnore';
 import { SourceComponent } from './sourceComponent';
@@ -168,7 +169,7 @@ export class MetadataResolver {
           // mixedContent and bundles don't have a suffix to match
           ['mixedContent', 'bundle'].includes(type.strategies?.adapter) ||
           // the suffix matches the type we think it is
-          (type.suffix && fsPath.endsWith(`${type.suffix}`)) ||
+          (type.suffix && fsPath.endsWith(`${type.suffix}${META_XML_SUFFIX}`)) ||
           // the type has children and the path also includes THAT directory
           (type.children?.types &&
             Object.values(type.children?.types)


### PR DESCRIPTION
### What does this PR do?
makes sitedotcom strictDir

### What issues does this PR fix or reference?
https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1636049318137700

### Functionality Before

ERROR running force:source:convert:  /home/circleci/ci_app/force-app/main/default/sites/IdeaExchange.site-meta.xml: Expected source files for type 'SiteDotCom'

### Functionality After

