### PR TITLE
fix: resolve strictDirectoryName types in mdapi format

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -499,8 +499,6 @@ v55 introduces the following new types.  Here's their current level of support
 |ExpressionSetDefinition|✅||
 |ExpressionSetDefinitionVersion|✅||
 |ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
-|ExternalDataTranField|❌|Not supported, but support could be added|
-|ExternalDataTranObject|❌|Not supported, but support could be added|
 |FlowTest|✅||
 |ForecastingFilter|❌|Not supported, but support could be added|
 |ForecastingFilterCondition|❌|Not supported, but support could be added|
@@ -511,10 +509,11 @@ v55 introduces the following new types.  Here's their current level of support
 |MessagingChannel|undefined|undefined|
 |PaymentsManagementEnabledSettings|✅||
 |RegisteredExternalService|❌|Not supported, but support could be added|
-|SchedulingObjective|❌|Not supported, but support could be added|
+|SchedulingObjective|undefined|undefined|
 |StreamingAppDataConnector|❌|Not supported, but support could be added|
 |SubscriptionManagementSettings|✅||
 |VoiceSettings|✅||
+|WarrantyLifecycleMgmtSettings|✅||
 
 ## Additional Types
 

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -174,8 +174,8 @@ export class MetadataResolver {
           // any of the following 3 options is considered a good match
           // mixedContent and bundles don't have a suffix to match
           ['mixedContent', 'bundle'].includes(type.strategies?.adapter) ||
-          // the suffix matches the type we think it is
-          (type.suffix && fsPath.endsWith(`${type.suffix}${META_XML_SUFFIX}`)) ||
+          // the file suffix (in source or mdapi format) matches the type suffix we think it is
+          (type.suffix && [type.suffix, `${type.suffix}${META_XML_SUFFIX}`].some((s) => fsPath.endsWith(s))) ||
           // the type has children and the path also includes THAT directory
           (type.children?.types &&
             Object.values(type.children?.types)

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -182,6 +182,21 @@ describe('MetadataResolver', () => {
         expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
       });
 
+      it('Should determine type for EmailServicesFunction metadata file (mdapi format)', () => {
+        const path = join('unpackaged', 'emailservices', 'MyEmailServices.xml');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([path]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const expectedComponent = new SourceComponent(
+          {
+            name: 'MyEmailServices',
+            type: registry.types.emailservicesfunction,
+            xml: path,
+          },
+          treeContainer
+        );
+        expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
+      });
+
       it('Should determine type for path of mixed content type', () => {
         const path = mixedContentDirectory.MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1];
         const access = testUtil.createMetadataResolver([

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -142,6 +142,46 @@ describe('MetadataResolver', () => {
         expect(access.getComponentsFromPath(path)).to.deep.equal([matchingContentFile.COMPONENT]);
       });
 
+      it('Should determine type for metadata file with known suffix and strictDirectoryName', () => {
+        // CustomSite is an example.  The conditions are:
+        //   1. Type has "strictDirectoryName": true
+        //   2. Type strategy adapter is neither "mixedContent" nor "bundle"
+        //   3. Type doesn't have children
+        //   4. mdapi format file path (E_Bikes.site)
+        const path = join('unpackaged', 'sites', 'E_Bikes.site');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([path]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const expectedComponent = new SourceComponent(
+          {
+            name: 'E_Bikes',
+            type: registry.types.customsite,
+            xml: path,
+          },
+          treeContainer
+        );
+        expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
+      });
+
+      it('Should determine type for source file with known suffix and strictDirectoryName', () => {
+        // CustomSite is an example.  The conditions are:
+        //   1. Type has "strictDirectoryName": true
+        //   2. Type strategy adapter is neither "mixedContent" nor "bundle"
+        //   3. Type doesn't have children
+        //   4. source format file path (E_Bikes.site-meta.xml)
+        const path = join('unpackaged', 'sites', 'E_Bikes.site-meta.xml');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([path]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const expectedComponent = new SourceComponent(
+          {
+            name: 'E_Bikes',
+            type: registry.types.customsite,
+            xml: path,
+          },
+          treeContainer
+        );
+        expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
+      });
+
       it('Should determine type for path of mixed content type', () => {
         const path = mixedContentDirectory.MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1];
         const access = testUtil.createMetadataResolver([


### PR DESCRIPTION
### What does this PR do?
Fixes `MetadataResolver` to match a file path in source format and mdapi format when testing types with strictDirectoryNames that also do not have an adapter strategy defined (those types are resolved properly another way).

This should fix the following types:
- CustomSite
- IntegrationHubSettings
- AppointmentSchedulingPolicy
- RestrictionRule
- ObjectHierarchyRelationship
- IndustriesManufacturingSettings
- DataSource
- FieldRestrictionRule
- AppointmentAssignmentPolicy

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1448
@W-10910004@

### Functionality Before
Would not resolve files in mdapi format with certain strictDirectoryName types such as CustomSite.  This would cause (e.g.) a retrieval of these types to fail to be written to the file system.

### Functionality After
Files resolve properly.  Metadata retrieval of these files are successful.
