### PR TITLE
Added DM/ES and its versions in metadataRegistry.json

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -486,22 +486,25 @@ v55 introduces the following new types.  Here's their current level of support
 |AssessmentQuestion|❌|Not supported, but support could be added|
 |AssessmentQuestionSet|❌|Not supported, but support could be added|
 |BotTemplate|❌|Not supported, but support could be added|
+|CallCtrAgentFavTrfrDest|❌|Not supported, but support could be added|
 |ConvReasonReportDefinition|❌|Not supported, but support could be added|
 |ConvReasonReportSegmentDef|❌|Not supported, but support could be added|
 |CustomAddressFieldSettings|✅||
-|DecisionMatrixDefinition|❌|Not supported, but support could be added|
-|DecisionMatrixDefinitionVersion|❌|Not supported, but support could be added|
-|Experience|undefined|undefined|
-|ExperienceMetadataResource|undefined|undefined|
-|ExperienceSpace|undefined|undefined|
-|ExpressionSetDefinition|❌|Not supported, but support could be added|
-|ExpressionSetDefinitionVersion|❌|Not supported, but support could be added|
+|DataImportManagementSettings|✅||
+|DecisionMatrixDefinition|✅||
+|DecisionMatrixDefinitionVersion|✅||
+|DigitalExperience|undefined|undefined|
+|DigitalExperienceBundle|undefined|undefined|
+|DigitalExperienceBundleSetting|undefined|undefined|
+|ExpressionSetDefinition|✅||
+|ExpressionSetDefinitionVersion|✅||
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
-|FavoriteTransferDestination|❌|Not supported, but support could be added|
+|FlowTest|✅||
 |IndustriesAutomotiveSettings|✅||
 |InvLatePymntRiskCalcSettings|✅||
+|MeetingsSettings|✅||
 |PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|
@@ -526,7 +529,6 @@ v55 introduces the following new types.  Here's their current level of support
 - FormSection
 - Portal
 - EmbeddedServiceFieldService
-- FlowTest
 - EventType
 - EventSubscription
 - EventDelivery

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2284,6 +2284,34 @@
       "directoryName": "decisionTableDatasetLinks",
       "strictDirectoryName": false
     },
+    "decisionmatrixdefinition": {
+      "id": "decisionmatrixdefinition",
+      "name": "DecisionMatrixDefinition",
+      "suffix": "decisionMatrixDefinition",
+      "directoryName": "decisionMatrixDefinitions",
+      "strictDirectoryName": false
+    },
+    "decisionmatrixdefinitionversion": {
+      "id": "decisionmatrixdefinitionversion",
+      "name": "DecisionMatrixDefinitionVersion",
+      "suffix": "decisionMatrixDefinitionVersion",
+      "directoryName": "decisionMatrixDefinitionVersions",
+      "strictDirectoryName": false
+    },
+    "expressionsetdefinition": {
+      "id": "expressionsetdefinitionversion",
+      "name": "ExpressionSetDefinitionVersion",
+      "suffix": "expressionSetDefinitionVersion",
+      "directoryName": "expressionSetDefinitionVersions",
+      "strictDirectoryName": false
+    },
+    "expressionsetdefinition": {
+      "id": "expressionsetdefinition",
+      "name": "ExpressionSetDefinition",
+      "suffix": "expressionSetDefinition",
+      "directoryName": "expressionSetDefinitions",
+      "strictDirectoryName": false
+    },
     "briefcasedefinition": {
       "id": "briefcasedefinition",
       "name": "BriefcaseDefinition",
@@ -2978,6 +3006,10 @@
     "apt": "actionplantemplate",
     "decisionTable": "decisiontable",
     "decisionTableDatasetLink": "decisiontabledatasetlink",
+    "decisionMatrixDefinition": "decisionmatrixdefinition",
+    "decisionMatrixDefinitionVersion": "decisionmatrixdefinitionversion",
+    "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetDefinitionVersion": "expressionsetdefinitionversion",
     "briefcaseDefinition": "briefcasedefinition",
     "batchProcessJobDefinition": "batchprocessjobdefinition",
     "acctMgrTargetSetting": "acctmgrtargetsettings",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2298,7 +2298,7 @@
       "directoryName": "decisionMatrixDefinitionVersions",
       "strictDirectoryName": false
     },
-    "expressionsetdefinition": {
+    "expressionsetdefinitionversion": {
       "id": "expressionsetdefinitionversion",
       "name": "ExpressionSetDefinitionVersion",
       "suffix": "expressionSetDefinitionVersion",


### PR DESCRIPTION
### What does this PR do?
Adds source tracking for metadata objects: DecisionMatrixDefinition, DecisionMatrixDefinitionVersion, ExpressionSetDefinition, ExpressionSetDefinitionVersion

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/_classic/%2Fa07EE00000cuh9QYAQ
@W-10389702@


### Functionality Before
`sfdx force:source` commands did not work for DecisionMatrixDefinition, DecisionMatrixDefinitionVersion, ExpressionSetDefinition, ExpressionSetDefinitionVersion

### Functionality After
`sfdx force:source` commands should work for DecisionMatrixDefinition, DecisionMatrixDefinitionVersion, ExpressionSetDefinition, ExpressionSetDefinitionVersion
