### PR TITLE
Wr/memory usage

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -488,9 +488,11 @@ v55 introduces the following new types.  Here's their current level of support
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
+|FavoriteTransferDestination|❌|Not supported, but support could be added|
 |IndustriesAutomotiveSettings|✅||
 |IndustriesMfgServiceSettings|✅||
 |InvLatePymntRiskCalcSettings|✅||
+|LiveChatObjectAccessDefinition|❌|Not supported, but support could be added|
 |PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|

--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -10,7 +10,7 @@ import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '../common';
 import { ComponentSet } from '../collections';
 import { normalizeToArray } from '../utils';
 import { RecompositionStrategy, TransformerStrategy } from '../registry';
-import { MetadataComponent, SourceComponent, NodeFSTreeContainer, TreeContainer } from '../resolve';
+import { MetadataComponent, NodeFSTreeContainer, SourceComponent, TreeContainer } from '../resolve';
 import { JsToXml } from './streams';
 import { WriteInfo, WriterFormat } from './types';
 
@@ -337,6 +337,7 @@ export class ConvertContext {
   public readonly decomposition = new DecompositionFinalizer();
   public readonly recomposition = new RecompositionFinalizer();
   public readonly nonDecomposition = new NonDecompositionFinalizer();
+  public readonly pipeline;
 
   // eslint-disable-next-line @typescript-eslint/require-await
   public async *executeFinalizers(defaultDirectory?: string): AsyncIterable<WriterFormat[]> {

--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -10,7 +10,7 @@ import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '../common';
 import { ComponentSet } from '../collections';
 import { normalizeToArray } from '../utils';
 import { RecompositionStrategy, TransformerStrategy } from '../registry';
-import { MetadataComponent, NodeFSTreeContainer, SourceComponent, TreeContainer } from '../resolve';
+import { MetadataComponent, SourceComponent, NodeFSTreeContainer, TreeContainer } from '../resolve';
 import { JsToXml } from './streams';
 import { WriteInfo, WriterFormat } from './types';
 
@@ -337,7 +337,6 @@ export class ConvertContext {
   public readonly decomposition = new DecompositionFinalizer();
   public readonly recomposition = new RecompositionFinalizer();
   public readonly nonDecomposition = new NonDecompositionFinalizer();
-  public readonly pipeline;
 
   // eslint-disable-next-line @typescript-eslint/require-await
   public async *executeFinalizers(defaultDirectory?: string): AsyncIterable<WriterFormat[]> {

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -13,11 +13,11 @@ import { JsonMap } from '@salesforce/ts-types';
 import { j2xParser } from 'fast-xml-parser';
 import { Logger } from '@salesforce/core';
 import { MetadataResolver, SourceComponent } from '../resolve';
-import { ensureFileExists } from '../utils/fileSystemHandler';
 import { SourcePath, XML_DECL } from '../common';
 import { ComponentSet } from '../collections';
 import { LibraryError } from '../errors';
 import { RegistryAccess } from '../registry';
+import { ensureFileExists } from '../utils/fileSystemHandler';
 import { MetadataTransformerFactory } from './transformers';
 import { ConvertContext } from './convertContext';
 import { SfdxFileFormat, WriteInfo, WriterFormat } from './types';
@@ -92,6 +92,7 @@ export class ComponentConverter extends Transform {
       try {
         const converts: Array<Promise<WriteInfo[]>> = [];
         const transformer = this.transformerFactory.getTransformer(chunk);
+        transformer.defaultDirectory = this.defaultDirectory;
         const mergeWith = this.mergeSet?.getSourceComponents(chunk);
         switch (this.targetFormat) {
           case 'source':

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { basename, dirname, isAbsolute, join } from 'path';
-import { pipeline as cbPipeline, Readable, Transform, Writable, Stream } from 'stream';
+import { pipeline as cbPipeline, Readable, Stream, Transform, Writable } from 'stream';
 import { promisify } from 'util';
 import { Archiver, create as createArchive } from 'archiver';
 import { createWriteStream, existsSync } from 'graceful-fs';
@@ -163,43 +163,43 @@ export class StandardWriter extends ComponentWriter {
     if (chunk.writeInfos.length !== 0) {
       try {
         const toResolve: string[] = [];
-        const writeTasks = chunk.writeInfos.map((info: WriteInfo) => {
-          const fullDest = isAbsolute(info.output) ? info.output : join(this.rootDestination, info.output);
-          if (!existsSync(fullDest)) {
-            for (const ignoredPath of this.forceIgnoredPaths) {
-              if (
-                dirname(ignoredPath).includes(dirname(fullDest)) &&
-                basename(ignoredPath).includes(basename(fullDest))
-              ) {
-                return;
-              }
-            }
-          }
-          if (this.forceIgnoredPaths.has(fullDest)) {
-            return;
-          }
-          // if there are children, resolve each file. o/w just pick one of the files to resolve
-          if (toResolve.length === 0 || chunk.component.type.children) {
-            // This is a workaround for a server side ListViews bug where
-            // duplicate components are sent. W-9614275
-            if (toResolve.includes(fullDest)) {
-              this.logger.debug(`Ignoring duplicate metadata for: ${fullDest}`);
-              return;
-            }
-            toResolve.push(fullDest);
-          }
-          ensureFileExists(fullDest);
-          return pipeline(info.source, createWriteStream(fullDest));
-        });
-
         // it is a reasonable expectation that when a conversion call exits, the files of
         // every component has been written to the destination. This await ensures the microtask
         // queue is empty when that call exits and overall less memory is consumed.
-        await Promise.all(writeTasks);
+        await Promise.all(
+          chunk.writeInfos.map((info: WriteInfo) => {
+            const fullDest = isAbsolute(info.output) ? info.output : join(this.rootDestination, info.output);
+            if (!existsSync(fullDest)) {
+              for (const ignoredPath of this.forceIgnoredPaths) {
+                if (
+                  dirname(ignoredPath).includes(dirname(fullDest)) &&
+                  basename(ignoredPath).includes(basename(fullDest))
+                ) {
+                  return;
+                }
+              }
+            }
+            if (this.forceIgnoredPaths.has(fullDest)) {
+              return;
+            }
+            // if there are children, resolve each file. o/w just pick one of the files to resolve
+            if (toResolve.length === 0 || chunk.component.type.children) {
+              // This is a workaround for a server side ListViews bug where
+              // duplicate components are sent. W-9614275
+              if (toResolve.includes(fullDest)) {
+                this.logger.debug(`Ignoring duplicate metadata for: ${fullDest}`);
+                return;
+              }
+              toResolve.push(fullDest);
+            }
+            ensureFileExists(fullDest);
+            return pipeline(info.source, createWriteStream(fullDest));
+          })
+        );
 
-        for (const fsPath of toResolve) {
+        toResolve.map((fsPath) => {
           this.converted.push(...this.resolver.getComponentsFromPath(fsPath));
-        }
+        });
       } catch (e) {
         err = e as Error;
       }

--- a/src/convert/transformers/baseMetadataTransformer.ts
+++ b/src/convert/transformers/baseMetadataTransformer.ts
@@ -11,6 +11,7 @@ import { RegistryAccess } from '../../registry';
 
 export abstract class BaseMetadataTransformer implements MetadataTransformer {
   public readonly context: ConvertContext;
+  public defaultDirectory?: string;
   protected registry: RegistryAccess;
 
   public constructor(registry = new RegistryAccess(), context = new ConvertContext()) {

--- a/src/convert/types.ts
+++ b/src/convert/types.ts
@@ -72,7 +72,6 @@ export type MergeConfig = {
  */
 export interface MetadataTransformer {
   defaultDirectory?: string;
-  writeAsSoonAsPossible?: boolean;
   toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]>;
   toSourceFormat(component: SourceComponent, mergeWith?: SourceComponent): Promise<WriteInfo[]>;
 }

--- a/src/convert/types.ts
+++ b/src/convert/types.ts
@@ -71,6 +71,8 @@ export type MergeConfig = {
  * Transforms metadata component files into different SFDX file formats
  */
 export interface MetadataTransformer {
+  defaultDirectory?: string;
+  writeAsSoonAsPossible?: boolean;
   toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]>;
   toSourceFormat(component: SourceComponent, mergeWith?: SourceComponent): Promise<WriteInfo[]>;
 }

--- a/test/convert/transformers/staticResourceMetadataTransformer.test.ts
+++ b/test/convert/transformers/staticResourceMetadataTransformer.test.ts
@@ -5,10 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { basename, join } from 'path';
+import deepEqualInAnyOrder = require('deep-equal-in-any-order');
+
 import * as archiver from 'archiver';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import { CentralDirectory, Entry, Open } from 'unzipper';
+import chai = require('chai');
 import { registry, SourceComponent, VirtualTreeContainer, WriteInfo } from '../../../src';
 import { StaticResourceMetadataTransformer } from '../../../src/convert/transformers/staticResourceMetadataTransformer';
 import { LibraryError } from '../../../src/errors';
@@ -21,6 +24,8 @@ import {
 } from '../../mock/type-constants/staticresourceConstant';
 import { TestReadable } from '../../mock/convert/readables';
 import { DEFAULT_PACKAGE_ROOT_SFDX } from '../../../src/common';
+
+chai.use(deepEqualInAnyOrder);
 
 const env = createSandbox();
 
@@ -123,7 +128,7 @@ describe('StaticResourceMetadataTransformer', () => {
       try {
         await transformer.toMetadataFormat(component);
       } catch (e) {
-        expect(e.message).to.equal(
+        expect(e.message).to.deep.equalInAnyOrder(
           nls.localize('error_static_resource_missing_resource_file', [join('staticresources', component.name)])
         );
       }
@@ -170,7 +175,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should rename extension from .resource for a fallback mime extension', async () => {
@@ -193,7 +198,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should rename extension from .resource for an unsupported mime extension', async () => {
@@ -216,7 +221,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should ignore components without content', async () => {
@@ -242,7 +247,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
       expect(pipelineStub.callCount).to.equal(1);
       expect(pipelineStub.firstCall.args[1]).to.equal(
         join(
@@ -275,7 +280,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should merge output with merge component when content is archive', async () => {
@@ -356,7 +361,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component, mergeComponent)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component, mergeComponent)).to.deep.equalInAnyOrder(expectedInfos);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Begins writing StaticResource files as soon as possible, rather than deferring them to the `WriteInfos` and finalizers

### What issues does this PR fix or reference?

[1348](https://github.com/forcedotcom/cli/issues/1348), @W-10417338@

### Functionality Before
A large spike in memory usage as SDR writes all SR files, up to 3GB but really unrestricted

### Functionality After
no spike in memory usage when writing SR files


QA helpful notes:
clone the repo mentioned in the issue
open activity monitory
deploy everything in the project to a new SO
`retrieve -m StaticResource` while looking at activity monitory
notice huge spike in the memory right before it prints the table, the spinner even slows down