### PR TITLE
chore: split source nuts in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,7 @@ jobs:
       - run:
           name: Nuts
           command: |
-            echo "Using node: $(node --version)"
-            echo "Environment Variables:"
-            env
-            NODE_OPTIONS=--max-old-space-size=8192 yarn test:nuts
+            <<parameters.test_command>>
 
 workflows:
   version: 2
@@ -169,13 +166,27 @@ workflows:
               ignore: main
           requires:
             - release-management/test-package
+            - release-management/test-nut
           sfdx_version: latest
-          size: 2xlarge
+          size: large
           matrix:
             parameters:
               os: [linux]
               node_version: [lts]
               external_project_git_url: ['https://github.com/salesforcecli/plugin-source']
+              test_command:
+                [
+                  'yarn test:nuts:convert',
+                  'yarn test:nuts:delete',
+                  'yarn test:nuts:deploy',
+                  'yarn test:nuts:deploy:async',
+                  'yarn test:nuts:folders',
+                  'yarn test:nuts:manifest:create',
+                  'yarn test:nuts:mdapi',
+                  'yarn test:nuts:retrieve',
+                  'yarn test:nuts:specialTypes',
+                  'yarn test:nuts:tracking',
+                ]
       - release-management/release-package:
           github-release: true
           post-job-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,9 +170,8 @@ workflows:
               ignore: main
           requires:
             - release-management/test-package
-            - release-management/test-nut
           sfdx_version: latest
-          size: large
+          size: medium
           matrix:
             parameters:
               os: [linux]
@@ -184,7 +183,6 @@ workflows:
                   'yarn test:nuts:delete',
                   'yarn test:nuts:deploy',
                   'yarn test:nuts:deploy:async',
-                  'yarn test:nuts:folders',
                   'yarn test:nuts:manifest:create',
                   'yarn test:nuts:mdapi',
                   'yarn test:nuts:retrieve',

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
     description: Runs NUTs from other (external) repos by cloning them.  Substitutes a dependency for the current pull request.  For example, you're testing a PR to a library and want to test a plugin in another repo that uses the library.
 
     parameters:
+      test_command:
+        type: string
+        description: 'command to execute (ex: yarn test:nuts)'
+        default: 'yarn test:nuts'
       node_version:
         description: version of node to run tests against
         type: string

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -483,14 +483,20 @@ v55 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|BotTemplate|❌|Not supported, but support could be added|
 |DataActionDefinition|❌|Not supported, but support could be added|
 |Experience|undefined|undefined|
+|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
 |IndustriesAutomotiveSettings|✅||
+|IndustriesMfgServiceSettings|✅||
+|InvLatePymntRiskCalcSettings|✅||
+|PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
 |SchedulingObjective|❌|Not supported, but support could be added|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|
+|SubscriptionManagementSettings|✅||
 |VoiceSettings|✅||
 
 ## Additional Types


### PR DESCRIPTION
### What does this PR do?
Rather than running all source NUTs in 1 container, break them up so that only some NUTs are run in a container while still running them all.

### What issues does this PR fix or reference?
@W-0@

### Functionality Before
runs all source nuts in 1 container

### Functionality After
runs pieces of source nuts in a container
