### PR TITLE
feat: add metadata types StnryAssetEnvSrcCnfg, BldgEnrgyIntensityCnfg…

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2724,6 +2724,30 @@
       "directoryName": "omniIntegrationProcedures",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "bldgenrgyintensitycnfg": {
+      "id": "bldgenrgyintensitycnfg",
+      "name": "BldgEnrgyIntensityCnfg",
+      "suffix": "buildingEnergyIntensityConfig",
+      "directoryName": "buildingEnergyIntensityConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "stnryassetenvsrccnfg": {
+      "id": "stnryassetenvsrccnfg",
+      "name": "StnryAssetEnvSrcCnfg",
+      "suffix": "stationaryAssetEnvSourceConfig",
+      "directoryName": "stationaryAssetEnvSourceConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "vehicleassetemssnsrccnfg": {
+      "id": "vehicleassetemssnsrccnfg",
+      "name": "VehicleAssetEmssnSrcCnfg",
+      "suffix": "vehicleAssetEmssnSourceConfig",
+      "directoryName": "vehicleAssetEmssnSourceConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3022,7 +3046,10 @@
     "rpt": "omnidatatransform",
     "mktDataTranField": "mktdatatranfield",
     "os": "omniscript",
-    "oip": "omniintegrationprocedure"
+    "oip": "omniintegrationprocedure",
+    "buildingEnergyIntensityConfig": "bldgenrgyintensitycnfg",
+    "stationaryAssetEnvSourceConfig": "stnryassetenvsrccnfg",
+    "vehicleAssetEmssnSourceConfig": "vehicleassetemssnsrccnfg"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
…, VehicleAssetEmssnSrcCnfg

### What does this PR do?
Adds StnryAssetEnvSrcCnfg, BldgEnrgyIntensityCnfg, VehicleAssetEmssnSrcCnfg metadata types to registry

### What issues does this PR fix or reference?
@W-10222550@

### Functionality Before
sfdx force:source commands did not work for the mentioned metadata types

### Functionality After
sfdx force:source commands should work for the mentioned metadata types
