### PR TITLE
fix: run unspecified child types through forceignore to avoid retrieving

### DIFF
--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { JsonMap } from '@salesforce/ts-types';
-import { MetadataComponent, SourceComponent } from '../../resolve';
+import { ForceIgnore, MetadataComponent, SourceComponent } from '../../resolve';
 import { JsToXml } from '../streams';
 import { WriteInfo } from '../types';
 import { META_XML_SUFFIX, SourcePath, XML_NS_KEY, XML_NS_URL } from '../../common';
@@ -52,6 +52,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     const writeInfos: WriteInfo[] = [];
     const childrenOfMergeComponent = new ComponentSet(mergeWith?.getChildren());
     const { type, fullName: parentFullName } = component;
+    const forceIgnore = new ForceIgnore();
 
     let parentXmlObject: JsonMap;
     const composedMetadata = await this.getComposedMetadataEntries(component);
@@ -68,36 +69,39 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
             type: childType,
             parent: component,
           };
-          const source = new JsToXml({
-            [childType.name]: Object.assign({ [XML_NS_KEY]: XML_NS_URL }, value),
-          });
-          // if there's nothing to merge with, push write operation now to default location
-          if (!mergeWith) {
-            writeInfos.push({
-              source,
-              output: this.getDefaultOutput(childComponent),
+          // only process child types that aren't forceignored
+          if (forceIgnore.accepts(this.getDefaultOutput(childComponent))) {
+            const source = new JsToXml({
+              [childType.name]: Object.assign({ [XML_NS_KEY]: XML_NS_URL }, value),
             });
-          }
-          // if the merge parent has a child that can be merged with, push write
-          // operation now and mark it as merged in the state
-          else if (childrenOfMergeComponent.has(childComponent)) {
-            const mergeChild: SourceComponent = childrenOfMergeComponent.getSourceComponents(childComponent).first();
-            writeInfos.push({
-              source,
-              output: mergeChild.xml,
-            });
-            this.setDecomposedState(childComponent, { foundMerge: true });
-          }
-          // if no child component is found to merge with yet, mark it as so in
-          // the state
-          else if (!this.getDecomposedState(childComponent)?.foundMerge) {
-            this.setDecomposedState(childComponent, {
-              foundMerge: false,
-              writeInfo: {
+            // if there's nothing to merge with, push write operation now to default location
+            if (!mergeWith) {
+              writeInfos.push({
                 source,
                 output: this.getDefaultOutput(childComponent),
-              },
-            });
+              });
+            }
+            // if the merge parent has a child that can be merged with, push write
+            // operation now and mark it as merged in the state
+            else if (childrenOfMergeComponent.has(childComponent)) {
+              const mergeChild: SourceComponent = childrenOfMergeComponent.getSourceComponents(childComponent).first();
+              writeInfos.push({
+                source,
+                output: mergeChild.xml,
+              });
+              this.setDecomposedState(childComponent, { foundMerge: true });
+            }
+            // if no child component is found to merge with yet, mark it as so in
+            // the state
+            else if (!this.getDecomposedState(childComponent)?.foundMerge) {
+              this.setDecomposedState(childComponent, {
+                foundMerge: false,
+                writeInfo: {
+                  source,
+                  output: this.getDefaultOutput(childComponent),
+                },
+              });
+            }
           }
         }
       } else {

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -6,7 +6,7 @@
  */
 import { join } from 'path';
 import { JsonMap } from '@salesforce/ts-types';
-import { ForceIgnore, MetadataComponent, SourceComponent } from '../../resolve';
+import { MetadataComponent, SourceComponent } from '../../resolve';
 import { JsToXml } from '../streams';
 import { WriteInfo } from '../types';
 import { META_XML_SUFFIX, SourcePath, XML_NS_KEY, XML_NS_URL } from '../../common';
@@ -52,7 +52,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
     const writeInfos: WriteInfo[] = [];
     const childrenOfMergeComponent = new ComponentSet(mergeWith?.getChildren());
     const { type, fullName: parentFullName } = component;
-    const forceIgnore = new ForceIgnore();
+    const forceIgnore = component.getForceIgnore();
 
     let parentXmlObject: JsonMap;
     const composedMetadata = await this.getComposedMetadataEntries(component);

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -132,6 +132,19 @@ export class SourceComponent implements MetadataComponent {
   }
 
   /**
+   * will return this instance of the forceignore, or will create one if undefined
+   *
+   * @return ForceIgnore
+   */
+  public getForceIgnore(): ForceIgnore {
+    if (this.forceIgnore) {
+      return this.forceIgnore;
+    } else {
+      return ForceIgnore.findAndCreate(this.content);
+    }
+  }
+
+  /**
    * As a performance enhancement, use the already parsed parent xml source
    * to return the child section of xml source. This is useful for non-decomposed
    * transformers where all child source components reference the parent's

--- a/test/convert/transformers/decomposedMetadataTransformer.ts
+++ b/test/convert/transformers/decomposedMetadataTransformer.ts
@@ -194,7 +194,7 @@ describe('DecomposedMetadataTransformer', () => {
       env
         .stub(ForceIgnore.prototype, 'accepts')
         .returns(true)
-        .withArgs('main/default/decomposeds/a/ys/child.y-meta.xml')
+        .withArgs(join('main', 'default', 'decomposeds', 'a', 'ys', 'child.y-meta.xml'))
         .returns(false);
 
       const result = await transformer.toSourceFormat(component);


### PR DESCRIPTION
### What does this PR do?
allows you to forceignore children of decomposed metadata types

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @W-9959024@

### Functionality Before
adding `**/Account/listViews/**` to your `.forceignore` and then `retrieve -m CustomObject:Account` would retrieve all `ListViews` for `Account`

<insert gif and/or summary>

### Functionality After

no `ListViews` or other child metadata types retrieved

<insert gif and/or summary>
