### PR TITLE
fix: can retrive COFT with COT automatically

### DIFF
--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -86,7 +86,7 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
              CustomObjectFieldTranslations are only addressable through their parent, and require a
              CustomObjectTranslation file to be present
              */
-            if (childType.requiresParent && composedMetadata.length <= 2) {
+            if (childType.unaddressableWithoutParent && composedMetadata.length <= 2) {
               parentXmlObject = {
                 [component.type.name]: '',
               };

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -850,7 +850,7 @@
             "directoryName": "fields",
             "suffix": "fieldTranslation",
             "isAddressable": false,
-            "requiresParent": true,
+            "unaddressableWithoutParent": true,
             "uniqueIdElement": "name"
           }
         },

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -850,6 +850,7 @@
             "directoryName": "fields",
             "suffix": "fieldTranslation",
             "isAddressable": false,
+            "requiresParent": true,
             "uniqueIdElement": "name"
           }
         },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -25,7 +25,6 @@ export interface MetadataRegistry {
  * Metadata type definition in the registry.
  */
 export interface MetadataType {
-  requiresParent?: boolean;
   /**
    * Unique identifier of the metadata type. Usually the API name lowercased.
    */
@@ -92,6 +91,10 @@ export interface MetadataType {
    * Whether the component is supported by the Metadata API and therefore should be included within a manifest.
    */
   isAddressable?: boolean;
+  /**
+   * Whether the component requires the parent to be present when deploying/retrieving
+   */
+  unaddressableWithoutParent?: boolean;
 
   /**
    * Whether or not components of the same type can be can be specified with the wildcard character, and by name in a manifest

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -25,6 +25,7 @@ export interface MetadataRegistry {
  * Metadata type definition in the registry.
  */
 export interface MetadataType {
+  requiresParent?: boolean;
   /**
    * Unique identifier of the metadata type. Usually the API name lowercased.
    */

--- a/test/convert/transformers/decomposedMetadataTransformer.ts
+++ b/test/convert/transformers/decomposedMetadataTransformer.ts
@@ -337,8 +337,8 @@ describe('DecomposedMetadataTransformer', () => {
       ]);
     });
     it('should create a parent xml when requiresParent = true on the child type', async () => {
-      component.type.children.types.y.requiresParent = true;
-      component.type.children.types.x.requiresParent = true;
+      component.type.children.types.y.unaddressableWithoutParent = true;
+      component.type.children.types.x.unaddressableWithoutParent = true;
       const { type, fullName } = component;
       const transformer = new DecomposedMetadataTransformer(mockRegistry);
       const root = join('main', 'default', type.directoryName, fullName);
@@ -385,6 +385,7 @@ describe('DecomposedMetadataTransformer', () => {
           }),
           output: join(root, type.children.types.x.directoryName, 'child3.x-meta.xml'),
         },
+        // the new parent was written
         {
           source: new JsToXml({
             [type.name]: '',
@@ -394,8 +395,8 @@ describe('DecomposedMetadataTransformer', () => {
       ]);
 
       // reset to avoid interfering with other tests
-      component.type.children.types.y.requiresParent = false;
-      component.type.children.types.x.requiresParent = false;
+      component.type.children.types.y.unaddressableWithoutParent = false;
+      component.type.children.types.x.unaddressableWithoutParent = false;
     });
 
     it('should handle decomposed parents with no files', async () => {


### PR DESCRIPTION
### What does this PR do?
fixes retrieval of COFT

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1233, https://github.com/forcedotcom/cli/issues/1241, https://github.com/forcedotcom/cli/issues/1262, @W-10222972@

### Functionality Before
`retrieve -m CustomFieldTranslation` without a CustomObjectTranslation in the org would only pull the CustomFieldTranslation files, which were invalid by themselves without a CustomObjectTranslation parent file


### Functionality After
a retrieve will retrieve both COFT/COT and write an empty COT if one doesn't exist in the org

