### PR TITLE
fix: sort ComponentSet.getObject

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -330,12 +330,12 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
 
     const typeMembers: PackageTypeMembers[] = [];
     for (const [typeName, members] of typeMap.entries()) {
-      typeMembers.push({ members, name: typeName });
+      typeMembers.push({ members: members.sort(), name: typeName });
     }
 
     return {
       Package: {
-        types: typeMembers,
+        types: typeMembers.sort((a, b) => (a.name > b.name ? 1 : -1)),
         version: this.sourceApiVersion || this.apiVersion,
         fullName: this.fullName,
       },

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -387,8 +387,8 @@ describe('ComponentSet', () => {
     it('should include required child types as defined in the registry', () => {
       const set = new ComponentSet([MATCHING_RULES_COMPONENT]);
       expect(set.getObject().Package.types).to.deep.equal([
-        { name: MATCHING_RULES_COMPONENT.type.name, members: [MATCHING_RULES_COMPONENT.name] },
         { name: 'MatchingRule', members: ['MatchingRules.My_Account_Matching_Rule'] },
+        { name: MATCHING_RULES_COMPONENT.type.name, members: [MATCHING_RULES_COMPONENT.name] },
       ]);
     });
 
@@ -407,7 +407,7 @@ describe('ComponentSet', () => {
       set.add(new SourceComponent({ name: 'myType2', type }));
       set.add(new SourceComponent({ name: 'myType', type }));
       expect(set.getObject().Package.types).to.deep.equal([
-        { members: ['myType', '*', 'myType2'], name: 'CustomObject' },
+        { members: ['*', 'myType', 'myType2'], name: 'CustomObject' },
       ]);
     });
 


### PR DESCRIPTION
What does this PR do?
sort manifest type members and types by name

What issues does this PR fix or reference?
@W-0@

Functionality Before
output of getPackageXml was not sorted

Functionality After
output of getPackageXml is sorted (type members and types by name)