### PR TITLE
fix: add variable polling times based on comp. set

### DIFF
--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -95,8 +95,8 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
     }
     // from the overloaded methods, there's a possibility frequency/timeout isn't set
     // guarantee frequency and timeout are set
-    pollingOptions.frequency = pollingOptions.frequency ?? Duration.milliseconds(this.calculatePollingFrequency());
-    pollingOptions.timeout = pollingOptions.timeout ?? Duration.minutes(60);
+    pollingOptions.frequency ??= Duration.milliseconds(this.calculatePollingFrequency());
+    pollingOptions.timeout ??= Duration.minutes(60);
 
     const pollingClient = await PollingClient.create(pollingOptions);
 

--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -14,6 +14,7 @@ import { MetadataConverter, SfdxFileFormat } from '../convert';
 import { MetadataTransferError } from '../errors';
 import { ComponentSet } from '../collections';
 import { AsyncResult, MetadataRequestStatus, MetadataTransferResult, RequestStatus } from './types';
+
 export interface MetadataTransferOptions {
   usernameOrConnection: string | Connection;
   components?: ComponentSet;
@@ -66,7 +67,7 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
   public async pollStatus(options?: Partial<PollingClient.Options>): Promise<Result>;
   /**
    * Poll for the status of the metadata transfer request.
-   * Default frequency is 100 ms.
+   * Default frequency is based on the number of SourceComponents, n, in the transfer, it ranges from 100ms -> n
    * Default timeout is 60 minutes.
    *
    * @param frequency Polling frequency in milliseconds.
@@ -79,7 +80,7 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
     timeout?: number
   ): Promise<Result> {
     let pollingOptions: PollingClient.Options = {
-      frequency: Duration.milliseconds(100),
+      frequency: Duration.milliseconds(this.calculatePollingFrequency()),
       timeout: Duration.minutes(60),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       poll: this.poll.bind(this),
@@ -92,6 +93,10 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
     if (isNumber(timeout)) {
       pollingOptions.timeout = Duration.seconds(timeout);
     }
+    // from the overloaded methods, there's a possibility frequency/timeout isn't set
+    // guarantee frequency and timeout are set
+    pollingOptions.frequency = pollingOptions.frequency ?? Duration.milliseconds(this.calculatePollingFrequency());
+    pollingOptions.timeout = pollingOptions.timeout ?? Duration.minutes(60);
 
     const pollingClient = await PollingClient.create(pollingOptions);
 
@@ -214,6 +219,28 @@ export abstract class MetadataTransfer<Status extends MetadataRequestStatus, Res
     this.logger.debug(`MDAPI status update: ${mdapiStatus.status}`);
 
     return { completed, payload: mdapiStatus as unknown as AnyJson };
+  }
+
+  /**
+   * Based on the source components in the component set, it will return a polling frequency in milliseconds
+   */
+  private calculatePollingFrequency(): number {
+    const size = this.components?.getSourceComponents().toArray().length || 0;
+    // take a piece-wise approach to encapsulate discrete deployment sizes in polling frequencies that "feel" good when deployed
+    if (size === 0) {
+      // no component set size is possible for retrieve
+      return 1000;
+    } else if (size <= 10) {
+      return 100;
+    } else if (size <= 50) {
+      return 250;
+    } else if (size <= 100) {
+      return 500;
+    } else if (size <= 1000) {
+      return 1000;
+    } else {
+      return size;
+    }
   }
 
   public abstract checkStatus(): Promise<Status>;

--- a/test/client/metadataTransfer.test.ts
+++ b/test/client/metadataTransfer.test.ts
@@ -184,7 +184,7 @@ describe('MetadataTransfer', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore only override length attribute
         toArray: () => {
-          return { length: 1 };
+          return { length: 10 };
         },
       });
       const pollingClientStub = env.stub(PollingClient, 'create').resolves(PollingClient.prototype);


### PR DESCRIPTION
What does this PR do?
adds variable polling frequency to the `pollStatus` method when no value is passed for the frequency

I ended up creating a piece-wise function to capture "small" vs "medium" vs "large" vs "larger" deploys - I'm very open to changing the boundaries and frequencies each should return. I did notice a difference between 250ms and 100ms

What issues does this PR fix or reference?
@W-9586672@
