### PR TITLE
fix: registry validation prevents ignoring non-supported types

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,7 +2,6 @@
   "require": "ts-node/register,source-map-support/register",
   "watch-extensions": "ts",
   "extensions": [".ts", ".js", ".json"],
-  "spec": ["./test/**/*.test.ts"],
   "watch-files": ["src", "test"],
   "recursive": true,
   "reporter": "spec",

--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -26,8 +26,6 @@ export const metadataTypes = [
 
   // things that don't show up in describe so far
   'PicklistValue', // only existed in v37, so it's hard to describe!
-  'FieldRestrictionRule', // not in describe for devorg.  ScratchDef might need feature 'EMPLOYEEEXPERIENCE' but it doesn't say that
-  'AppointmentSchedulingPolicy', // not in describe?
   'AppointmentAssignmentPolicy', // not in describe?
   'WorkflowFlowAction', // not in describe
   'AdvAcctForecastDimSource', // not in describe

--- a/test/registry/registryValidation.test.ts
+++ b/test/registry/registryValidation.test.ts
@@ -8,10 +8,26 @@ import { expect } from 'chai';
 import { MetadataRegistry } from '../../src';
 import { registry as defaultRegistry } from '../../src/registry/registry';
 import { MetadataType } from '../../src/registry/types';
+import { metadataTypes as UnsupportedTypes } from '../../src/registry/nonSupportedTypes';
 
 describe('Registry Validation', () => {
   const registry = defaultRegistry as MetadataRegistry;
   const typesWithChildren = Object.values(registry.types).filter((type) => type.children);
+
+  describe('non-supported types', () => {
+    Object.values(registry.types).forEach((type) => {
+      it(`${type.name} should not be in UnsupportedTypes`, () => {
+        expect(UnsupportedTypes).to.not.include(type.name);
+      });
+    });
+    typesWithChildren.forEach((type) => {
+      Object.values(type.children.types).forEach((child) => {
+        it(`${child.name} should not be in UnsupportedTypes`, () => {
+          expect(UnsupportedTypes).to.not.include(child.name);
+        });
+      });
+    });
+  });
 
   describe('child types', () => {
     describe('child types are configured properly', () => {


### PR DESCRIPTION
### What does this PR do?
- removing some nonSupportedTypes that are now avaialable.
- validation to prevent that from happening again
### What issues does this PR fix or reference?

@W-0@