### PR TITLE
feat(metadata registry): adding flowtest type to metadata registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -618,6 +618,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "flowtest": {
+      "id": "flowtest",
+      "name": "FlowTest",
+      "suffix": "flowtest",
+      "directoryName": "flowTest",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "eventtype": {
       "id": "eventtype",
       "name": "EventType",
@@ -2861,6 +2869,7 @@
     "recommendationStrategy": "recommendationstrategy",
     "flow": "flow",
     "flowDefinition": "flowdefinition",
+    "flowtest": "flowtest",
     "eventType": "eventtype",
     "subscription": "eventsubscription",
     "delivery": "eventdelivery",


### PR DESCRIPTION
### What does this PR do?
Add new FlowTest type to metadataRegistry

### What issues does this PR fix or reference?

#<[Sfdx force:source for FlowTest](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Uk6aYAC/view)>, @W-9790379@

### Functionality Before
Sfdx force:source commands did not work for FlowTest type

### Functionality After

Sfdx force:source commands work for FlowTest type
