### PR TITLE
Sm/tweaks fp

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -488,9 +488,11 @@ v55 introduces the following new types.  Here's their current level of support
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
+|FavoriteTransferDestination|❌|Not supported, but support could be added|
 |IndustriesAutomotiveSettings|✅||
 |IndustriesMfgServiceSettings|✅||
 |InvLatePymntRiskCalcSettings|✅||
+|LiveChatObjectAccessDefinition|❌|Not supported, but support could be added|
 |PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|

--- a/test/convert/transformers/staticResourceMetadataTransformer.test.ts
+++ b/test/convert/transformers/staticResourceMetadataTransformer.test.ts
@@ -5,10 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { basename, join } from 'path';
+import deepEqualInAnyOrder = require('deep-equal-in-any-order');
+
 import * as archiver from 'archiver';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import { CentralDirectory, Entry, Open } from 'unzipper';
+import chai = require('chai');
 import { registry, SourceComponent, VirtualTreeContainer, WriteInfo } from '../../../src';
 import { StaticResourceMetadataTransformer } from '../../../src/convert/transformers/staticResourceMetadataTransformer';
 import { LibraryError } from '../../../src/errors';
@@ -21,6 +24,8 @@ import {
 } from '../../mock/type-constants/staticresourceConstant';
 import { TestReadable } from '../../mock/convert/readables';
 import { DEFAULT_PACKAGE_ROOT_SFDX } from '../../../src/common';
+
+chai.use(deepEqualInAnyOrder);
 
 const env = createSandbox();
 
@@ -123,7 +128,7 @@ describe('StaticResourceMetadataTransformer', () => {
       try {
         await transformer.toMetadataFormat(component);
       } catch (e) {
-        expect(e.message).to.equal(
+        expect(e.message).to.deep.equalInAnyOrder(
           nls.localize('error_static_resource_missing_resource_file', [join('staticresources', component.name)])
         );
       }
@@ -170,7 +175,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should rename extension from .resource for a fallback mime extension', async () => {
@@ -193,7 +198,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should rename extension from .resource for an unsupported mime extension', async () => {
@@ -216,7 +221,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should ignore components without content', async () => {
@@ -242,7 +247,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
       expect(pipelineStub.callCount).to.equal(1);
       expect(pipelineStub.firstCall.args[1]).to.equal(
         join(
@@ -275,7 +280,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component)).to.deep.equalInAnyOrder(expectedInfos);
     });
 
     it('should merge output with merge component when content is archive', async () => {
@@ -356,7 +361,7 @@ describe('StaticResourceMetadataTransformer', () => {
         },
       ];
 
-      expect(await transformer.toSourceFormat(component, mergeComponent)).to.deep.equal(expectedInfos);
+      expect(await transformer.toSourceFormat(component, mergeComponent)).to.deep.equalInAnyOrder(expectedInfos);
     });
   });
 });


### PR DESCRIPTION
What does this PR do?
Begins writing StaticResource files as soon as possible, rather than deferring them to the WriteInfos and finalizers

What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1348, @W-10417338@

Functionality Before
A large spike in memory usage as SDR writes all SR files, up to 3GB but really unrestricted

Functionality After
no spike in memory usage when writing SR files

QA helpful notes:
clone the repo mentioned in the issue
open activity monitory
deploy everything in the project to a new SO
retrieve -m StaticResource while looking at activity monitory
notice huge spike in the memory right before it prints the table, the spinner even slows down