### PR TITLE
feat: add retrieve in mdapi format

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -482,6 +482,7 @@ v55 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|Experience|undefined|undefined|
 
 ## Additional Types
 

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -175,7 +175,7 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
       }
     }
 
-    components = components ?? new ComponentSet(undefined, this.options.registry);
+    components ??= new ComponentSet(undefined, this.options.registry);
 
     if (!isMdapiRetrieve) {
       // This should only be done when retrieving source format since retrieving

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -168,7 +168,8 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
 
         if (this.options.unzip) {
           const dir = await unzipper.Open.buffer(zipFileContents);
-          await dir.extract({ path: this.options.output });
+          const extractPath = path.join(this.options.output, path.parse(name).name);
+          await dir.extract({ path: extractPath });
         }
       } else {
         components = await this.extract(zipFileContents);
@@ -203,6 +204,11 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
     // otherwise don't - it causes errors if undefined or an empty array
     if (packageNames?.length) {
       requestBody.packageNames = packageNames;
+      // delete unpackaged when no components and metadata format to prevent
+      // sending an empty unpackaged manifest.
+      if (this.options.format === 'metadata' && this.components.size === 0) {
+        delete requestBody.unpackaged;
+      }
     }
     if (this.options.singlePackage) {
       requestBody.singlePackage = this.options.singlePackage;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -8,6 +8,7 @@ import { ComponentSet } from '../collections';
 import { PackageTypeMembers } from '../collections/types';
 import { SourcePath } from '../common/types';
 import { MetadataComponent, SourceComponent } from '../resolve';
+import { SfdxFileFormat } from '../convert';
 
 // ------------------------------------------------
 // API results reformatted for source development
@@ -326,6 +327,23 @@ export interface RetrieveOptions {
    * A list of package names to retrieve, or package names and their retrieval locations.
    */
   packageOptions?: PackageOptions;
+  /**
+   * The file format desired for the retrieved files.
+   */
+  format?: SfdxFileFormat;
+  /**
+   * Specifies whether only a single package is being retrieved (true) or not (false).
+   * If false, then more than one package is being retrieved.
+   */
+  singlePackage?: boolean;
+  /**
+   * The name of the retrieved zip file containing the source from the org. Only applies when `format: metadata`.
+   */
+  zipFileName?: string;
+  /**
+   * Specifies whether to unzip the retrieved zip file. Only applies when `format: metadata`.
+   */
+  unzip?: boolean;
 }
 
 export interface MetadataApiDeployOptions {

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -7,14 +7,17 @@
 import { fail } from 'assert';
 import { join } from 'path';
 import { expect } from 'chai';
-import { createSandbox, match } from 'sinon';
+import * as unzipper from 'unzipper';
+import { createSandbox, match, SinonStub } from 'sinon';
 import { getString } from '@salesforce/ts-types';
 import * as fs from 'graceful-fs';
 import {
   ComponentSet,
   ComponentStatus,
   FileResponse,
+  MetadataApiRetrieve,
   MetadataApiRetrieveStatus,
+  RequestStatus,
   RetrieveResult,
   SourceComponent,
   VirtualTreeContainer,
@@ -404,6 +407,67 @@ describe('MetadataApiRetrieve', () => {
         expect(e.name).to.equal(expectedError.name);
         expect(e.message).to.equal(expectedError.message);
       }
+    });
+  });
+
+  describe('post', () => {
+    const output = join('mdapi', 'retrieve', 'dir');
+    const format = 'metadata';
+    const zipFile = 'abcd1234';
+    const zipFileContents = Buffer.from(zipFile, 'base64');
+    const usernameOrConnection = 'retrieve@test.org';
+    const fakeResults = { status: RequestStatus.Succeeded, zipFile } as MetadataApiRetrieveStatus;
+    let writeFileStub: SinonStub;
+    let openBufferStub: SinonStub;
+    let extractStub: SinonStub;
+    const mdapiRetrieveExtractStub = env.stub().resolves({});
+
+    beforeEach(() => {
+      writeFileStub = env.stub(fs, 'writeFileSync');
+      extractStub = env.stub().resolves();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      openBufferStub = env.stub(unzipper.Open, 'buffer').resolves({ extract: extractStub } as any);
+    });
+
+    it('should write the retrieved zip when format=metadata', async () => {
+      const mdapiRetrieve = new MetadataApiRetrieve({ usernameOrConnection, output, format });
+      // @ts-ignore overriding private method
+      mdapiRetrieve.extract = mdapiRetrieveExtractStub;
+      await mdapiRetrieve.post(fakeResults);
+
+      expect(writeFileStub.calledOnce).to.be.true;
+      expect(writeFileStub.firstCall.args[0]).to.equal(join(output, 'unpackaged.zip'));
+      expect(writeFileStub.firstCall.args[1]).to.deep.equal(zipFileContents);
+      expect(openBufferStub.called).to.be.false;
+      expect(mdapiRetrieveExtractStub.called).to.be.false;
+    });
+
+    it('should unzip the retrieved zip when format=metadata and unzip=true', async () => {
+      const mdapiRetrieve = new MetadataApiRetrieve({ usernameOrConnection, output, format, unzip: true });
+      // @ts-ignore overriding private method
+      mdapiRetrieve.extract = mdapiRetrieveExtractStub;
+      await mdapiRetrieve.post(fakeResults);
+
+      expect(writeFileStub.calledOnce).to.be.true;
+      expect(writeFileStub.firstCall.args[0]).to.equal(join(output, 'unpackaged.zip'));
+      expect(writeFileStub.firstCall.args[1]).to.deep.equal(zipFileContents);
+      expect(openBufferStub.called).to.be.true;
+      expect(extractStub.called).to.be.true;
+      expect(mdapiRetrieveExtractStub.called).to.be.false;
+    });
+
+    it('should write the retrieved zip with specified name when format=metadata and zipFileName is set', async () => {
+      const zipFileName = 'retrievedFiles.zip';
+      const mdapiRetrieve = new MetadataApiRetrieve({ usernameOrConnection, output, format, zipFileName });
+      // @ts-ignore overriding private method
+      mdapiRetrieve.extract = mdapiRetrieveExtractStub;
+      await mdapiRetrieve.post(fakeResults);
+
+      expect(writeFileStub.calledOnce).to.be.true;
+      expect(writeFileStub.firstCall.args[0]).to.equal(join(output, zipFileName));
+      expect(writeFileStub.firstCall.args[1]).to.deep.equal(zipFileContents);
+      expect(openBufferStub.called).to.be.false;
+      expect(mdapiRetrieveExtractStub.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds support to `MetadataApiRetrieve` for retrieving source in metadata format, naming the zip file that is written, and extracting the zip file contents.

### What issues does this PR fix or reference?
@W-10364895@

### Functionality Before
no support; only source format

### Functionality After
source is retrieved, zip file is written to output directory.  Optionally naming the zip file and extracting the contents to the output dir.
