### PR TITLE
fix: convert CFT

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -114,6 +114,9 @@ export class MetadataConverter {
           break;
       }
 
+      // only types that are addressable should be written - I'm looking at you CustomFieldTranslation
+      components = Array.from(components).filter((comp) => comp.type.isAddressable !== false);
+
       const conversionPipeline = pipeline(
         new ComponentReader(components),
         new ComponentConverter(targetFormat, this.registry, mergeSet, defaultDirectory),


### PR DESCRIPTION
### What does this PR do?
when converting a project that included `CustomFieldTranslations` an unaddressable type, we were writing them even though they shouldn't be

QA: install sfdx-cli@7.123.0 and `sfdx force:source:convert --outputdir=7.123.0` the [EDA](https://github.com/SalesforceFoundation/EDA) project, inspect the package and note lack of `fields` directory

install a newer version and `sfdx force:source:convert --outputdir=bad`

link this branch and `sfdx force:source:convert --outputdir=test`

`diff` the directories like `diff -rq 7.123.0 bad` and see it mention the `fields` directory
then `diff -rq 7.123.0 test` and note it's identical
then add some gibberish to a file in `test` and run the `diff` again, it'll pick it up, so the two directories are 100% identical

✅ : plugin-source NUTs "pass" (few unrelated failures)
✅ : UTs
✅ : `diff` command check

### What issues does this PR fix or reference?

#[1383](https://github.com/forcedotcom/cli/issues/1383), @W-10501883@

### Functionality Before

would write `fields` directory and populate it with CFT

### Functionality After
no `field` directory
