### PR TITLE
fix: wrap error from fast-xml-parser when invalid xml parsed

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -8,483 +8,485 @@ Currently, there are 420/464 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
-| Metadata Type                         | Support | Notes                                            |
-| :------------------------------------ | :------ | :----------------------------------------------- |
-| AIApplication                         | ✅      |                                                  |
-| AIApplicationConfig                   | ✅      |                                                  |
-| AIReplyRecommendationsSettings        | ✅      |                                                  |
-| AccountForecastSettings               | ✅      |                                                  |
-| AccountInsightsSettings               | ✅      |                                                  |
-| AccountIntelligenceSettings           | ✅      |                                                  |
-| AccountRelationshipShareRule          | ✅      |                                                  |
-| AccountSettings                       | ✅      |                                                  |
-| AcctMgrTargetSettings                 | ✅      |                                                  |
-| ActionLinkGroupTemplate               | ✅      |                                                  |
-| ActionPlanTemplate                    | ✅      |                                                  |
-| ActionsSettings                       | ✅      |                                                  |
-| ActivationPlatform                    | ❌      | Not supported, but support could be added        |
-| ActivitiesSettings                    | ✅      |                                                  |
-| AddressSettings                       | ✅      |                                                  |
-| AdvAccountForecastSet                 | ✅      |                                                  |
-| AdvAcctForecastDimSource              | ❌      | Not supported, but support could be added        |
-| AdvAcctForecastPeriodGroup            | ✅      |                                                  |
-| AnalyticSnapshot                      | ✅      |                                                  |
-| AnalyticsDataServicesSettings         | ✅      |                                                  |
-| AnalyticsSettings                     | ✅      |                                                  |
-| AnimationRule                         | ✅      |                                                  |
-| ApexClass                             | ✅      |                                                  |
-| ApexComponent                         | ✅      |                                                  |
-| ApexEmailNotifications                | ✅      |                                                  |
-| ApexPage                              | ✅      |                                                  |
-| ApexSettings                          | ✅      |                                                  |
-| ApexTestSuite                         | ✅      |                                                  |
-| ApexTrigger                           | ✅      |                                                  |
-| AppAnalyticsSettings                  | ✅      |                                                  |
-| AppExperienceSettings                 | ✅      |                                                  |
-| AppMenu                               | ✅      |                                                  |
-| ApplicationRecordTypeConfig           | ✅      |                                                  |
-| ApplicationSubtypeDefinition          | ❌      | Not supported, but support could be added        |
-| AppointmentAssignmentPolicy           | ❌      | Not supported, but support could be added        |
-| AppointmentSchedulingPolicy           | ✅      |                                                  |
-| ApprovalProcess                       | ✅      |                                                  |
-| ArchiveSettings                       | ✅      |                                                  |
-| AssignmentRules                       | ✅      |                                                  |
-| AssistantContextItem                  | ✅      |                                                  |
-| AssistantDefinition                   | ✅      |                                                  |
-| AssistantSkillQuickAction             | ✅      |                                                  |
-| AssistantSkillSobjectAction           | ✅      |                                                  |
-| AssistantVersion                      | ✅      |                                                  |
-| AssociationEngineSettings             | ✅      |                                                  |
-| AttributeDefinition2                  | ❌      | Not supported, but support could be added        |
-| Audience                              | ✅      |                                                  |
-| AuraDefinitionBundle                  | ✅      |                                                  |
-| AuthProvider                          | ✅      |                                                  |
-| AutoResponseRules                     | ✅      |                                                  |
-| AutomatedContactsSettings             | ✅      |                                                  |
-| BatchCalcJobDefinition                | ✅      |                                                  |
-| BatchProcessJobDefinition             | ✅      |                                                  |
-| BenefitAction                         | ✅      |                                                  |
-| BlacklistedConsumer                   | ✅      |                                                  |
-| BldgEnrgyIntensityCnfg                | ✅      |                                                  |
-| BlockchainSettings                    | ✅      |                                                  |
-| Bot                                   | ✅      |                                                  |
-| BotSettings                           | ✅      |                                                  |
-| BotVersion                            | ✅      |                                                  |
-| BranchManagementSettings              | ✅      |                                                  |
-| BrandingSet                           | ✅      |                                                  |
-| BriefcaseDefinition                   | ✅      |                                                  |
-| BusinessHoursSettings                 | ✅      |                                                  |
-| BusinessProcess                       | ✅      |                                                  |
-| BusinessProcessGroup                  | ✅      |                                                  |
-| BusinessProcessTypeDefinition         | ❌      | Not supported, but support could be added        |
-| CMSConnectSource                      | ✅      |                                                  |
-| CallCenter                            | ✅      |                                                  |
-| CallCenterRoutingMap                  | ✅      |                                                  |
-| CallCoachingMediaProvider             | ⚠️      | Supports deploy/retrieve but not source tracking |
-| CampaignInfluenceModel                | ✅      |                                                  |
-| CampaignSettings                      | ✅      |                                                  |
-| CanvasMetadata                        | ✅      |                                                  |
-| CareBenefitVerifySettings             | ✅      |                                                  |
-| CareLimitType                         | ❌      | Not supported, but support could be added        |
-| CareProviderSearchConfig              | ✅      |                                                  |
-| CareRequestConfiguration              | ✅      |                                                  |
-| CareSystemFieldMapping                | ✅      |                                                  |
-| CaseSettings                          | ✅      |                                                  |
-| CaseSubjectParticle                   | ✅      |                                                  |
-| Certificate                           | ✅      |                                                  |
-| ChannelLayout                         | ✅      |                                                  |
-| ChannelObjectLinkingRule              | ✅      |                                                  |
-| ChatterAnswersSettings                | ✅      |                                                  |
-| ChatterEmailsMDSettings               | ✅      |                                                  |
-| ChatterExtension                      | ✅      |                                                  |
-| ChatterSettings                       | ✅      |                                                  |
-| CleanDataService                      | ✅      |                                                  |
-| CommandAction                         | ✅      |                                                  |
-| CommerceSettings                      | ✅      |                                                  |
-| CommunitiesSettings                   | ✅      |                                                  |
-| Community                             | ✅      |                                                  |
-| CommunityTemplateDefinition           | ✅      |                                                  |
-| CommunityThemeDefinition              | ✅      |                                                  |
-| CompactLayout                         | ✅      |                                                  |
-| CompanySettings                       | ✅      |                                                  |
-| ConnectedApp                          | ✅      |                                                  |
-| ConnectedAppSettings                  | ✅      |                                                  |
-| ConnectedSystem                       | ✅      |                                                  |
-| ContentAsset                          | ✅      |                                                  |
-| ContentSettings                       | ✅      |                                                  |
-| ContractSettings                      | ✅      |                                                  |
-| ContractType                          | ❌      | Not supported, but support could be added        |
-| ConversationVendorInfo                | ✅      |                                                  |
-| ConversationalIntelligenceSettings    | ✅      |                                                  |
-| CorsWhitelistOrigin                   | ✅      |                                                  |
-| CspTrustedSite                        | ✅      |                                                  |
-| CurrencySettings                      | ✅      |                                                  |
-| CustomApplication                     | ✅      |                                                  |
-| CustomApplicationComponent            | ✅      |                                                  |
-| CustomFeedFilter                      | ✅      |                                                  |
-| CustomField                           | ✅      |                                                  |
-| CustomHelpMenuSection                 | ✅      |                                                  |
-| CustomIndex                           | ✅      |                                                  |
-| CustomLabels                          | ✅      |                                                  |
-| CustomMetadata                        | ✅      |                                                  |
-| CustomNotificationType                | ✅      |                                                  |
-| CustomObject                          | ✅      |                                                  |
-| CustomObjectTranslation               | ✅      |                                                  |
-| CustomPageWebLink                     | ✅      |                                                  |
-| CustomPermission                      | ✅      |                                                  |
-| CustomSite                            | ✅      |                                                  |
-| CustomTab                             | ✅      |                                                  |
-| CustomValue                           | ❌      | Not supported, but support could be added        |
-| CustomerDataPlatformSettings          | ✅      |                                                  |
-| Dashboard                             | ✅      |                                                  |
-| DashboardFolder                       | ✅      |                                                  |
-| DataCategoryGroup                     | ✅      |                                                  |
-| DataConnectorS3                       | ✅      |                                                  |
-| DataDotComSettings                    | ✅      |                                                  |
-| DataMapping                           | ✅      |                                                  |
-| DataMappingFieldDefinition            | ✅      |                                                  |
-| DataMappingObjectDefinition           | ✅      |                                                  |
-| DataMappingSchema                     | ✅      |                                                  |
-| DataSource                            | ✅      |                                                  |
-| DataSourceObject                      | ✅      |                                                  |
-| DataSourceTenant                      | ❌      | Not supported, but support could be added        |
-| DataStreamDefinition                  | ✅      |                                                  |
-| DecisionTable                         | ✅      |                                                  |
-| DecisionTableDatasetLink              | ✅      |                                                  |
-| DelegateGroup                         | ✅      |                                                  |
-| DeploymentSettings                    | ✅      |                                                  |
-| DevHubSettings                        | ✅      |                                                  |
-| DiscoveryAIModel                      | ✅      |                                                  |
-| DiscoveryGoal                         | ✅      |                                                  |
-| DiscoverySettings                     | ✅      |                                                  |
-| DiscoveryStory                        | ❌      | Not supported, but support could be added        |
-| Document                              | ✅      |                                                  |
-| DocumentChecklistSettings             | ✅      |                                                  |
-| DocumentFolder                        | ✅      |                                                  |
-| DocumentGenerationSetting             | ✅      |                                                  |
-| DocumentType                          | ✅      |                                                  |
-| DuplicateRule                         | ✅      |                                                  |
-| EACSettings                           | ✅      |                                                  |
-| ESignatureConfig                      | ❌      | Not supported, but support could be added        |
-| ESignatureEnvelopeConfig              | ❌      | Not supported, but support could be added        |
-| EclairGeoData                         | ✅      |                                                  |
-| EinsteinAgentSettings                 | ✅      |                                                  |
-| EinsteinAssistantSettings             | ✅      |                                                  |
-| EinsteinDealInsightsSettings          | ✅      |                                                  |
-| EinsteinDocumentCaptureSettings       | ✅      |                                                  |
-| EmailAdministrationSettings           | ✅      |                                                  |
-| EmailFolder                           | ✅      |                                                  |
-| EmailIntegrationSettings              | ✅      |                                                  |
-| EmailServicesFunction                 | ✅      |                                                  |
-| EmailTemplate                         | ✅      |                                                  |
-| EmailTemplateFolder                   | ❌      | Not supported, but support could be added        |
-| EmailTemplateSettings                 | ✅      |                                                  |
-| EmbeddedServiceBranding               | ✅      |                                                  |
-| EmbeddedServiceConfig                 | ✅      |                                                  |
-| EmbeddedServiceFlowConfig             | ✅      |                                                  |
-| EmbeddedServiceLiveAgent              | ✅      |                                                  |
-| EmbeddedServiceMenuSettings           | ✅      |                                                  |
-| EmployeeDataSyncProfile               | ❌      | Not supported, but support could be added        |
-| EmployeeFieldAccessSettings           | ✅      |                                                  |
-| EmployeeUserSettings                  | ✅      |                                                  |
-| EnhancedNotesSettings                 | ✅      |                                                  |
-| EntitlementProcess                    | ✅      |                                                  |
-| EntitlementSettings                   | ✅      |                                                  |
-| EntitlementTemplate                   | ✅      |                                                  |
-| EntityImplements                      | ✅      |                                                  |
-| EscalationRules                       | ✅      |                                                  |
-| EssentialsSettings                    | ✅      |                                                  |
-| EventSettings                         | ✅      |                                                  |
-| ExperienceBundle                      | ✅      |                                                  |
-| ExperienceBundleSettings              | ✅      |                                                  |
-| ExplainabilityActionDefinition        | ❌      | Not supported, but support could be added        |
-| ExplainabilityActionVersion           | ❌      | Not supported, but support could be added        |
-| ExternalAIModel                       | ❌      | Not supported, but support could be added        |
-| ExternalCredential                    | ❌      | Not supported, but support could be added        |
-| ExternalDataConnector                 | ✅      |                                                  |
-| ExternalDataSource                    | ✅      |                                                  |
-| ExternalServiceRegistration           | ✅      |                                                  |
-| ExternalServicesSettings              | ✅      |                                                  |
-| FeatureParameterBoolean               | ✅      |                                                  |
-| FeatureParameterDate                  | ✅      |                                                  |
-| FeatureParameterInteger               | ✅      |                                                  |
-| FederationDataMappingUsage            | ✅      |                                                  |
-| FieldRestrictionRule                  | ✅      |                                                  |
-| FieldServiceMobileExtension           | ✅      |                                                  |
-| FieldServiceSettings                  | ✅      |                                                  |
-| FieldSet                              | ✅      |                                                  |
-| FieldSrcTrgtRelationship              | ✅      |                                                  |
-| FileUploadAndDownloadSecuritySettings | ✅      |                                                  |
-| FilesConnectSettings                  | ✅      |                                                  |
-| FlexiPage                             | ✅      |                                                  |
-| Flow                                  | ✅      |                                                  |
-| FlowCategory                          | ✅      |                                                  |
-| FlowDefinition                        | ⚠️      | Supports deploy/retrieve but not source tracking |
-| FlowSettings                          | ✅      |                                                  |
-| ForecastingObjectListSettings         | ✅      |                                                  |
-| ForecastingSettings                   | ✅      |                                                  |
-| ForecastingSourceDefinition           | ✅      |                                                  |
-| ForecastingType                       | ✅      |                                                  |
-| ForecastingTypeSource                 | ✅      |                                                  |
-| FormulaSettings                       | ✅      |                                                  |
-| FunctionReference                     | ⚠️      | Supports deploy/retrieve but not source tracking |
-| GatewayProviderPaymentMethodType      | ✅      |                                                  |
-| GlobalValueSet                        | ✅      |                                                  |
-| GlobalValueSetTranslation             | ✅      |                                                  |
-| GoogleAppsSettings                    | ✅      |                                                  |
-| Group                                 | ✅      |                                                  |
-| HighVelocitySalesSettings             | ✅      |                                                  |
-| HomePageComponent                     | ✅      |                                                  |
-| HomePageLayout                        | ✅      |                                                  |
-| IPAddressRange                        | ✅      |                                                  |
-| Icon                                  | ✅      |                                                  |
-| IdeasSettings                         | ✅      |                                                  |
-| IdentityVerificationProcDef           | ❌      | Not supported, but support could be added        |
-| IdentityVerificationProcDtl           | ❌      | Not supported, but support could be added        |
-| IdentityVerificationProcFld           | ❌      | Not supported, but support could be added        |
-| IframeWhiteListUrlSettings            | ✅      |                                                  |
-| InboundCertificate                    | ✅      |                                                  |
-| InboundNetworkConnection              | ✅      |                                                  |
-| IncidentMgmtSettings                  | ✅      |                                                  |
-| Index                                 | ⚠️      | Supports deploy/retrieve but not source tracking |
-| IndustriesLoyaltySettings             | ✅      |                                                  |
-| IndustriesManufacturingSettings       | ✅      |                                                  |
-| IndustriesSettings                    | ✅      |                                                  |
-| InstalledPackage                      | ⚠️      | Supports deploy/retrieve but not source tracking |
-| InterestTaggingSettings               | ✅      |                                                  |
-| InternalDataConnector                 | ❌      | Not supported, but support could be added        |
-| InventorySettings                     | ✅      |                                                  |
-| InvocableActionSettings               | ✅      |                                                  |
-| IoTSettings                           | ✅      |                                                  |
-| KeywordList                           | ✅      |                                                  |
-| KnowledgeSettings                     | ✅      |                                                  |
-| LanguageSettings                      | ✅      |                                                  |
-| Layout                                | ✅      |                                                  |
-| LeadConfigSettings                    | ✅      |                                                  |
-| LeadConvertSettings                   | ✅      |                                                  |
-| Letterhead                            | ✅      |                                                  |
-| LightningBolt                         | ✅      |                                                  |
-| LightningComponentBundle              | ✅      |                                                  |
-| LightningExperienceSettings           | ✅      |                                                  |
-| LightningExperienceTheme              | ✅      |                                                  |
-| LightningMessageChannel               | ✅      |                                                  |
-| LightningOnboardingConfig             | ✅      |                                                  |
-| ListView                              | ✅      |                                                  |
-| LiveAgentSettings                     | ✅      |                                                  |
-| LiveChatAgentConfig                   | ✅      |                                                  |
-| LiveChatButton                        | ✅      |                                                  |
-| LiveChatDeployment                    | ✅      |                                                  |
-| LiveChatSensitiveDataRule             | ✅      |                                                  |
-| LiveMessageSettings                   | ✅      |                                                  |
-| LoyaltyProgramSetup                   | ⚠️      | Supports deploy/retrieve but not source tracking |
-| MLDataDefinition                      | ✅      |                                                  |
-| MLPredictionDefinition                | ✅      |                                                  |
-| MLRecommendationDefinition            | ✅      |                                                  |
-| MacroSettings                         | ✅      |                                                  |
-| MailMergeSettings                     | ✅      |                                                  |
-| ManagedContentType                    | ⚠️      | Supports deploy/retrieve but not source tracking |
-| ManagedTopics                         | ✅      |                                                  |
-| MapsAndLocationSettings               | ✅      |                                                  |
-| MarketingAppExtActivity               | ❌      | Not supported, but support could be added        |
-| MarketingAppExtension                 | ❌      | Not supported, but support could be added        |
-| MatchingRules                         | ✅      |                                                  |
-| MediaAdSalesSettings                  | ✅      |                                                  |
-| MfgProgramTemplate                    | ❌      | Not supported, but support could be added        |
-| MilestoneType                         | ✅      |                                                  |
-| MktCalcInsightObjectDef               | ✅      |                                                  |
-| MktDataTranObject                     | ✅      |                                                  |
-| MlDomain                              | ✅      |                                                  |
-| MobSecurityCertPinConfig              | ❌      | Not supported, but support could be added        |
-| MobileApplicationDetail               | ✅      |                                                  |
-| MobileSecurityAssignment              | ❌      | Not supported, but support could be added        |
-| MobileSecurityPolicy                  | ❌      | Not supported, but support could be added        |
-| MobileSecurityPolicySet               | ❌      | Not supported, but support could be added        |
-| MobileSettings                        | ✅      |                                                  |
-| ModerationRule                        | ✅      |                                                  |
-| MutingPermissionSet                   | ✅      |                                                  |
-| MyDomainDiscoverableLogin             | ✅      |                                                  |
-| MyDomainSettings                      | ✅      |                                                  |
-| NameSettings                          | ✅      |                                                  |
-| NamedCredential                       | ✅      |                                                  |
-| NavigationMenu                        | ✅      |                                                  |
-| Network                               | ✅      |                                                  |
-| NetworkBranding                       | ✅      |                                                  |
-| NotificationTypeConfig                | ✅      |                                                  |
-| NotificationsSettings                 | ✅      |                                                  |
-| OauthCustomScope                      | ✅      |                                                  |
-| ObjectHierarchyRelationship           | ✅      |                                                  |
-| ObjectLinkingSettings                 | ✅      |                                                  |
-| ObjectSourceTargetMap                 | ✅      |                                                  |
-| OcrSampleDocument                     | ✅      |                                                  |
-| OcrTemplate                           | ✅      |                                                  |
-| OmniChannelSettings                   | ✅      |                                                  |
-| OmniDataTransform                     | ✅      |                                                  |
-| OmniIntegrationProcedure              | ✅      |                                                  |
-| OmniInteractionAccessConfig           | ❌      | Not supported, but support could be added        |
-| OmniInteractionConfig                 | ✅      |                                                  |
-| OmniScript                            | ✅      |                                                  |
-| OmniUiCard                            | ✅      |                                                  |
-| OnlineSalesSettings                   | ✅      |                                                  |
-| OpportunityInsightsSettings           | ✅      |                                                  |
-| OpportunityScoreSettings              | ✅      |                                                  |
-| OpportunitySettings                   | ✅      |                                                  |
-| OrderManagementSettings               | ✅      |                                                  |
-| OrderSettings                         | ✅      |                                                  |
-| OrgSettings                           | ✅      |                                                  |
-| OutboundNetworkConnection             | ✅      |                                                  |
-| PardotEinsteinSettings                | ✅      |                                                  |
-| PardotSettings                        | ✅      |                                                  |
-| ParticipantRole                       | ✅      |                                                  |
-| PartyDataModelSettings                | ✅      |                                                  |
-| PathAssistant                         | ✅      |                                                  |
-| PathAssistantSettings                 | ✅      |                                                  |
-| PaymentGatewayProvider                | ✅      |                                                  |
-| PermissionSet                         | ✅      |                                                  |
-| PermissionSetGroup                    | ✅      |                                                  |
-| PermissionSetLicenseDefinition        | ✅      |                                                  |
-| PicklistSettings                      | ✅      |                                                  |
-| PicklistValue                         | ❌      | Not supported, but support could be added        |
-| PlatformCachePartition                | ✅      |                                                  |
-| PlatformEventChannel                  | ✅      |                                                  |
-| PlatformEventChannelMember            | ✅      |                                                  |
-| PlatformEventSubscriberConfig         | ✅      |                                                  |
-| PlatformSlackSettings                 | ✅      |                                                  |
-| PortalsSettings                       | ✅      |                                                  |
-| PostTemplate                          | ✅      |                                                  |
-| PredictionBuilderSettings             | ✅      |                                                  |
-| PresenceDeclineReason                 | ✅      |                                                  |
-| PresenceUserConfig                    | ✅      |                                                  |
-| PrivacySettings                       | ✅      |                                                  |
-| ProductAttributeSet                   | ❌      | Not supported, but support could be added        |
-| ProductSettings                       | ✅      |                                                  |
-| Profile                               | ✅      |                                                  |
-| ProfilePasswordPolicy                 | ✅      |                                                  |
-| ProfileSessionSetting                 | ✅      |                                                  |
-| Prompt                                | ✅      |                                                  |
-| Queue                                 | ✅      |                                                  |
-| QueueRoutingConfig                    | ✅      |                                                  |
-| QuickAction                           | ✅      |                                                  |
-| QuickTextSettings                     | ✅      |                                                  |
-| QuoteSettings                         | ✅      |                                                  |
-| RealTimeEventSettings                 | ✅      |                                                  |
-| RecommendationBuilderSettings         | ✅      |                                                  |
-| RecommendationStrategy                | ✅      |                                                  |
-| RecordActionDeployment                | ✅      |                                                  |
-| RecordAlertCategory                   | ❌      | Not supported, but support could be added        |
-| RecordAlertDataSource                 | ❌      | Not supported, but support could be added        |
-| RecordPageSettings                    | ✅      |                                                  |
-| RecordType                            | ✅      |                                                  |
-| RedirectWhitelistUrl                  | ✅      |                                                  |
-| RelatedRecordAssocCriteria            | ❌      | Not supported, but support could be added        |
-| RemoteSiteSetting                     | ✅      |                                                  |
-| Report                                | ✅      |                                                  |
-| ReportFolder                          | ✅      |                                                  |
-| ReportType                            | ✅      |                                                  |
-| RestrictionRule                       | ✅      |                                                  |
-| RetailExecutionSettings               | ✅      |                                                  |
-| Role                                  | ✅      |                                                  |
-| SalesAgreementSettings                | ✅      |                                                  |
-| SalesWorkQueueSettings                | ✅      |                                                  |
-| SamlSsoConfig                         | ✅      |                                                  |
-| SchedulingRule                        | ✅      |                                                  |
-| SchemaSettings                        | ✅      |                                                  |
-| ScoreCategory                         | ❌      | Not supported, but support could be added        |
-| ScoreRange                            | ❌      | Not supported, but support could be added        |
-| SearchSettings                        | ✅      |                                                  |
-| SecuritySettings                      | ✅      |                                                  |
-| ServiceAISetupDefinition              | ❌      | Not supported, but support could be added        |
-| ServiceAISetupField                   | ❌      | Not supported, but support could be added        |
-| ServiceChannel                        | ✅      |                                                  |
-| ServiceCloudVoiceSettings             | ✅      |                                                  |
-| ServicePresenceStatus                 | ✅      |                                                  |
-| ServiceSetupAssistantSettings         | ✅      |                                                  |
-| SharingCriteriaRule                   | ✅      |                                                  |
-| SharingGuestRule                      | ✅      |                                                  |
-| SharingOwnerRule                      | ✅      |                                                  |
-| SharingReason                         | ✅      |                                                  |
-| SharingRules                          | ⚠️      | Supports deploy/retrieve but not source tracking |
-| SharingSet                            | ✅      |                                                  |
-| SharingSettings                       | ✅      |                                                  |
-| SharingTerritoryRule                  | ✅      |                                                  |
-| SiteDotCom                            | ✅      |                                                  |
-| SiteSettings                          | ✅      |                                                  |
-| Skill                                 | ✅      |                                                  |
-| SlackApp                              | ✅      |                                                  |
-| SocialCustomerServiceSettings         | ✅      |                                                  |
-| SocialProfileSettings                 | ✅      |                                                  |
-| SourceTrackingSettings                | ✅      |                                                  |
-| StandardValue                         | ❌      | Not supported, but support could be added        |
-| StandardValueSet                      | ✅      |                                                  |
-| StandardValueSetTranslation           | ✅      |                                                  |
-| StaticResource                        | ✅      |                                                  |
-| StnryAssetEnvSrcCnfg                  | ✅      |                                                  |
-| SurveySettings                        | ✅      |                                                  |
-| SvcCatalogCategory                    | ✅      |                                                  |
-| SvcCatalogFulfillmentFlow             | ✅      |                                                  |
-| SvcCatalogItemDef                     | ✅      |                                                  |
-| SynonymDictionary                     | ✅      |                                                  |
-| SystemNotificationSettings            | ✅      |                                                  |
-| Territory                             | ✅      |                                                  |
-| Territory2                            | ✅      |                                                  |
-| Territory2Model                       | ✅      |                                                  |
-| Territory2Rule                        | ✅      |                                                  |
-| Territory2Settings                    | ✅      |                                                  |
-| Territory2Type                        | ✅      |                                                  |
-| TimeSheetTemplate                     | ✅      |                                                  |
-| TimelineObjectDefinition              | ❌      | Not supported, but support could be added        |
-| TopicsForObjects                      | ✅      |                                                  |
-| TrailheadSettings                     | ✅      |                                                  |
-| TransactionSecurityPolicy             | ✅      |                                                  |
-| Translations                          | ✅      |                                                  |
-| TrialOrgSettings                      | ✅      |                                                  |
-| UIObjectRelationConfig                | ✅      |                                                  |
-| UiPlugin                              | ✅      |                                                  |
-| UserAuthCertificate                   | ✅      |                                                  |
-| UserCriteria                          | ✅      |                                                  |
-| UserEngagementSettings                | ✅      |                                                  |
-| UserInterfaceSettings                 | ✅      |                                                  |
-| UserManagementSettings                | ✅      |                                                  |
-| UserProfileSearchScope                | ✅      |                                                  |
-| UserProvisioningConfig                | ✅      |                                                  |
-| ValidationRule                        | ✅      |                                                  |
-| VehicleAssetEmssnSrcCnfg              | ✅      |                                                  |
-| ViewDefinition                        | ✅      |                                                  |
-| VirtualVisitConfig                    | ❌      | Not supported, but support could be added        |
-| WaveApplication                       | ✅      |                                                  |
-| WaveComponent                         | ✅      |                                                  |
-| WaveDashboard                         | ✅      |                                                  |
-| WaveDataflow                          | ✅      |                                                  |
-| WaveDataset                           | ✅      |                                                  |
-| WaveLens                              | ✅      |                                                  |
-| WaveRecipe                            | ✅      |                                                  |
-| WaveTemplateBundle                    | ✅      |                                                  |
-| WaveXmd                               | ✅      |                                                  |
-| WebLink                               | ✅      |                                                  |
-| WebStoreTemplate                      | ✅      |                                                  |
-| WebToXSettings                        | ✅      |                                                  |
-| WorkDotComSettings                    | ✅      |                                                  |
-| WorkSkillRouting                      | ✅      |                                                  |
-| Workflow                              | ✅      |                                                  |
-| WorkflowAlert                         | ✅      |                                                  |
-| WorkflowFieldUpdate                   | ✅      |                                                  |
-| WorkflowFlowAction                    | ❌      | Not supported, but support could be added        |
-| WorkflowKnowledgePublish              | ✅      |                                                  |
-| WorkflowOutboundMessage               | ✅      |                                                  |
-| WorkflowRule                          | ✅      |                                                  |
-| WorkflowSend                          | ✅      |                                                  |
-| WorkflowTask                          | ✅      |                                                  |
-| WorkforceEngagementSettings           | ✅      |                                                  |
+|Metadata Type|Support|Notes|
+|:---|:---|:---|
+|AIApplication|✅||
+|AIApplicationConfig|✅||
+|AIReplyRecommendationsSettings|✅||
+|AccountForecastSettings|✅||
+|AccountInsightsSettings|✅||
+|AccountIntelligenceSettings|✅||
+|AccountRelationshipShareRule|✅||
+|AccountSettings|✅||
+|AcctMgrTargetSettings|✅||
+|ActionLinkGroupTemplate|✅||
+|ActionPlanTemplate|✅||
+|ActionsSettings|✅||
+|ActivationPlatform|❌|Not supported, but support could be added|
+|ActivitiesSettings|✅||
+|AddressSettings|✅||
+|AdvAccountForecastSet|✅||
+|AdvAcctForecastDimSource|❌|Not supported, but support could be added|
+|AdvAcctForecastPeriodGroup|✅||
+|AnalyticSnapshot|✅||
+|AnalyticsDataServicesSettings|✅||
+|AnalyticsSettings|✅||
+|AnimationRule|✅||
+|ApexClass|✅||
+|ApexComponent|✅||
+|ApexEmailNotifications|✅||
+|ApexPage|✅||
+|ApexSettings|✅||
+|ApexTestSuite|✅||
+|ApexTrigger|✅||
+|AppAnalyticsSettings|✅||
+|AppExperienceSettings|✅||
+|AppMenu|✅||
+|ApplicationRecordTypeConfig|✅||
+|ApplicationSubtypeDefinition|❌|Not supported, but support could be added|
+|AppointmentAssignmentPolicy|❌|Not supported, but support could be added|
+|AppointmentSchedulingPolicy|✅||
+|ApprovalProcess|✅||
+|ArchiveSettings|✅||
+|AssignmentRules|✅||
+|AssistantContextItem|✅||
+|AssistantDefinition|✅||
+|AssistantSkillQuickAction|✅||
+|AssistantSkillSobjectAction|✅||
+|AssistantVersion|✅||
+|AssociationEngineSettings|✅||
+|AttributeDefinition2|❌|Not supported, but support could be added|
+|Audience|✅||
+|AuraDefinitionBundle|✅||
+|AuthProvider|✅||
+|AutoResponseRules|✅||
+|AutomatedContactsSettings|✅||
+|BatchCalcJobDefinition|✅||
+|BatchProcessJobDefinition|✅||
+|BenefitAction|✅||
+|BlacklistedConsumer|✅||
+|BldgEnrgyIntensityCnfg|✅||
+|BlockchainSettings|✅||
+|Bot|✅||
+|BotSettings|✅||
+|BotVersion|✅||
+|BranchManagementSettings|✅||
+|BrandingSet|✅||
+|BriefcaseDefinition|✅||
+|BusinessHoursSettings|✅||
+|BusinessProcess|✅||
+|BusinessProcessGroup|✅||
+|BusinessProcessTypeDefinition|❌|Not supported, but support could be added|
+|CMSConnectSource|✅||
+|CallCenter|✅||
+|CallCenterRoutingMap|✅||
+|CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
+|CampaignInfluenceModel|✅||
+|CampaignSettings|✅||
+|CanvasMetadata|✅||
+|CareBenefitVerifySettings|✅||
+|CareLimitType|❌|Not supported, but support could be added|
+|CareProviderSearchConfig|✅||
+|CareRequestConfiguration|✅||
+|CareSystemFieldMapping|✅||
+|CaseSettings|✅||
+|CaseSubjectParticle|✅||
+|Certificate|✅||
+|ChannelLayout|✅||
+|ChannelObjectLinkingRule|✅||
+|ChatterAnswersSettings|✅||
+|ChatterEmailsMDSettings|✅||
+|ChatterExtension|✅||
+|ChatterSettings|✅||
+|CleanDataService|✅||
+|CommandAction|✅||
+|CommerceSettings|✅||
+|CommunitiesSettings|✅||
+|Community|✅||
+|CommunityTemplateDefinition|✅||
+|CommunityThemeDefinition|✅||
+|CompactLayout|✅||
+|CompanySettings|✅||
+|ConnectedApp|✅||
+|ConnectedAppSettings|✅||
+|ConnectedSystem|✅||
+|ContentAsset|✅||
+|ContentSettings|✅||
+|ContractSettings|✅||
+|ContractType|❌|Not supported, but support could be added|
+|ConversationVendorInfo|✅||
+|ConversationalIntelligenceSettings|✅||
+|CorsWhitelistOrigin|✅||
+|CspTrustedSite|✅||
+|CurrencySettings|✅||
+|CustomApplication|✅||
+|CustomApplicationComponent|✅||
+|CustomFeedFilter|✅||
+|CustomField|✅||
+|CustomHelpMenuSection|✅||
+|CustomIndex|✅||
+|CustomLabels|✅||
+|CustomMetadata|✅||
+|CustomNotificationType|✅||
+|CustomObject|✅||
+|CustomObjectTranslation|✅||
+|CustomPageWebLink|✅||
+|CustomPermission|✅||
+|CustomSite|✅||
+|CustomTab|✅||
+|CustomValue|❌|Not supported, but support could be added|
+|CustomerDataPlatformSettings|✅||
+|Dashboard|✅||
+|DashboardFolder|✅||
+|DataCategoryGroup|✅||
+|DataConnectorS3|✅||
+|DataDotComSettings|✅||
+|DataMapping|✅||
+|DataMappingFieldDefinition|✅||
+|DataMappingObjectDefinition|✅||
+|DataMappingSchema|✅||
+|DataSource|✅||
+|DataSourceObject|✅||
+|DataSourceTenant|❌|Not supported, but support could be added|
+|DataStreamDefinition|✅||
+|DecisionTable|✅||
+|DecisionTableDatasetLink|✅||
+|DelegateGroup|✅||
+|DeploymentSettings|✅||
+|DevHubSettings|✅||
+|DiscoveryAIModel|✅||
+|DiscoveryGoal|✅||
+|DiscoverySettings|✅||
+|DiscoveryStory|❌|Not supported, but support could be added|
+|Document|✅||
+|DocumentChecklistSettings|✅||
+|DocumentFolder|✅||
+|DocumentGenerationSetting|✅||
+|DocumentType|✅||
+|DuplicateRule|✅||
+|EACSettings|✅||
+|ESignatureConfig|❌|Not supported, but support could be added|
+|ESignatureEnvelopeConfig|❌|Not supported, but support could be added|
+|EclairGeoData|✅||
+|EinsteinAgentSettings|✅||
+|EinsteinAssistantSettings|✅||
+|EinsteinDealInsightsSettings|✅||
+|EinsteinDocumentCaptureSettings|✅||
+|EmailAdministrationSettings|✅||
+|EmailFolder|✅||
+|EmailIntegrationSettings|✅||
+|EmailServicesFunction|✅||
+|EmailTemplate|✅||
+|EmailTemplateFolder|❌|Not supported, but support could be added|
+|EmailTemplateSettings|✅||
+|EmbeddedServiceBranding|✅||
+|EmbeddedServiceConfig|✅||
+|EmbeddedServiceFlowConfig|✅||
+|EmbeddedServiceLiveAgent|✅||
+|EmbeddedServiceMenuSettings|✅||
+|EmployeeDataSyncProfile|❌|Not supported, but support could be added|
+|EmployeeFieldAccessSettings|✅||
+|EmployeeUserSettings|✅||
+|EnhancedNotesSettings|✅||
+|EntitlementProcess|✅||
+|EntitlementSettings|✅||
+|EntitlementTemplate|✅||
+|EntityImplements|✅||
+|EscalationRules|✅||
+|EssentialsSettings|✅||
+|EventSettings|✅||
+|ExperienceBundle|✅||
+|ExperienceBundleSettings|✅||
+|ExplainabilityActionDefinition|❌|Not supported, but support could be added|
+|ExplainabilityActionVersion|❌|Not supported, but support could be added|
+|ExternalAIModel|❌|Not supported, but support could be added|
+|ExternalCredential|❌|Not supported, but support could be added|
+|ExternalDataConnector|✅||
+|ExternalDataSource|✅||
+|ExternalServiceRegistration|✅||
+|ExternalServicesSettings|✅||
+|FeatureParameterBoolean|✅||
+|FeatureParameterDate|✅||
+|FeatureParameterInteger|✅||
+|FederationDataMappingUsage|✅||
+|FieldRestrictionRule|✅||
+|FieldServiceMobileExtension|✅||
+|FieldServiceSettings|✅||
+|FieldSet|✅||
+|FieldSrcTrgtRelationship|✅||
+|FileUploadAndDownloadSecuritySettings|✅||
+|FilesConnectSettings|✅||
+|FlexiPage|✅||
+|Flow|✅||
+|FlowCategory|✅||
+|FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|FlowSettings|✅||
+|ForecastingObjectListSettings|✅||
+|ForecastingSettings|✅||
+|ForecastingSourceDefinition|✅||
+|ForecastingType|✅||
+|ForecastingTypeSource|✅||
+|FormulaSettings|✅||
+|FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
+|GatewayProviderPaymentMethodType|✅||
+|GlobalValueSet|✅||
+|GlobalValueSetTranslation|✅||
+|GoogleAppsSettings|✅||
+|Group|✅||
+|HighVelocitySalesSettings|✅||
+|HomePageComponent|✅||
+|HomePageLayout|✅||
+|IPAddressRange|✅||
+|Icon|✅||
+|IdeasSettings|✅||
+|IdentityVerificationProcDef|❌|Not supported, but support could be added|
+|IdentityVerificationProcDtl|❌|Not supported, but support could be added|
+|IdentityVerificationProcFld|❌|Not supported, but support could be added|
+|IframeWhiteListUrlSettings|✅||
+|InboundCertificate|✅||
+|InboundNetworkConnection|✅||
+|IncidentMgmtSettings|✅||
+|Index|⚠️|Supports deploy/retrieve but not source tracking|
+|IndustriesLoyaltySettings|✅||
+|IndustriesManufacturingSettings|✅||
+|IndustriesSettings|✅||
+|InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
+|InterestTaggingSettings|✅||
+|InternalDataConnector|❌|Not supported, but support could be added|
+|InventorySettings|✅||
+|InvocableActionSettings|✅||
+|IoTSettings|✅||
+|KeywordList|✅||
+|KnowledgeSettings|✅||
+|LanguageSettings|✅||
+|Layout|✅||
+|LeadConfigSettings|✅||
+|LeadConvertSettings|✅||
+|Letterhead|✅||
+|LightningBolt|✅||
+|LightningComponentBundle|✅||
+|LightningExperienceSettings|✅||
+|LightningExperienceTheme|✅||
+|LightningMessageChannel|✅||
+|LightningOnboardingConfig|✅||
+|ListView|✅||
+|LiveAgentSettings|✅||
+|LiveChatAgentConfig|✅||
+|LiveChatButton|✅||
+|LiveChatDeployment|✅||
+|LiveChatSensitiveDataRule|✅||
+|LiveMessageSettings|✅||
+|LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
+|MLDataDefinition|✅||
+|MLPredictionDefinition|✅||
+|MLRecommendationDefinition|✅||
+|MacroSettings|✅||
+|MailMergeSettings|✅||
+|ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
+|ManagedTopics|✅||
+|MapsAndLocationSettings|✅||
+|MarketingAppExtActivity|❌|Not supported, but support could be added|
+|MarketingAppExtension|❌|Not supported, but support could be added|
+|MatchingRules|✅||
+|MediaAdSalesSettings|✅||
+|MfgProgramTemplate|❌|Not supported, but support could be added|
+|MilestoneType|✅||
+|MktCalcInsightObjectDef|✅||
+|MktDataTranObject|✅||
+|MlDomain|✅||
+|MobSecurityCertPinConfig|❌|Not supported, but support could be added|
+|MobileApplicationDetail|✅||
+|MobileSecurityAssignment|❌|Not supported, but support could be added|
+|MobileSecurityPolicy|❌|Not supported, but support could be added|
+|MobileSecurityPolicySet|❌|Not supported, but support could be added|
+|MobileSettings|✅||
+|ModerationRule|✅||
+|MutingPermissionSet|✅||
+|MyDomainDiscoverableLogin|✅||
+|MyDomainSettings|✅||
+|NameSettings|✅||
+|NamedCredential|✅||
+|NavigationMenu|✅||
+|Network|✅||
+|NetworkBranding|✅||
+|NotificationTypeConfig|✅||
+|NotificationsSettings|✅||
+|OauthCustomScope|✅||
+|ObjectHierarchyRelationship|✅||
+|ObjectLinkingSettings|✅||
+|ObjectSourceTargetMap|✅||
+|OcrSampleDocument|✅||
+|OcrTemplate|✅||
+|OmniChannelSettings|✅||
+|OmniDataTransform|✅||
+|OmniIntegrationProcedure|✅||
+|OmniInteractionAccessConfig|❌|Not supported, but support could be added|
+|OmniInteractionConfig|✅||
+|OmniScript|✅||
+|OmniUiCard|✅||
+|OnlineSalesSettings|✅||
+|OpportunityInsightsSettings|✅||
+|OpportunityScoreSettings|✅||
+|OpportunitySettings|✅||
+|OrderManagementSettings|✅||
+|OrderSettings|✅||
+|OrgSettings|✅||
+|OutboundNetworkConnection|✅||
+|PardotEinsteinSettings|✅||
+|PardotSettings|✅||
+|ParticipantRole|✅||
+|PartyDataModelSettings|✅||
+|PathAssistant|✅||
+|PathAssistantSettings|✅||
+|PaymentGatewayProvider|✅||
+|PermissionSet|✅||
+|PermissionSetGroup|✅||
+|PermissionSetLicenseDefinition|✅||
+|PicklistSettings|✅||
+|PicklistValue|❌|Not supported, but support could be added|
+|PlatformCachePartition|✅||
+|PlatformEventChannel|✅||
+|PlatformEventChannelMember|✅||
+|PlatformEventSubscriberConfig|✅||
+|PlatformSlackSettings|✅||
+|PortalsSettings|✅||
+|PostTemplate|✅||
+|PredictionBuilderSettings|✅||
+|PresenceDeclineReason|✅||
+|PresenceUserConfig|✅||
+|PrivacySettings|✅||
+|ProductAttributeSet|❌|Not supported, but support could be added|
+|ProductSettings|✅||
+|Profile|✅||
+|ProfilePasswordPolicy|✅||
+|ProfileSessionSetting|✅||
+|Prompt|✅||
+|Queue|✅||
+|QueueRoutingConfig|✅||
+|QuickAction|✅||
+|QuickTextSettings|✅||
+|QuoteSettings|✅||
+|RealTimeEventSettings|✅||
+|RecommendationBuilderSettings|✅||
+|RecommendationStrategy|✅||
+|RecordActionDeployment|✅||
+|RecordAlertCategory|❌|Not supported, but support could be added|
+|RecordAlertDataSource|❌|Not supported, but support could be added|
+|RecordPageSettings|✅||
+|RecordType|✅||
+|RedirectWhitelistUrl|✅||
+|RelatedRecordAssocCriteria|❌|Not supported, but support could be added|
+|RemoteSiteSetting|✅||
+|Report|✅||
+|ReportFolder|✅||
+|ReportType|✅||
+|RestrictionRule|✅||
+|RetailExecutionSettings|✅||
+|Role|✅||
+|SalesAgreementSettings|✅||
+|SalesWorkQueueSettings|✅||
+|SamlSsoConfig|✅||
+|SchedulingRule|✅||
+|SchemaSettings|✅||
+|ScoreCategory|❌|Not supported, but support could be added|
+|ScoreRange|❌|Not supported, but support could be added|
+|SearchSettings|✅||
+|SecuritySettings|✅||
+|ServiceAISetupDefinition|❌|Not supported, but support could be added|
+|ServiceAISetupField|❌|Not supported, but support could be added|
+|ServiceChannel|✅||
+|ServiceCloudVoiceSettings|✅||
+|ServicePresenceStatus|✅||
+|ServiceSetupAssistantSettings|✅||
+|SharingCriteriaRule|✅||
+|SharingGuestRule|✅||
+|SharingOwnerRule|✅||
+|SharingReason|✅||
+|SharingRules|⚠️|Supports deploy/retrieve but not source tracking|
+|SharingSet|✅||
+|SharingSettings|✅||
+|SharingTerritoryRule|✅||
+|SiteDotCom|✅||
+|SiteSettings|✅||
+|Skill|✅||
+|SlackApp|✅||
+|SocialCustomerServiceSettings|✅||
+|SocialProfileSettings|✅||
+|SourceTrackingSettings|✅||
+|StandardValue|❌|Not supported, but support could be added|
+|StandardValueSet|✅||
+|StandardValueSetTranslation|✅||
+|StaticResource|✅||
+|StnryAssetEnvSrcCnfg|✅||
+|SurveySettings|✅||
+|SvcCatalogCategory|✅||
+|SvcCatalogFulfillmentFlow|✅||
+|SvcCatalogItemDef|✅||
+|SynonymDictionary|✅||
+|SystemNotificationSettings|✅||
+|Territory|✅||
+|Territory2|✅||
+|Territory2Model|✅||
+|Territory2Rule|✅||
+|Territory2Settings|✅||
+|Territory2Type|✅||
+|TimeSheetTemplate|✅||
+|TimelineObjectDefinition|❌|Not supported, but support could be added|
+|TopicsForObjects|✅||
+|TrailheadSettings|✅||
+|TransactionSecurityPolicy|✅||
+|Translations|✅||
+|TrialOrgSettings|✅||
+|UIObjectRelationConfig|✅||
+|UiPlugin|✅||
+|UserAuthCertificate|✅||
+|UserCriteria|✅||
+|UserEngagementSettings|✅||
+|UserInterfaceSettings|✅||
+|UserManagementSettings|✅||
+|UserProfileSearchScope|✅||
+|UserProvisioningConfig|✅||
+|ValidationRule|✅||
+|VehicleAssetEmssnSrcCnfg|✅||
+|ViewDefinition|✅||
+|VirtualVisitConfig|❌|Not supported, but support could be added|
+|WaveApplication|✅||
+|WaveComponent|✅||
+|WaveDashboard|✅||
+|WaveDataflow|✅||
+|WaveDataset|✅||
+|WaveLens|✅||
+|WaveRecipe|✅||
+|WaveTemplateBundle|✅||
+|WaveXmd|✅||
+|WebLink|✅||
+|WebStoreTemplate|✅||
+|WebToXSettings|✅||
+|WorkDotComSettings|✅||
+|WorkSkillRouting|✅||
+|Workflow|✅||
+|WorkflowAlert|✅||
+|WorkflowFieldUpdate|✅||
+|WorkflowFlowAction|❌|Not supported, but support could be added|
+|WorkflowKnowledgePublish|✅||
+|WorkflowOutboundMessage|✅||
+|WorkflowRule|✅||
+|WorkflowSend|✅||
+|WorkflowTask|✅||
+|WorkforceEngagementSettings|✅||
+
+
 
 ## Next Release (v55)
+v55 introduces the following new types.  Here's their current level of support
 
-v55 introduces the following new types. Here's their current level of support
-
-| Metadata Type | Support | Notes |
-| :------------ | :------ | :---- |
+|Metadata Type|Support|Notes|
+|:---|:---|:---|
+|Experience|undefined|undefined|
 
 ## Additional Types
 
-> The following types are supported by this library but not in the coverage reports for either version. These are typically
+> The following types are supported by this library but not in the coverage reports for either version.  These are typically
 >
 > 1. types that have been removed from the metadata API but were supported in previous versions
 > 1. types that are available for pilots but not officially part of the metadata API (use with caution)

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -482,6 +482,7 @@ v55 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|Experience|undefined|undefined|
 
 ## Additional Types
 

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -8,485 +8,483 @@ Currently, there are 420/464 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|AIApplication|✅||
-|AIApplicationConfig|✅||
-|AIReplyRecommendationsSettings|✅||
-|AccountForecastSettings|✅||
-|AccountInsightsSettings|✅||
-|AccountIntelligenceSettings|✅||
-|AccountRelationshipShareRule|✅||
-|AccountSettings|✅||
-|AcctMgrTargetSettings|✅||
-|ActionLinkGroupTemplate|✅||
-|ActionPlanTemplate|✅||
-|ActionsSettings|✅||
-|ActivationPlatform|❌|Not supported, but support could be added|
-|ActivitiesSettings|✅||
-|AddressSettings|✅||
-|AdvAccountForecastSet|✅||
-|AdvAcctForecastDimSource|❌|Not supported, but support could be added|
-|AdvAcctForecastPeriodGroup|✅||
-|AnalyticSnapshot|✅||
-|AnalyticsDataServicesSettings|✅||
-|AnalyticsSettings|✅||
-|AnimationRule|✅||
-|ApexClass|✅||
-|ApexComponent|✅||
-|ApexEmailNotifications|✅||
-|ApexPage|✅||
-|ApexSettings|✅||
-|ApexTestSuite|✅||
-|ApexTrigger|✅||
-|AppAnalyticsSettings|✅||
-|AppExperienceSettings|✅||
-|AppMenu|✅||
-|ApplicationRecordTypeConfig|✅||
-|ApplicationSubtypeDefinition|❌|Not supported, but support could be added|
-|AppointmentAssignmentPolicy|❌|Not supported, but support could be added|
-|AppointmentSchedulingPolicy|✅||
-|ApprovalProcess|✅||
-|ArchiveSettings|✅||
-|AssignmentRules|✅||
-|AssistantContextItem|✅||
-|AssistantDefinition|✅||
-|AssistantSkillQuickAction|✅||
-|AssistantSkillSobjectAction|✅||
-|AssistantVersion|✅||
-|AssociationEngineSettings|✅||
-|AttributeDefinition2|❌|Not supported, but support could be added|
-|Audience|✅||
-|AuraDefinitionBundle|✅||
-|AuthProvider|✅||
-|AutoResponseRules|✅||
-|AutomatedContactsSettings|✅||
-|BatchCalcJobDefinition|✅||
-|BatchProcessJobDefinition|✅||
-|BenefitAction|✅||
-|BlacklistedConsumer|✅||
-|BldgEnrgyIntensityCnfg|✅||
-|BlockchainSettings|✅||
-|Bot|✅||
-|BotSettings|✅||
-|BotVersion|✅||
-|BranchManagementSettings|✅||
-|BrandingSet|✅||
-|BriefcaseDefinition|✅||
-|BusinessHoursSettings|✅||
-|BusinessProcess|✅||
-|BusinessProcessGroup|✅||
-|BusinessProcessTypeDefinition|❌|Not supported, but support could be added|
-|CMSConnectSource|✅||
-|CallCenter|✅||
-|CallCenterRoutingMap|✅||
-|CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
-|CampaignInfluenceModel|✅||
-|CampaignSettings|✅||
-|CanvasMetadata|✅||
-|CareBenefitVerifySettings|✅||
-|CareLimitType|❌|Not supported, but support could be added|
-|CareProviderSearchConfig|✅||
-|CareRequestConfiguration|✅||
-|CareSystemFieldMapping|✅||
-|CaseSettings|✅||
-|CaseSubjectParticle|✅||
-|Certificate|✅||
-|ChannelLayout|✅||
-|ChannelObjectLinkingRule|✅||
-|ChatterAnswersSettings|✅||
-|ChatterEmailsMDSettings|✅||
-|ChatterExtension|✅||
-|ChatterSettings|✅||
-|CleanDataService|✅||
-|CommandAction|✅||
-|CommerceSettings|✅||
-|CommunitiesSettings|✅||
-|Community|✅||
-|CommunityTemplateDefinition|✅||
-|CommunityThemeDefinition|✅||
-|CompactLayout|✅||
-|CompanySettings|✅||
-|ConnectedApp|✅||
-|ConnectedAppSettings|✅||
-|ConnectedSystem|✅||
-|ContentAsset|✅||
-|ContentSettings|✅||
-|ContractSettings|✅||
-|ContractType|❌|Not supported, but support could be added|
-|ConversationVendorInfo|✅||
-|ConversationalIntelligenceSettings|✅||
-|CorsWhitelistOrigin|✅||
-|CspTrustedSite|✅||
-|CurrencySettings|✅||
-|CustomApplication|✅||
-|CustomApplicationComponent|✅||
-|CustomFeedFilter|✅||
-|CustomField|✅||
-|CustomHelpMenuSection|✅||
-|CustomIndex|✅||
-|CustomLabels|✅||
-|CustomMetadata|✅||
-|CustomNotificationType|✅||
-|CustomObject|✅||
-|CustomObjectTranslation|✅||
-|CustomPageWebLink|✅||
-|CustomPermission|✅||
-|CustomSite|✅||
-|CustomTab|✅||
-|CustomValue|❌|Not supported, but support could be added|
-|CustomerDataPlatformSettings|✅||
-|Dashboard|✅||
-|DashboardFolder|✅||
-|DataCategoryGroup|✅||
-|DataConnectorS3|✅||
-|DataDotComSettings|✅||
-|DataMapping|✅||
-|DataMappingFieldDefinition|✅||
-|DataMappingObjectDefinition|✅||
-|DataMappingSchema|✅||
-|DataSource|✅||
-|DataSourceObject|✅||
-|DataSourceTenant|❌|Not supported, but support could be added|
-|DataStreamDefinition|✅||
-|DecisionTable|✅||
-|DecisionTableDatasetLink|✅||
-|DelegateGroup|✅||
-|DeploymentSettings|✅||
-|DevHubSettings|✅||
-|DiscoveryAIModel|✅||
-|DiscoveryGoal|✅||
-|DiscoverySettings|✅||
-|DiscoveryStory|❌|Not supported, but support could be added|
-|Document|✅||
-|DocumentChecklistSettings|✅||
-|DocumentFolder|✅||
-|DocumentGenerationSetting|✅||
-|DocumentType|✅||
-|DuplicateRule|✅||
-|EACSettings|✅||
-|ESignatureConfig|❌|Not supported, but support could be added|
-|ESignatureEnvelopeConfig|❌|Not supported, but support could be added|
-|EclairGeoData|✅||
-|EinsteinAgentSettings|✅||
-|EinsteinAssistantSettings|✅||
-|EinsteinDealInsightsSettings|✅||
-|EinsteinDocumentCaptureSettings|✅||
-|EmailAdministrationSettings|✅||
-|EmailFolder|✅||
-|EmailIntegrationSettings|✅||
-|EmailServicesFunction|✅||
-|EmailTemplate|✅||
-|EmailTemplateFolder|❌|Not supported, but support could be added|
-|EmailTemplateSettings|✅||
-|EmbeddedServiceBranding|✅||
-|EmbeddedServiceConfig|✅||
-|EmbeddedServiceFlowConfig|✅||
-|EmbeddedServiceLiveAgent|✅||
-|EmbeddedServiceMenuSettings|✅||
-|EmployeeDataSyncProfile|❌|Not supported, but support could be added|
-|EmployeeFieldAccessSettings|✅||
-|EmployeeUserSettings|✅||
-|EnhancedNotesSettings|✅||
-|EntitlementProcess|✅||
-|EntitlementSettings|✅||
-|EntitlementTemplate|✅||
-|EntityImplements|✅||
-|EscalationRules|✅||
-|EssentialsSettings|✅||
-|EventSettings|✅||
-|ExperienceBundle|✅||
-|ExperienceBundleSettings|✅||
-|ExplainabilityActionDefinition|❌|Not supported, but support could be added|
-|ExplainabilityActionVersion|❌|Not supported, but support could be added|
-|ExternalAIModel|❌|Not supported, but support could be added|
-|ExternalCredential|❌|Not supported, but support could be added|
-|ExternalDataConnector|✅||
-|ExternalDataSource|✅||
-|ExternalServiceRegistration|✅||
-|ExternalServicesSettings|✅||
-|FeatureParameterBoolean|✅||
-|FeatureParameterDate|✅||
-|FeatureParameterInteger|✅||
-|FederationDataMappingUsage|✅||
-|FieldRestrictionRule|✅||
-|FieldServiceMobileExtension|✅||
-|FieldServiceSettings|✅||
-|FieldSet|✅||
-|FieldSrcTrgtRelationship|✅||
-|FileUploadAndDownloadSecuritySettings|✅||
-|FilesConnectSettings|✅||
-|FlexiPage|✅||
-|Flow|✅||
-|FlowCategory|✅||
-|FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|FlowSettings|✅||
-|ForecastingObjectListSettings|✅||
-|ForecastingSettings|✅||
-|ForecastingSourceDefinition|✅||
-|ForecastingType|✅||
-|ForecastingTypeSource|✅||
-|FormulaSettings|✅||
-|FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
-|GatewayProviderPaymentMethodType|✅||
-|GlobalValueSet|✅||
-|GlobalValueSetTranslation|✅||
-|GoogleAppsSettings|✅||
-|Group|✅||
-|HighVelocitySalesSettings|✅||
-|HomePageComponent|✅||
-|HomePageLayout|✅||
-|IPAddressRange|✅||
-|Icon|✅||
-|IdeasSettings|✅||
-|IdentityVerificationProcDef|❌|Not supported, but support could be added|
-|IdentityVerificationProcDtl|❌|Not supported, but support could be added|
-|IdentityVerificationProcFld|❌|Not supported, but support could be added|
-|IframeWhiteListUrlSettings|✅||
-|InboundCertificate|✅||
-|InboundNetworkConnection|✅||
-|IncidentMgmtSettings|✅||
-|Index|⚠️|Supports deploy/retrieve but not source tracking|
-|IndustriesLoyaltySettings|✅||
-|IndustriesManufacturingSettings|✅||
-|IndustriesSettings|✅||
-|InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
-|InterestTaggingSettings|✅||
-|InternalDataConnector|❌|Not supported, but support could be added|
-|InventorySettings|✅||
-|InvocableActionSettings|✅||
-|IoTSettings|✅||
-|KeywordList|✅||
-|KnowledgeSettings|✅||
-|LanguageSettings|✅||
-|Layout|✅||
-|LeadConfigSettings|✅||
-|LeadConvertSettings|✅||
-|Letterhead|✅||
-|LightningBolt|✅||
-|LightningComponentBundle|✅||
-|LightningExperienceSettings|✅||
-|LightningExperienceTheme|✅||
-|LightningMessageChannel|✅||
-|LightningOnboardingConfig|✅||
-|ListView|✅||
-|LiveAgentSettings|✅||
-|LiveChatAgentConfig|✅||
-|LiveChatButton|✅||
-|LiveChatDeployment|✅||
-|LiveChatSensitiveDataRule|✅||
-|LiveMessageSettings|✅||
-|LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
-|MLDataDefinition|✅||
-|MLPredictionDefinition|✅||
-|MLRecommendationDefinition|✅||
-|MacroSettings|✅||
-|MailMergeSettings|✅||
-|ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
-|ManagedTopics|✅||
-|MapsAndLocationSettings|✅||
-|MarketingAppExtActivity|❌|Not supported, but support could be added|
-|MarketingAppExtension|❌|Not supported, but support could be added|
-|MatchingRules|✅||
-|MediaAdSalesSettings|✅||
-|MfgProgramTemplate|❌|Not supported, but support could be added|
-|MilestoneType|✅||
-|MktCalcInsightObjectDef|✅||
-|MktDataTranObject|✅||
-|MlDomain|✅||
-|MobSecurityCertPinConfig|❌|Not supported, but support could be added|
-|MobileApplicationDetail|✅||
-|MobileSecurityAssignment|❌|Not supported, but support could be added|
-|MobileSecurityPolicy|❌|Not supported, but support could be added|
-|MobileSecurityPolicySet|❌|Not supported, but support could be added|
-|MobileSettings|✅||
-|ModerationRule|✅||
-|MutingPermissionSet|✅||
-|MyDomainDiscoverableLogin|✅||
-|MyDomainSettings|✅||
-|NameSettings|✅||
-|NamedCredential|✅||
-|NavigationMenu|✅||
-|Network|✅||
-|NetworkBranding|✅||
-|NotificationTypeConfig|✅||
-|NotificationsSettings|✅||
-|OauthCustomScope|✅||
-|ObjectHierarchyRelationship|✅||
-|ObjectLinkingSettings|✅||
-|ObjectSourceTargetMap|✅||
-|OcrSampleDocument|✅||
-|OcrTemplate|✅||
-|OmniChannelSettings|✅||
-|OmniDataTransform|✅||
-|OmniIntegrationProcedure|✅||
-|OmniInteractionAccessConfig|❌|Not supported, but support could be added|
-|OmniInteractionConfig|✅||
-|OmniScript|✅||
-|OmniUiCard|✅||
-|OnlineSalesSettings|✅||
-|OpportunityInsightsSettings|✅||
-|OpportunityScoreSettings|✅||
-|OpportunitySettings|✅||
-|OrderManagementSettings|✅||
-|OrderSettings|✅||
-|OrgSettings|✅||
-|OutboundNetworkConnection|✅||
-|PardotEinsteinSettings|✅||
-|PardotSettings|✅||
-|ParticipantRole|✅||
-|PartyDataModelSettings|✅||
-|PathAssistant|✅||
-|PathAssistantSettings|✅||
-|PaymentGatewayProvider|✅||
-|PermissionSet|✅||
-|PermissionSetGroup|✅||
-|PermissionSetLicenseDefinition|✅||
-|PicklistSettings|✅||
-|PicklistValue|❌|Not supported, but support could be added|
-|PlatformCachePartition|✅||
-|PlatformEventChannel|✅||
-|PlatformEventChannelMember|✅||
-|PlatformEventSubscriberConfig|✅||
-|PlatformSlackSettings|✅||
-|PortalsSettings|✅||
-|PostTemplate|✅||
-|PredictionBuilderSettings|✅||
-|PresenceDeclineReason|✅||
-|PresenceUserConfig|✅||
-|PrivacySettings|✅||
-|ProductAttributeSet|❌|Not supported, but support could be added|
-|ProductSettings|✅||
-|Profile|✅||
-|ProfilePasswordPolicy|✅||
-|ProfileSessionSetting|✅||
-|Prompt|✅||
-|Queue|✅||
-|QueueRoutingConfig|✅||
-|QuickAction|✅||
-|QuickTextSettings|✅||
-|QuoteSettings|✅||
-|RealTimeEventSettings|✅||
-|RecommendationBuilderSettings|✅||
-|RecommendationStrategy|✅||
-|RecordActionDeployment|✅||
-|RecordAlertCategory|❌|Not supported, but support could be added|
-|RecordAlertDataSource|❌|Not supported, but support could be added|
-|RecordPageSettings|✅||
-|RecordType|✅||
-|RedirectWhitelistUrl|✅||
-|RelatedRecordAssocCriteria|❌|Not supported, but support could be added|
-|RemoteSiteSetting|✅||
-|Report|✅||
-|ReportFolder|✅||
-|ReportType|✅||
-|RestrictionRule|✅||
-|RetailExecutionSettings|✅||
-|Role|✅||
-|SalesAgreementSettings|✅||
-|SalesWorkQueueSettings|✅||
-|SamlSsoConfig|✅||
-|SchedulingRule|✅||
-|SchemaSettings|✅||
-|ScoreCategory|❌|Not supported, but support could be added|
-|ScoreRange|❌|Not supported, but support could be added|
-|SearchSettings|✅||
-|SecuritySettings|✅||
-|ServiceAISetupDefinition|❌|Not supported, but support could be added|
-|ServiceAISetupField|❌|Not supported, but support could be added|
-|ServiceChannel|✅||
-|ServiceCloudVoiceSettings|✅||
-|ServicePresenceStatus|✅||
-|ServiceSetupAssistantSettings|✅||
-|SharingCriteriaRule|✅||
-|SharingGuestRule|✅||
-|SharingOwnerRule|✅||
-|SharingReason|✅||
-|SharingRules|⚠️|Supports deploy/retrieve but not source tracking|
-|SharingSet|✅||
-|SharingSettings|✅||
-|SharingTerritoryRule|✅||
-|SiteDotCom|✅||
-|SiteSettings|✅||
-|Skill|✅||
-|SlackApp|✅||
-|SocialCustomerServiceSettings|✅||
-|SocialProfileSettings|✅||
-|SourceTrackingSettings|✅||
-|StandardValue|❌|Not supported, but support could be added|
-|StandardValueSet|✅||
-|StandardValueSetTranslation|✅||
-|StaticResource|✅||
-|StnryAssetEnvSrcCnfg|✅||
-|SurveySettings|✅||
-|SvcCatalogCategory|✅||
-|SvcCatalogFulfillmentFlow|✅||
-|SvcCatalogItemDef|✅||
-|SynonymDictionary|✅||
-|SystemNotificationSettings|✅||
-|Territory|✅||
-|Territory2|✅||
-|Territory2Model|✅||
-|Territory2Rule|✅||
-|Territory2Settings|✅||
-|Territory2Type|✅||
-|TimeSheetTemplate|✅||
-|TimelineObjectDefinition|❌|Not supported, but support could be added|
-|TopicsForObjects|✅||
-|TrailheadSettings|✅||
-|TransactionSecurityPolicy|✅||
-|Translations|✅||
-|TrialOrgSettings|✅||
-|UIObjectRelationConfig|✅||
-|UiPlugin|✅||
-|UserAuthCertificate|✅||
-|UserCriteria|✅||
-|UserEngagementSettings|✅||
-|UserInterfaceSettings|✅||
-|UserManagementSettings|✅||
-|UserProfileSearchScope|✅||
-|UserProvisioningConfig|✅||
-|ValidationRule|✅||
-|VehicleAssetEmssnSrcCnfg|✅||
-|ViewDefinition|✅||
-|VirtualVisitConfig|❌|Not supported, but support could be added|
-|WaveApplication|✅||
-|WaveComponent|✅||
-|WaveDashboard|✅||
-|WaveDataflow|✅||
-|WaveDataset|✅||
-|WaveLens|✅||
-|WaveRecipe|✅||
-|WaveTemplateBundle|✅||
-|WaveXmd|✅||
-|WebLink|✅||
-|WebStoreTemplate|✅||
-|WebToXSettings|✅||
-|WorkDotComSettings|✅||
-|WorkSkillRouting|✅||
-|Workflow|✅||
-|WorkflowAlert|✅||
-|WorkflowFieldUpdate|✅||
-|WorkflowFlowAction|❌|Not supported, but support could be added|
-|WorkflowKnowledgePublish|✅||
-|WorkflowOutboundMessage|✅||
-|WorkflowRule|✅||
-|WorkflowSend|✅||
-|WorkflowTask|✅||
-|WorkforceEngagementSettings|✅||
-
-
+| Metadata Type                         | Support | Notes                                            |
+| :------------------------------------ | :------ | :----------------------------------------------- |
+| AIApplication                         | ✅      |                                                  |
+| AIApplicationConfig                   | ✅      |                                                  |
+| AIReplyRecommendationsSettings        | ✅      |                                                  |
+| AccountForecastSettings               | ✅      |                                                  |
+| AccountInsightsSettings               | ✅      |                                                  |
+| AccountIntelligenceSettings           | ✅      |                                                  |
+| AccountRelationshipShareRule          | ✅      |                                                  |
+| AccountSettings                       | ✅      |                                                  |
+| AcctMgrTargetSettings                 | ✅      |                                                  |
+| ActionLinkGroupTemplate               | ✅      |                                                  |
+| ActionPlanTemplate                    | ✅      |                                                  |
+| ActionsSettings                       | ✅      |                                                  |
+| ActivationPlatform                    | ❌      | Not supported, but support could be added        |
+| ActivitiesSettings                    | ✅      |                                                  |
+| AddressSettings                       | ✅      |                                                  |
+| AdvAccountForecastSet                 | ✅      |                                                  |
+| AdvAcctForecastDimSource              | ❌      | Not supported, but support could be added        |
+| AdvAcctForecastPeriodGroup            | ✅      |                                                  |
+| AnalyticSnapshot                      | ✅      |                                                  |
+| AnalyticsDataServicesSettings         | ✅      |                                                  |
+| AnalyticsSettings                     | ✅      |                                                  |
+| AnimationRule                         | ✅      |                                                  |
+| ApexClass                             | ✅      |                                                  |
+| ApexComponent                         | ✅      |                                                  |
+| ApexEmailNotifications                | ✅      |                                                  |
+| ApexPage                              | ✅      |                                                  |
+| ApexSettings                          | ✅      |                                                  |
+| ApexTestSuite                         | ✅      |                                                  |
+| ApexTrigger                           | ✅      |                                                  |
+| AppAnalyticsSettings                  | ✅      |                                                  |
+| AppExperienceSettings                 | ✅      |                                                  |
+| AppMenu                               | ✅      |                                                  |
+| ApplicationRecordTypeConfig           | ✅      |                                                  |
+| ApplicationSubtypeDefinition          | ❌      | Not supported, but support could be added        |
+| AppointmentAssignmentPolicy           | ❌      | Not supported, but support could be added        |
+| AppointmentSchedulingPolicy           | ✅      |                                                  |
+| ApprovalProcess                       | ✅      |                                                  |
+| ArchiveSettings                       | ✅      |                                                  |
+| AssignmentRules                       | ✅      |                                                  |
+| AssistantContextItem                  | ✅      |                                                  |
+| AssistantDefinition                   | ✅      |                                                  |
+| AssistantSkillQuickAction             | ✅      |                                                  |
+| AssistantSkillSobjectAction           | ✅      |                                                  |
+| AssistantVersion                      | ✅      |                                                  |
+| AssociationEngineSettings             | ✅      |                                                  |
+| AttributeDefinition2                  | ❌      | Not supported, but support could be added        |
+| Audience                              | ✅      |                                                  |
+| AuraDefinitionBundle                  | ✅      |                                                  |
+| AuthProvider                          | ✅      |                                                  |
+| AutoResponseRules                     | ✅      |                                                  |
+| AutomatedContactsSettings             | ✅      |                                                  |
+| BatchCalcJobDefinition                | ✅      |                                                  |
+| BatchProcessJobDefinition             | ✅      |                                                  |
+| BenefitAction                         | ✅      |                                                  |
+| BlacklistedConsumer                   | ✅      |                                                  |
+| BldgEnrgyIntensityCnfg                | ✅      |                                                  |
+| BlockchainSettings                    | ✅      |                                                  |
+| Bot                                   | ✅      |                                                  |
+| BotSettings                           | ✅      |                                                  |
+| BotVersion                            | ✅      |                                                  |
+| BranchManagementSettings              | ✅      |                                                  |
+| BrandingSet                           | ✅      |                                                  |
+| BriefcaseDefinition                   | ✅      |                                                  |
+| BusinessHoursSettings                 | ✅      |                                                  |
+| BusinessProcess                       | ✅      |                                                  |
+| BusinessProcessGroup                  | ✅      |                                                  |
+| BusinessProcessTypeDefinition         | ❌      | Not supported, but support could be added        |
+| CMSConnectSource                      | ✅      |                                                  |
+| CallCenter                            | ✅      |                                                  |
+| CallCenterRoutingMap                  | ✅      |                                                  |
+| CallCoachingMediaProvider             | ⚠️      | Supports deploy/retrieve but not source tracking |
+| CampaignInfluenceModel                | ✅      |                                                  |
+| CampaignSettings                      | ✅      |                                                  |
+| CanvasMetadata                        | ✅      |                                                  |
+| CareBenefitVerifySettings             | ✅      |                                                  |
+| CareLimitType                         | ❌      | Not supported, but support could be added        |
+| CareProviderSearchConfig              | ✅      |                                                  |
+| CareRequestConfiguration              | ✅      |                                                  |
+| CareSystemFieldMapping                | ✅      |                                                  |
+| CaseSettings                          | ✅      |                                                  |
+| CaseSubjectParticle                   | ✅      |                                                  |
+| Certificate                           | ✅      |                                                  |
+| ChannelLayout                         | ✅      |                                                  |
+| ChannelObjectLinkingRule              | ✅      |                                                  |
+| ChatterAnswersSettings                | ✅      |                                                  |
+| ChatterEmailsMDSettings               | ✅      |                                                  |
+| ChatterExtension                      | ✅      |                                                  |
+| ChatterSettings                       | ✅      |                                                  |
+| CleanDataService                      | ✅      |                                                  |
+| CommandAction                         | ✅      |                                                  |
+| CommerceSettings                      | ✅      |                                                  |
+| CommunitiesSettings                   | ✅      |                                                  |
+| Community                             | ✅      |                                                  |
+| CommunityTemplateDefinition           | ✅      |                                                  |
+| CommunityThemeDefinition              | ✅      |                                                  |
+| CompactLayout                         | ✅      |                                                  |
+| CompanySettings                       | ✅      |                                                  |
+| ConnectedApp                          | ✅      |                                                  |
+| ConnectedAppSettings                  | ✅      |                                                  |
+| ConnectedSystem                       | ✅      |                                                  |
+| ContentAsset                          | ✅      |                                                  |
+| ContentSettings                       | ✅      |                                                  |
+| ContractSettings                      | ✅      |                                                  |
+| ContractType                          | ❌      | Not supported, but support could be added        |
+| ConversationVendorInfo                | ✅      |                                                  |
+| ConversationalIntelligenceSettings    | ✅      |                                                  |
+| CorsWhitelistOrigin                   | ✅      |                                                  |
+| CspTrustedSite                        | ✅      |                                                  |
+| CurrencySettings                      | ✅      |                                                  |
+| CustomApplication                     | ✅      |                                                  |
+| CustomApplicationComponent            | ✅      |                                                  |
+| CustomFeedFilter                      | ✅      |                                                  |
+| CustomField                           | ✅      |                                                  |
+| CustomHelpMenuSection                 | ✅      |                                                  |
+| CustomIndex                           | ✅      |                                                  |
+| CustomLabels                          | ✅      |                                                  |
+| CustomMetadata                        | ✅      |                                                  |
+| CustomNotificationType                | ✅      |                                                  |
+| CustomObject                          | ✅      |                                                  |
+| CustomObjectTranslation               | ✅      |                                                  |
+| CustomPageWebLink                     | ✅      |                                                  |
+| CustomPermission                      | ✅      |                                                  |
+| CustomSite                            | ✅      |                                                  |
+| CustomTab                             | ✅      |                                                  |
+| CustomValue                           | ❌      | Not supported, but support could be added        |
+| CustomerDataPlatformSettings          | ✅      |                                                  |
+| Dashboard                             | ✅      |                                                  |
+| DashboardFolder                       | ✅      |                                                  |
+| DataCategoryGroup                     | ✅      |                                                  |
+| DataConnectorS3                       | ✅      |                                                  |
+| DataDotComSettings                    | ✅      |                                                  |
+| DataMapping                           | ✅      |                                                  |
+| DataMappingFieldDefinition            | ✅      |                                                  |
+| DataMappingObjectDefinition           | ✅      |                                                  |
+| DataMappingSchema                     | ✅      |                                                  |
+| DataSource                            | ✅      |                                                  |
+| DataSourceObject                      | ✅      |                                                  |
+| DataSourceTenant                      | ❌      | Not supported, but support could be added        |
+| DataStreamDefinition                  | ✅      |                                                  |
+| DecisionTable                         | ✅      |                                                  |
+| DecisionTableDatasetLink              | ✅      |                                                  |
+| DelegateGroup                         | ✅      |                                                  |
+| DeploymentSettings                    | ✅      |                                                  |
+| DevHubSettings                        | ✅      |                                                  |
+| DiscoveryAIModel                      | ✅      |                                                  |
+| DiscoveryGoal                         | ✅      |                                                  |
+| DiscoverySettings                     | ✅      |                                                  |
+| DiscoveryStory                        | ❌      | Not supported, but support could be added        |
+| Document                              | ✅      |                                                  |
+| DocumentChecklistSettings             | ✅      |                                                  |
+| DocumentFolder                        | ✅      |                                                  |
+| DocumentGenerationSetting             | ✅      |                                                  |
+| DocumentType                          | ✅      |                                                  |
+| DuplicateRule                         | ✅      |                                                  |
+| EACSettings                           | ✅      |                                                  |
+| ESignatureConfig                      | ❌      | Not supported, but support could be added        |
+| ESignatureEnvelopeConfig              | ❌      | Not supported, but support could be added        |
+| EclairGeoData                         | ✅      |                                                  |
+| EinsteinAgentSettings                 | ✅      |                                                  |
+| EinsteinAssistantSettings             | ✅      |                                                  |
+| EinsteinDealInsightsSettings          | ✅      |                                                  |
+| EinsteinDocumentCaptureSettings       | ✅      |                                                  |
+| EmailAdministrationSettings           | ✅      |                                                  |
+| EmailFolder                           | ✅      |                                                  |
+| EmailIntegrationSettings              | ✅      |                                                  |
+| EmailServicesFunction                 | ✅      |                                                  |
+| EmailTemplate                         | ✅      |                                                  |
+| EmailTemplateFolder                   | ❌      | Not supported, but support could be added        |
+| EmailTemplateSettings                 | ✅      |                                                  |
+| EmbeddedServiceBranding               | ✅      |                                                  |
+| EmbeddedServiceConfig                 | ✅      |                                                  |
+| EmbeddedServiceFlowConfig             | ✅      |                                                  |
+| EmbeddedServiceLiveAgent              | ✅      |                                                  |
+| EmbeddedServiceMenuSettings           | ✅      |                                                  |
+| EmployeeDataSyncProfile               | ❌      | Not supported, but support could be added        |
+| EmployeeFieldAccessSettings           | ✅      |                                                  |
+| EmployeeUserSettings                  | ✅      |                                                  |
+| EnhancedNotesSettings                 | ✅      |                                                  |
+| EntitlementProcess                    | ✅      |                                                  |
+| EntitlementSettings                   | ✅      |                                                  |
+| EntitlementTemplate                   | ✅      |                                                  |
+| EntityImplements                      | ✅      |                                                  |
+| EscalationRules                       | ✅      |                                                  |
+| EssentialsSettings                    | ✅      |                                                  |
+| EventSettings                         | ✅      |                                                  |
+| ExperienceBundle                      | ✅      |                                                  |
+| ExperienceBundleSettings              | ✅      |                                                  |
+| ExplainabilityActionDefinition        | ❌      | Not supported, but support could be added        |
+| ExplainabilityActionVersion           | ❌      | Not supported, but support could be added        |
+| ExternalAIModel                       | ❌      | Not supported, but support could be added        |
+| ExternalCredential                    | ❌      | Not supported, but support could be added        |
+| ExternalDataConnector                 | ✅      |                                                  |
+| ExternalDataSource                    | ✅      |                                                  |
+| ExternalServiceRegistration           | ✅      |                                                  |
+| ExternalServicesSettings              | ✅      |                                                  |
+| FeatureParameterBoolean               | ✅      |                                                  |
+| FeatureParameterDate                  | ✅      |                                                  |
+| FeatureParameterInteger               | ✅      |                                                  |
+| FederationDataMappingUsage            | ✅      |                                                  |
+| FieldRestrictionRule                  | ✅      |                                                  |
+| FieldServiceMobileExtension           | ✅      |                                                  |
+| FieldServiceSettings                  | ✅      |                                                  |
+| FieldSet                              | ✅      |                                                  |
+| FieldSrcTrgtRelationship              | ✅      |                                                  |
+| FileUploadAndDownloadSecuritySettings | ✅      |                                                  |
+| FilesConnectSettings                  | ✅      |                                                  |
+| FlexiPage                             | ✅      |                                                  |
+| Flow                                  | ✅      |                                                  |
+| FlowCategory                          | ✅      |                                                  |
+| FlowDefinition                        | ⚠️      | Supports deploy/retrieve but not source tracking |
+| FlowSettings                          | ✅      |                                                  |
+| ForecastingObjectListSettings         | ✅      |                                                  |
+| ForecastingSettings                   | ✅      |                                                  |
+| ForecastingSourceDefinition           | ✅      |                                                  |
+| ForecastingType                       | ✅      |                                                  |
+| ForecastingTypeSource                 | ✅      |                                                  |
+| FormulaSettings                       | ✅      |                                                  |
+| FunctionReference                     | ⚠️      | Supports deploy/retrieve but not source tracking |
+| GatewayProviderPaymentMethodType      | ✅      |                                                  |
+| GlobalValueSet                        | ✅      |                                                  |
+| GlobalValueSetTranslation             | ✅      |                                                  |
+| GoogleAppsSettings                    | ✅      |                                                  |
+| Group                                 | ✅      |                                                  |
+| HighVelocitySalesSettings             | ✅      |                                                  |
+| HomePageComponent                     | ✅      |                                                  |
+| HomePageLayout                        | ✅      |                                                  |
+| IPAddressRange                        | ✅      |                                                  |
+| Icon                                  | ✅      |                                                  |
+| IdeasSettings                         | ✅      |                                                  |
+| IdentityVerificationProcDef           | ❌      | Not supported, but support could be added        |
+| IdentityVerificationProcDtl           | ❌      | Not supported, but support could be added        |
+| IdentityVerificationProcFld           | ❌      | Not supported, but support could be added        |
+| IframeWhiteListUrlSettings            | ✅      |                                                  |
+| InboundCertificate                    | ✅      |                                                  |
+| InboundNetworkConnection              | ✅      |                                                  |
+| IncidentMgmtSettings                  | ✅      |                                                  |
+| Index                                 | ⚠️      | Supports deploy/retrieve but not source tracking |
+| IndustriesLoyaltySettings             | ✅      |                                                  |
+| IndustriesManufacturingSettings       | ✅      |                                                  |
+| IndustriesSettings                    | ✅      |                                                  |
+| InstalledPackage                      | ⚠️      | Supports deploy/retrieve but not source tracking |
+| InterestTaggingSettings               | ✅      |                                                  |
+| InternalDataConnector                 | ❌      | Not supported, but support could be added        |
+| InventorySettings                     | ✅      |                                                  |
+| InvocableActionSettings               | ✅      |                                                  |
+| IoTSettings                           | ✅      |                                                  |
+| KeywordList                           | ✅      |                                                  |
+| KnowledgeSettings                     | ✅      |                                                  |
+| LanguageSettings                      | ✅      |                                                  |
+| Layout                                | ✅      |                                                  |
+| LeadConfigSettings                    | ✅      |                                                  |
+| LeadConvertSettings                   | ✅      |                                                  |
+| Letterhead                            | ✅      |                                                  |
+| LightningBolt                         | ✅      |                                                  |
+| LightningComponentBundle              | ✅      |                                                  |
+| LightningExperienceSettings           | ✅      |                                                  |
+| LightningExperienceTheme              | ✅      |                                                  |
+| LightningMessageChannel               | ✅      |                                                  |
+| LightningOnboardingConfig             | ✅      |                                                  |
+| ListView                              | ✅      |                                                  |
+| LiveAgentSettings                     | ✅      |                                                  |
+| LiveChatAgentConfig                   | ✅      |                                                  |
+| LiveChatButton                        | ✅      |                                                  |
+| LiveChatDeployment                    | ✅      |                                                  |
+| LiveChatSensitiveDataRule             | ✅      |                                                  |
+| LiveMessageSettings                   | ✅      |                                                  |
+| LoyaltyProgramSetup                   | ⚠️      | Supports deploy/retrieve but not source tracking |
+| MLDataDefinition                      | ✅      |                                                  |
+| MLPredictionDefinition                | ✅      |                                                  |
+| MLRecommendationDefinition            | ✅      |                                                  |
+| MacroSettings                         | ✅      |                                                  |
+| MailMergeSettings                     | ✅      |                                                  |
+| ManagedContentType                    | ⚠️      | Supports deploy/retrieve but not source tracking |
+| ManagedTopics                         | ✅      |                                                  |
+| MapsAndLocationSettings               | ✅      |                                                  |
+| MarketingAppExtActivity               | ❌      | Not supported, but support could be added        |
+| MarketingAppExtension                 | ❌      | Not supported, but support could be added        |
+| MatchingRules                         | ✅      |                                                  |
+| MediaAdSalesSettings                  | ✅      |                                                  |
+| MfgProgramTemplate                    | ❌      | Not supported, but support could be added        |
+| MilestoneType                         | ✅      |                                                  |
+| MktCalcInsightObjectDef               | ✅      |                                                  |
+| MktDataTranObject                     | ✅      |                                                  |
+| MlDomain                              | ✅      |                                                  |
+| MobSecurityCertPinConfig              | ❌      | Not supported, but support could be added        |
+| MobileApplicationDetail               | ✅      |                                                  |
+| MobileSecurityAssignment              | ❌      | Not supported, but support could be added        |
+| MobileSecurityPolicy                  | ❌      | Not supported, but support could be added        |
+| MobileSecurityPolicySet               | ❌      | Not supported, but support could be added        |
+| MobileSettings                        | ✅      |                                                  |
+| ModerationRule                        | ✅      |                                                  |
+| MutingPermissionSet                   | ✅      |                                                  |
+| MyDomainDiscoverableLogin             | ✅      |                                                  |
+| MyDomainSettings                      | ✅      |                                                  |
+| NameSettings                          | ✅      |                                                  |
+| NamedCredential                       | ✅      |                                                  |
+| NavigationMenu                        | ✅      |                                                  |
+| Network                               | ✅      |                                                  |
+| NetworkBranding                       | ✅      |                                                  |
+| NotificationTypeConfig                | ✅      |                                                  |
+| NotificationsSettings                 | ✅      |                                                  |
+| OauthCustomScope                      | ✅      |                                                  |
+| ObjectHierarchyRelationship           | ✅      |                                                  |
+| ObjectLinkingSettings                 | ✅      |                                                  |
+| ObjectSourceTargetMap                 | ✅      |                                                  |
+| OcrSampleDocument                     | ✅      |                                                  |
+| OcrTemplate                           | ✅      |                                                  |
+| OmniChannelSettings                   | ✅      |                                                  |
+| OmniDataTransform                     | ✅      |                                                  |
+| OmniIntegrationProcedure              | ✅      |                                                  |
+| OmniInteractionAccessConfig           | ❌      | Not supported, but support could be added        |
+| OmniInteractionConfig                 | ✅      |                                                  |
+| OmniScript                            | ✅      |                                                  |
+| OmniUiCard                            | ✅      |                                                  |
+| OnlineSalesSettings                   | ✅      |                                                  |
+| OpportunityInsightsSettings           | ✅      |                                                  |
+| OpportunityScoreSettings              | ✅      |                                                  |
+| OpportunitySettings                   | ✅      |                                                  |
+| OrderManagementSettings               | ✅      |                                                  |
+| OrderSettings                         | ✅      |                                                  |
+| OrgSettings                           | ✅      |                                                  |
+| OutboundNetworkConnection             | ✅      |                                                  |
+| PardotEinsteinSettings                | ✅      |                                                  |
+| PardotSettings                        | ✅      |                                                  |
+| ParticipantRole                       | ✅      |                                                  |
+| PartyDataModelSettings                | ✅      |                                                  |
+| PathAssistant                         | ✅      |                                                  |
+| PathAssistantSettings                 | ✅      |                                                  |
+| PaymentGatewayProvider                | ✅      |                                                  |
+| PermissionSet                         | ✅      |                                                  |
+| PermissionSetGroup                    | ✅      |                                                  |
+| PermissionSetLicenseDefinition        | ✅      |                                                  |
+| PicklistSettings                      | ✅      |                                                  |
+| PicklistValue                         | ❌      | Not supported, but support could be added        |
+| PlatformCachePartition                | ✅      |                                                  |
+| PlatformEventChannel                  | ✅      |                                                  |
+| PlatformEventChannelMember            | ✅      |                                                  |
+| PlatformEventSubscriberConfig         | ✅      |                                                  |
+| PlatformSlackSettings                 | ✅      |                                                  |
+| PortalsSettings                       | ✅      |                                                  |
+| PostTemplate                          | ✅      |                                                  |
+| PredictionBuilderSettings             | ✅      |                                                  |
+| PresenceDeclineReason                 | ✅      |                                                  |
+| PresenceUserConfig                    | ✅      |                                                  |
+| PrivacySettings                       | ✅      |                                                  |
+| ProductAttributeSet                   | ❌      | Not supported, but support could be added        |
+| ProductSettings                       | ✅      |                                                  |
+| Profile                               | ✅      |                                                  |
+| ProfilePasswordPolicy                 | ✅      |                                                  |
+| ProfileSessionSetting                 | ✅      |                                                  |
+| Prompt                                | ✅      |                                                  |
+| Queue                                 | ✅      |                                                  |
+| QueueRoutingConfig                    | ✅      |                                                  |
+| QuickAction                           | ✅      |                                                  |
+| QuickTextSettings                     | ✅      |                                                  |
+| QuoteSettings                         | ✅      |                                                  |
+| RealTimeEventSettings                 | ✅      |                                                  |
+| RecommendationBuilderSettings         | ✅      |                                                  |
+| RecommendationStrategy                | ✅      |                                                  |
+| RecordActionDeployment                | ✅      |                                                  |
+| RecordAlertCategory                   | ❌      | Not supported, but support could be added        |
+| RecordAlertDataSource                 | ❌      | Not supported, but support could be added        |
+| RecordPageSettings                    | ✅      |                                                  |
+| RecordType                            | ✅      |                                                  |
+| RedirectWhitelistUrl                  | ✅      |                                                  |
+| RelatedRecordAssocCriteria            | ❌      | Not supported, but support could be added        |
+| RemoteSiteSetting                     | ✅      |                                                  |
+| Report                                | ✅      |                                                  |
+| ReportFolder                          | ✅      |                                                  |
+| ReportType                            | ✅      |                                                  |
+| RestrictionRule                       | ✅      |                                                  |
+| RetailExecutionSettings               | ✅      |                                                  |
+| Role                                  | ✅      |                                                  |
+| SalesAgreementSettings                | ✅      |                                                  |
+| SalesWorkQueueSettings                | ✅      |                                                  |
+| SamlSsoConfig                         | ✅      |                                                  |
+| SchedulingRule                        | ✅      |                                                  |
+| SchemaSettings                        | ✅      |                                                  |
+| ScoreCategory                         | ❌      | Not supported, but support could be added        |
+| ScoreRange                            | ❌      | Not supported, but support could be added        |
+| SearchSettings                        | ✅      |                                                  |
+| SecuritySettings                      | ✅      |                                                  |
+| ServiceAISetupDefinition              | ❌      | Not supported, but support could be added        |
+| ServiceAISetupField                   | ❌      | Not supported, but support could be added        |
+| ServiceChannel                        | ✅      |                                                  |
+| ServiceCloudVoiceSettings             | ✅      |                                                  |
+| ServicePresenceStatus                 | ✅      |                                                  |
+| ServiceSetupAssistantSettings         | ✅      |                                                  |
+| SharingCriteriaRule                   | ✅      |                                                  |
+| SharingGuestRule                      | ✅      |                                                  |
+| SharingOwnerRule                      | ✅      |                                                  |
+| SharingReason                         | ✅      |                                                  |
+| SharingRules                          | ⚠️      | Supports deploy/retrieve but not source tracking |
+| SharingSet                            | ✅      |                                                  |
+| SharingSettings                       | ✅      |                                                  |
+| SharingTerritoryRule                  | ✅      |                                                  |
+| SiteDotCom                            | ✅      |                                                  |
+| SiteSettings                          | ✅      |                                                  |
+| Skill                                 | ✅      |                                                  |
+| SlackApp                              | ✅      |                                                  |
+| SocialCustomerServiceSettings         | ✅      |                                                  |
+| SocialProfileSettings                 | ✅      |                                                  |
+| SourceTrackingSettings                | ✅      |                                                  |
+| StandardValue                         | ❌      | Not supported, but support could be added        |
+| StandardValueSet                      | ✅      |                                                  |
+| StandardValueSetTranslation           | ✅      |                                                  |
+| StaticResource                        | ✅      |                                                  |
+| StnryAssetEnvSrcCnfg                  | ✅      |                                                  |
+| SurveySettings                        | ✅      |                                                  |
+| SvcCatalogCategory                    | ✅      |                                                  |
+| SvcCatalogFulfillmentFlow             | ✅      |                                                  |
+| SvcCatalogItemDef                     | ✅      |                                                  |
+| SynonymDictionary                     | ✅      |                                                  |
+| SystemNotificationSettings            | ✅      |                                                  |
+| Territory                             | ✅      |                                                  |
+| Territory2                            | ✅      |                                                  |
+| Territory2Model                       | ✅      |                                                  |
+| Territory2Rule                        | ✅      |                                                  |
+| Territory2Settings                    | ✅      |                                                  |
+| Territory2Type                        | ✅      |                                                  |
+| TimeSheetTemplate                     | ✅      |                                                  |
+| TimelineObjectDefinition              | ❌      | Not supported, but support could be added        |
+| TopicsForObjects                      | ✅      |                                                  |
+| TrailheadSettings                     | ✅      |                                                  |
+| TransactionSecurityPolicy             | ✅      |                                                  |
+| Translations                          | ✅      |                                                  |
+| TrialOrgSettings                      | ✅      |                                                  |
+| UIObjectRelationConfig                | ✅      |                                                  |
+| UiPlugin                              | ✅      |                                                  |
+| UserAuthCertificate                   | ✅      |                                                  |
+| UserCriteria                          | ✅      |                                                  |
+| UserEngagementSettings                | ✅      |                                                  |
+| UserInterfaceSettings                 | ✅      |                                                  |
+| UserManagementSettings                | ✅      |                                                  |
+| UserProfileSearchScope                | ✅      |                                                  |
+| UserProvisioningConfig                | ✅      |                                                  |
+| ValidationRule                        | ✅      |                                                  |
+| VehicleAssetEmssnSrcCnfg              | ✅      |                                                  |
+| ViewDefinition                        | ✅      |                                                  |
+| VirtualVisitConfig                    | ❌      | Not supported, but support could be added        |
+| WaveApplication                       | ✅      |                                                  |
+| WaveComponent                         | ✅      |                                                  |
+| WaveDashboard                         | ✅      |                                                  |
+| WaveDataflow                          | ✅      |                                                  |
+| WaveDataset                           | ✅      |                                                  |
+| WaveLens                              | ✅      |                                                  |
+| WaveRecipe                            | ✅      |                                                  |
+| WaveTemplateBundle                    | ✅      |                                                  |
+| WaveXmd                               | ✅      |                                                  |
+| WebLink                               | ✅      |                                                  |
+| WebStoreTemplate                      | ✅      |                                                  |
+| WebToXSettings                        | ✅      |                                                  |
+| WorkDotComSettings                    | ✅      |                                                  |
+| WorkSkillRouting                      | ✅      |                                                  |
+| Workflow                              | ✅      |                                                  |
+| WorkflowAlert                         | ✅      |                                                  |
+| WorkflowFieldUpdate                   | ✅      |                                                  |
+| WorkflowFlowAction                    | ❌      | Not supported, but support could be added        |
+| WorkflowKnowledgePublish              | ✅      |                                                  |
+| WorkflowOutboundMessage               | ✅      |                                                  |
+| WorkflowRule                          | ✅      |                                                  |
+| WorkflowSend                          | ✅      |                                                  |
+| WorkflowTask                          | ✅      |                                                  |
+| WorkforceEngagementSettings           | ✅      |                                                  |
 
 ## Next Release (v55)
-v55 introduces the following new types.  Here's their current level of support
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|Experience|undefined|undefined|
+v55 introduces the following new types. Here's their current level of support
+
+| Metadata Type | Support | Notes |
+| :------------ | :------ | :---- |
 
 ## Additional Types
 
-> The following types are supported by this library but not in the coverage reports for either version.  These are typically
+> The following types are supported by this library but not in the coverage reports for either version. These are typically
 >
 > 1. types that have been removed from the metadata API but were supported in previous versions
 > 1. types that are available for pilots but not officially part of the metadata API (use with caution)

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -65,4 +65,5 @@ export const messages = {
   error_no_job_id: 'The %s operation is missing a job ID. Initialize an operation with an ID, or start a new job.',
   tapi_deploy_component_limit_error: 'This deploy method only supports deploying one metadata component at a time',
   warn_unresolved_source_for_components: 'The following components will not be deployed due to unresolved source: %s',
+  invalid_xml_parsing: 'error parsing %s due to:\n  message: %s\n  line: %s\n  code: %s',
 };

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -117,21 +117,7 @@ export class SourceComponent implements MetadataComponent {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
       const contents = (await this.tree.readFile(xml)).toString();
-      try {
-        return this.parse<T>(contents);
-      } catch (e) {
-        // only attempt validating once there's an error to avoid the performance hit of validating every file
-        const validation = validate(contents);
-        if (validation !== true) {
-          throw new LibraryError('invalid_xml_parsing', [
-            xml,
-            validation.err.msg,
-            validation.err.line.toString(),
-            validation.err.code,
-          ]);
-        }
-        throw e;
-      }
+      return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;
   }
@@ -140,21 +126,7 @@ export class SourceComponent implements MetadataComponent {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
       const contents = this.tree.readFileSync(xml).toString();
-      try {
-        return this.parse<T>(contents);
-      } catch (e) {
-        // only attempt validating once there's an error to avoid the performance hit of validating every file
-        const validation = validate(contents);
-        if (validation !== true) {
-          throw new LibraryError('invalid_xml_parsing', [
-            xml,
-            validation.err.msg,
-            validation.err.line.toString(),
-            validation.err.code,
-          ]);
-        }
-        throw e;
-      }
+      return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;
   }
@@ -257,6 +229,24 @@ export class SourceComponent implements MetadataComponent {
       return this.parseFromParentXml(parsed);
     } else {
       return parsed;
+    }
+  }
+
+  private parseAndValidateXML<T = JsonMap>(contents: string, xml: string): T {
+    try {
+      return this.parse<T>(contents);
+    } catch (e) {
+      // only attempt validating once there's an error to avoid the performance hit of validating every file
+      const validation = validate(contents);
+      if (validation !== true) {
+        throw new LibraryError('invalid_xml_parsing', [
+          xml,
+          validation.err.msg,
+          validation.err.line.toString(),
+          validation.err.code,
+        ]);
+      }
+      throw e;
     }
   }
 

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -232,7 +232,7 @@ export class SourceComponent implements MetadataComponent {
     }
   }
 
-  private parseAndValidateXML<T = JsonMap>(contents: string, xml: string): T {
+  private parseAndValidateXML<T = JsonMap>(contents: string, path: string): T {
     try {
       return this.parse<T>(contents);
     } catch (e) {
@@ -240,7 +240,7 @@ export class SourceComponent implements MetadataComponent {
       const validation = validate(contents);
       if (validation !== true) {
         throw new LibraryError('invalid_xml_parsing', [
-          xml,
+          path,
           validation.err.msg,
           validation.err.line.toString(),
           validation.err.code,

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -117,6 +117,37 @@ describe('SourceComponent', () => {
       });
     });
 
+    it('should handle improperly formatted xml and throw a helpful message (sync)', async () => {
+      const component = COMPONENT;
+      env
+        .stub(component.tree, 'readFile')
+        .resolves(Buffer.from('</CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"></CustomLabels>'));
+      try {
+        await component.parseXml();
+      } catch (e) {
+        expect(e.message).to.include(`error parsing ${component.xml} due to:`);
+        expect(e.message).to.include("message: Closing tag 'CustomLabels' can't have attributes or invalid starting.");
+        expect(e.message).to.include('line: 1');
+        expect(e.message).to.include('code: InvalidTag');
+      }
+    });
+
+    it('should handle improperly formatted xml and throw a helpful message (async)', async () => {
+      const component = COMPONENT;
+      env
+        .stub(component.tree, 'readFile')
+        .resolves(Buffer.from('</CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata"></CustomLabels>'));
+
+      try {
+        component.parseXmlSync();
+      } catch (e) {
+        expect(e.message).to.include(`error parsing ${component.xml} due to:`);
+        expect(e.message).to.include("message: Closing tag 'CustomLabels' can't have attributes or invalid starting.");
+        expect(e.message).to.include('line: 1');
+        expect(e.message).to.include('code: InvalidTag');
+      }
+    });
+
     it('should parse the child components xml content to js object', async () => {
       const component = new SourceComponent({
         name: 'nondecomposedchild',

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -117,7 +117,7 @@ describe('SourceComponent', () => {
       });
     });
 
-    it('should handle improperly formatted xml and throw a helpful message (sync)', async () => {
+    it('should handle improperly formatted xml and throw a helpful message (async)', async () => {
       const component = COMPONENT;
       env
         .stub(component.tree, 'readFile')
@@ -132,7 +132,7 @@ describe('SourceComponent', () => {
       }
     });
 
-    it('should handle improperly formatted xml and throw a helpful message (async)', async () => {
+    it('should handle improperly formatted xml and throw a helpful message (sync)', async () => {
       const component = COMPONENT;
       env
         .stub(component.tree, 'readFile')


### PR DESCRIPTION
### What does this PR do?
when the `fast-xml-parser` library throws an error due to invalid xml, we will parse that error, and add the file that caused the error. 

given a custom labels xml file
```
<?xml version="1.0" encoding="UTF-8"?>
</CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
  <labels>
    <fullName>force_app_Label_1</fullName>
    <language>en_US</language>
    <protected>true</protected>
    <shortDescription>force-app Label 1</shortDescription>
    <value>force-app</value>
  </labels>
</CustomLabels>
```
 

note the opening CustomLabels tag is actually a closing tag

### What issues does this PR fix or reference?

#[1261](https://github.com/forcedotcom/cli/issues/1261), @W-10119453@

### Functionality Before
`TypeError: Cannot read property 'addChild' of undefined`

### Functionality After
```
 Component conversion failed: error parsing dreamhouse-lwc/force-app/main/default/labels/CustomLabels.labels-meta.xml due to:
  message: Closing tag 'CustomLabels' can't have attributes or invalid starting..
  line: 2.
  code: InvalidTag.
```
