### PR TITLE
Sm/return-ignores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       node_version:
         description: version of node to run tests against
         type: string
-        default: 'latest'
+        default: 'lts'
       os:
         description: operating system to run tests on
         type: enum
@@ -157,7 +157,7 @@ workflows:
                 - maintenance
             exclude:
               - os: windows
-                node_version: lts
+                node_version: latest
               - os: windows
                 node_version: maintenance
       - external-nut:

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v54 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 420/464 supported metadata types.
+Currently, there are 420/465 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -139,6 +139,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |Dashboard|✅||
 |DashboardFolder|✅||
 |DataCategoryGroup|✅||
+|DataConnectorIngestApi|❌|Not supported, but support could be added|
 |DataConnectorS3|✅||
 |DataDotComSettings|✅||
 |DataMapping|✅||
@@ -482,7 +483,12 @@ v55 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|DataActionDefinition|❌|Not supported, but support could be added|
 |Experience|undefined|undefined|
+|ExternalDataTranField|❌|Not supported, but support could be added|
+|ExternalDataTranObject|❌|Not supported, but support could be added|
+|RegisteredExternalService|❌|Not supported, but support could be added|
+|StreamingAppDataConnector|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -108,6 +108,11 @@ export class MetadataResolver {
             return components;
           }
         }
+      } else {
+        // the file is not metadata, but could be in the forceignore, in which case we'd want to report it
+        if (this.forceIgnore.denies(fsPath)) {
+          this.forceIgnoredPaths.add(fsPath);
+        }
       }
     }
 

--- a/test/convert/transformers/metadataTransformerFactory.test.ts
+++ b/test/convert/transformers/metadataTransformerFactory.test.ts
@@ -18,7 +18,7 @@ import { DECOMPOSED_COMPONENT } from '../../mock/type-constants/customObjectCons
 import { COMPONENT_1 } from '../../mock/type-constants/customlabelsConstant';
 import { RegistryError } from '../../../src/errors';
 import { nls } from '../../../src/i18n';
-import { registry } from '../../../scripts/update-registry/update2';
+import { registry } from '../../../src/registry';
 
 const registryAccess = new RegistryAccess();
 

--- a/test/convert/transformers/metadataTransformerFactory.test.ts
+++ b/test/convert/transformers/metadataTransformerFactory.test.ts
@@ -61,7 +61,10 @@ describe('MetadataTransformerFactory', () => {
   it('should throw an error for a missing transformer mapping', () => {
     const component = new SourceComponent({
       name: 'Test',
-      type: registry.types.apexclass,
+      type: {
+        ...registry.types.apexclass,
+        strategies: { adapter: 'matchingContentFile', transformer: 'MissingStrategies' },
+      },
       xml: 'Test.xml',
     });
     component.type.strategies.transformer = 'MissingStrategies';


### PR DESCRIPTION
### What does this PR do?
make a more complete `forceIgnoredPaths` 

### What issues does this PR fix or reference?
@W-10449080@

### Functionality Before

forceignored from metadataResolver or componentSet would only list resolved components that were ignored.  Commonly ignored files like `lwc/jsconfig.json` were not listed even though they were ignored because they weren't being recognized as components.
