### PR TITLE
fix: network error tolerance

### DIFF
--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -200,11 +200,9 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
         this.logger.error(e);
         // tolerate intermittent network errors upto retry limit
         if (
-          e instanceof Error &&
-          (e.message.includes('ETIMEDOUT') ||
-            e.message.includes('ENOTFOUND') ||
-            e.message.includes('ECONNRESET') ||
-            e.message.includes('socket hang up'))
+          ['ETIMEDOUT', 'ENOTFOUND', 'ECONNRESET', 'socket hang up'].some((retryableNetworkError) =>
+            (e as Error).message.includes(retryableNetworkError)
+          )
         ) {
           this.logger.debug('Network error on the request', e);
           await Lifecycle.getInstance().emitWarning('Network error occurred.  Continuing to poll.');

--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -199,8 +199,14 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
       } catch (e) {
         this.logger.error(e);
         // tolerate intermittent network errors upto retry limit
-        if (e instanceof Error && (e.message.includes('ETIMEDOUT') || e.message.includes('ENOTFOUND'))) {
-          this.logger.debug('Network error on the request (ETIMEDOUT or ENOTFOUND)');
+        if (
+          e instanceof Error &&
+          (e.message.includes('ETIMEDOUT') ||
+            e.message.includes('ENOTFOUND') ||
+            e.message.includes('ECONNRESET') ||
+            e.message.includes('socket hang up'))
+        ) {
+          this.logger.debug('Network error on the request', e);
           await Lifecycle.getInstance().emitWarning('Network error occurred.  Continuing to poll.');
           return { completed: false };
         }


### PR DESCRIPTION
### What does this PR do?
tolerate ETIMEDOUT and ENOTFOUND on all SDR metadata operations

this is just a low-hanging solution for SDR, not jsforce, so we'll have network errors throwing in auth, org create, packaging,  and some other longer-running processes.  But hopefully deploy/retrieve operations (push/pull and the deploy/retrieve/delete and mdapi ops) will be a good partial solve.

### What issues does this PR fix or reference?

partial solve for @W-5657753@
https://github.com/forcedotcom/cli/issues/1301
https://github.com/forcedotcom/cli/issues/529
https://github.com/forcedotcom/cli/issues/1007

### Functionality Before
SDR throws on first connection problem

```
Error: connect ETIMEDOUT 160.8.252.85:443
    at TCPConnectWrap.afterConnect [as oncomplete*** (node:net:1161:16) ***
  errno: -110,
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '160.8.252.85',
  port: 443
***
***
  "status": 1,
  "name": "MetadataTransferError",
  "message": "Metadata API request failed: connect ETIMEDOUT 160.8.252.85:443",
  "exitCode": 1,
  "commandName": "Deploy",
  "stack": "MetadataTransferError: Metadata API request failed: connect ETIMEDOUT 160.8.252.85:443\n    at MetadataApiDeploy.pollStatus (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/source-deploy-retrieve/lib/src/client/metadataTransfer.js:78:27)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async Deploy.deploy (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/plugin-source/lib/commands/force/source/deploy.js:94:37)\n    at async Deploy.run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/plugin-source/lib/commands/force/source/deploy.js:37:9)\n    at async Deploy._run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/command/lib/sfdxCommand.js:81:40)\n    at async Config.runCommand (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/config/lib/config.js:173:24)\n    at async SfdxMain.run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/command/lib/main.js:27:9)\n    at async SfdxMain._run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/command/lib/command.js:43:20)\n    at async Object.run (/usr/local/lib/node_modules/sfdx-cli/dist/cli.js:162:47)\nDUE TO:\nError: connect ETIMEDOUT 160.8.252.85:443\n    at TCPConnectWrap.afterConnect [as oncomplete*** (node:net:1161:16)\nOuter stack:\n    at Function.wrap (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/core/lib/sfdxError.js:171:27)\n    at Deploy.catch (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/command/lib/sfdxCommand.js:248:67)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async Deploy._run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@salesforce/command/lib/sfdxCommand.js:85:13)\n    at async Config.runCommand (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/config/lib/config.js:173:24)\n    at async SfdxMain.run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/command/lib/main.js:27:9)\n    at async SfdxMain._run (/usr/local/lib/node_modules/sfdx-cli/node_modules/@oclif/command/lib/command.js:43:20)\n    at async Object.run (/usr/local/lib/node_modules/sfdx-cli/dist/cli.js:162:47)",
```

### Functionality After

it'll keep trying (within the retry boundaries provided to the poller).
It does emit warnings and debugs about the problem so they're not hidden from the user.

Testing/QA
- link SDR in plugin-source
- start a deploy and then turn off your wifi (or pull a cable if you've got one)
