### PR TITLE
Sm/settings messages bug

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -484,7 +484,6 @@ v55 introduces the following new types.  Here's their current level of support
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
 |BotTemplate|❌|Not supported, but support could be added|
-|DataActionDefinition|❌|Not supported, but support could be added|
 |Experience|undefined|undefined|
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -188,6 +188,13 @@ export class DeployResult implements MetadataTransferResult {
    * TODO: remove cases if fixes are made in the api.
    */
   private sanitizeDeployMessage(message: DeployMessage): DeployMessage {
+    // mdapi error messages have the type as "FooSettings" but SDR only recognizes "Settings"
+    if (message.componentType.endsWith('Settings') && message.fileName.endsWith('.settings')) {
+      return {
+        ...message,
+        componentType: 'Settings',
+      };
+    }
     switch (message.componentType) {
       case registry.types.lightningcomponentbundle.name:
         // remove the markup scheme from fullName


### PR DESCRIPTION
### What does this PR do?
Imagine the deploy messages has a failure on a Setting component {"SecuritySettings#Security" => Array(1)}
But then it calls key() which receives the registryType of Settings with name Security
- it returns Settings#Security
- which doesn’t match, and therefore doesn’t appear in FileResponses 

Then, because push is modifying the FileResponses instead of trusting the top-level status (which it has to do for idempotent deletes where the file was delete locally, but then “pushed” to an org that didn’t have the file and we have to not treat that as a failure) *it receives no errors from SDR FileReponses()*


### What issues does this PR fix or reference?
@W-10678876@

### Functionality Before
File responses didn't contain an error on settings deploy failures

### Functionality After
error exists in FileResponses

### QA tips
there's a repro from the customer...you just need a "bad" custom setting that will fail to deploy.
you can run `force:source:beta:status` to see the state of tracking file after the `push`