### PR TITLE
fix: fix fullName undefined in manifest

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -374,13 +374,18 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       typeMembers.push({ members: members.sort(), name: typeName });
     }
 
-    return {
+    const pkg: PackageManifestObject = {
       Package: {
         types: typeMembers.sort((a, b) => (a.name > b.name ? 1 : -1)),
         version: this.sourceApiVersion || this.apiVersion,
-        fullName: this.fullName,
       },
     };
+
+    if (this.fullName) {
+      pkg.Package.fullName = this.fullName;
+    }
+
+    return pkg;
   }
 
   /**

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -18,7 +18,7 @@ export interface PackageManifestObject {
   Package: {
     types: PackageTypeMembers[];
     version: string;
-    fullName: string;
+    fullName?: string;
     [XML_NS_KEY]?: string;
   };
 }

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -348,7 +348,6 @@ describe('ComponentSet', () => {
       });
       expect(set.getObject()).to.deep.equal({
         Package: {
-          fullName: undefined,
           types: [
             {
               name: registry.types.customobjecttranslation.name,
@@ -373,7 +372,6 @@ describe('ComponentSet', () => {
       });
       expect(set.getObject(DestructiveChangesType.POST)).to.deep.equal({
         Package: {
-          fullName: undefined,
           types: [
             {
               name: registry.types.customobjecttranslation.name,
@@ -423,7 +421,6 @@ describe('ComponentSet', () => {
       set.sourceApiVersion = '45.0';
       expect(set.getObject()).to.deep.equal({
         Package: {
-          fullName: undefined,
           types: [
             {
               name: registry.types.customobjecttranslation.name,


### PR DESCRIPTION
### What does this PR do?

Proposal to fix `<fullName>undefined</fullName>` in manifest.

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

e.g.
```
Error  unpackaged/package.xml  package.xml  You cannot install or upgrade a package that has a AssignmentRule component. Remove components of AssignmentRule type from the package.
```
### Functionality After

successful deployment with manfest created by `force:mdapi:beta:retrieve`