### PR TITLE
Sm/file-responses-windows-paths-bug

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -488,9 +488,11 @@ v55 introduces the following new types.  Here's their current level of support
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
+|FavoriteTransferDestination|❌|Not supported, but support could be added|
 |IndustriesAutomotiveSettings|✅||
 |IndustriesMfgServiceSettings|✅||
 |InvLatePymntRiskCalcSettings|✅||
+|LiveChatObjectAccessDefinition|❌|Not supported, but support could be added|
 |PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, extname, join } from 'path';
+import { basename, dirname, extname, join, posix, sep } from 'path';
 import { isString } from '@salesforce/ts-types';
 import { create as createArchive } from 'archiver';
 import * as fs from 'graceful-fs';
@@ -30,6 +30,7 @@ export class DeployResult implements MetadataTransferResult {
   public readonly response: MetadataApiDeployStatus;
   public readonly components: ComponentSet;
   private readonly diagnosticUtil = new DiagnosticUtil('metadata');
+  private readonly shouldConvertPaths = sep !== posix.sep;
 
   public constructor(response: MetadataApiDeployStatus, components: ComponentSet) {
     this.response = response;
@@ -215,7 +216,7 @@ export class DeployResult implements MetadataTransferResult {
 
   private key(component: ComponentLike): string {
     const type = typeof component.type === 'string' ? component.type : component.type.name;
-    return `${type}#${component.fullName}`;
+    return `${type}#${this.shouldConvertPaths ? component.fullName.split(sep).join(posix.sep) : component.fullName}`;
   }
 }
 

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -367,13 +367,16 @@ describe('MetadataApiDeploy', () => {
           expect(responses).to.deep.equal(expected);
         });
 
+        // folder types have a name like TestFolder/TestImageDoc
+        // which may include a platform-specific separator TestFolder\\TestImageDoc
         it('should fix deploy message issue for "Document" type', () => {
           const type = registry.types.document;
           const name = 'test';
+          const foldername = 'A_Folder';
           const contentName = `${name}.xyz`;
-          const basePath = join('path', 'to', type.directoryName, 'A_Folder');
+          const basePath = join('path', 'to', type.directoryName, foldername);
           const props = {
-            name: 'test',
+            name: join(foldername, name),
             type,
             xml: join(basePath, `${name}.document${META_XML_SUFFIX}`),
             content: join(basePath, contentName),
@@ -393,7 +396,7 @@ describe('MetadataApiDeploy', () => {
                 deleted: 'false',
                 success: 'true',
                 // fullname contains file extension that must be stripped
-                fullName: contentName,
+                fullName: join(foldername, name),
                 componentType: type.name,
               } as DeployMessage,
             },


### PR DESCRIPTION
### What does this PR do?
SDR FileResponses were missing members on Windows for Documents (and probably other inFolder types) due to path separators not being handled when generating the message keys

the UT was building an invalid component (fullname includes folder when in a folder)

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1398
@W-10678360@

see github issue for expected/actual

QA:
You can repro with the user's repo/steps from the issue
You can also just use `force:source:deploy` and see the Document missing from the output