### PR TITLE
fix(metadata registry): update directory name for flowtest in registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -622,7 +622,7 @@
       "id": "flowtest",
       "name": "FlowTest",
       "suffix": "flowtest",
-      "directoryName": "flowTest",
+      "directoryName": "flowtests",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?
A previous [PR](https://github.com/forcedotcom/source-deploy-retrieve/pull/580) had added FlowTest to the registry. This PR updates the directoryName for FlowTest.

### What issues does this PR fix or reference?
#<https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Uk6aYAC/view>, @W-9790379@

### Functionality Before
FlowTest directoryName was flowTest

### Functionality After
FlowTest directoryName is updated to flowtests
