### PR TITLE
Sm/timeout id in sfdx error

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -1,10 +1,10 @@
 # Supported CLI Metadata Types
 
-This list compares metadata types found in Salesforce v54 with the [metadata registry file](./src/registry/metadataRegistry.json) included in this repository.
+This list compares metadata types found in Salesforce v55 with the [metadata registry file](./src/registry/metadataRegistry.json) included in this repository.
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 442/467 supported metadata types.
+Currently, there are 456/494 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -48,6 +48,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |AppointmentSchedulingPolicy|✅||
 |ApprovalProcess|✅||
 |ArchiveSettings|✅||
+|AssessmentQuestion|❌|Not supported, but support could be added|
+|AssessmentQuestionSet|❌|Not supported, but support could be added|
 |AssignmentRules|✅||
 |AssistantContextItem|✅||
 |AssistantDefinition|✅||
@@ -55,7 +57,6 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |AssistantSkillSobjectAction|✅||
 |AssistantVersion|✅||
 |AssociationEngineSettings|✅||
-|AttributeDefinition2|❌|Not supported, but support could be added|
 |Audience|✅||
 |AuraDefinitionBundle|✅||
 |AuthProvider|✅||
@@ -69,6 +70,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |BlockchainSettings|✅||
 |Bot|✅||
 |BotSettings|✅||
+|BotTemplate|❌|Not supported, but support could be added|
 |BotVersion|✅||
 |BranchManagementSettings|✅||
 |BrandingSet|✅||
@@ -81,6 +83,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |CallCenter|✅||
 |CallCenterRoutingMap|✅||
 |CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
+|CallCtrAgentFavTrfrDest|❌|Not supported, but support could be added|
 |CampaignInfluenceModel|✅||
 |CampaignSettings|✅||
 |CanvasMetadata|✅||
@@ -119,6 +122,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |CorsWhitelistOrigin|✅||
 |CspTrustedSite|✅||
 |CurrencySettings|✅||
+|CustomAddressFieldSettings|✅||
 |CustomApplication|✅||
 |CustomApplicationComponent|✅||
 |CustomFeedFilter|✅||
@@ -142,6 +146,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |DataConnectorIngestApi|✅||
 |DataConnectorS3|✅||
 |DataDotComSettings|✅||
+|DataImportManagementSettings|✅||
 |DataMapping|✅||
 |DataMappingFieldDefinition|✅||
 |DataMappingObjectDefinition|✅||
@@ -150,11 +155,16 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |DataSourceObject|✅||
 |DataSourceTenant|✅||
 |DataStreamDefinition|✅||
+|DecisionMatrixDefinition|✅||
+|DecisionMatrixDefinitionVersion|✅||
 |DecisionTable|✅||
 |DecisionTableDatasetLink|✅||
 |DelegateGroup|✅||
 |DeploymentSettings|✅||
 |DevHubSettings|✅||
+|DigitalExperience|❌|Not supported, but support could be added (but not for tracking)|
+|DigitalExperienceBundle|❌|Not supported, but support could be added (but not for tracking)|
+|DigitalExperienceBundleSetting|❌|Not supported, but support could be added (but not for tracking)|
 |DiscoveryAIModel|✅||
 |DiscoveryGoal|✅||
 |DiscoverySettings|✅||
@@ -200,10 +210,13 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ExperienceBundleSettings|✅||
 |ExplainabilityActionDefinition|✅||
 |ExplainabilityActionVersion|✅||
+|ExpressionSetDefinition|✅||
+|ExpressionSetDefinitionVersion|✅||
 |ExternalAIModel|❌|Not supported, but support could be added|
 |ExternalCredential|❌|Not supported, but support could be added|
 |ExternalDataConnector|✅||
 |ExternalDataSource|✅||
+|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
 |ExternalServiceRegistration|✅||
@@ -224,6 +237,9 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |FlowCategory|✅||
 |FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
 |FlowSettings|✅||
+|FlowTest|✅||
+|ForecastingFilter|❌|Not supported, but support could be added|
+|ForecastingFilterCondition|❌|Not supported, but support could be added|
 |ForecastingObjectListSettings|✅||
 |ForecastingSettings|✅||
 |ForecastingSourceDefinition|✅||
@@ -243,19 +259,19 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |Icon|✅||
 |IdeasSettings|✅||
 |IdentityVerificationProcDef|❌|Not supported, but support could be added|
-|IdentityVerificationProcDtl|❌|Not supported, but support could be added|
-|IdentityVerificationProcFld|❌|Not supported, but support could be added|
 |IframeWhiteListUrlSettings|✅||
 |InboundCertificate|✅||
 |InboundNetworkConnection|✅||
 |IncidentMgmtSettings|✅||
 |Index|⚠️|Supports deploy/retrieve but not source tracking|
+|IndustriesAutomotiveSettings|✅||
 |IndustriesLoyaltySettings|✅||
 |IndustriesManufacturingSettings|✅||
 |IndustriesSettings|✅||
 |InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
 |InterestTaggingSettings|✅||
 |InternalDataConnector|✅||
+|InvLatePymntRiskCalcSettings|✅||
 |InventorySettings|✅||
 |InvocableActionSettings|✅||
 |IoTSettings|✅||
@@ -288,10 +304,13 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
 |ManagedTopics|✅||
 |MapsAndLocationSettings|✅||
+|MarketSegmentDefinition|❌|Not supported, but support could be added|
 |MarketingAppExtActivity|❌|Not supported, but support could be added|
 |MarketingAppExtension|❌|Not supported, but support could be added|
 |MatchingRules|✅||
 |MediaAdSalesSettings|✅||
+|MeetingsSettings|✅||
+|MessagingChannel|❌|Not supported, but support could be added (but not for tracking)|
 |MfgProgramTemplate|❌|Not supported, but support could be added|
 |MilestoneType|✅||
 |MktCalcInsightObjectDef|✅||
@@ -342,6 +361,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |PathAssistant|✅||
 |PathAssistantSettings|✅||
 |PaymentGatewayProvider|✅||
+|PaymentsManagementEnabledSettings|✅||
 |PermissionSet|✅||
 |PermissionSetGroup|✅||
 |PermissionSetLicenseDefinition|✅||
@@ -378,7 +398,9 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |RecordPageSettings|✅||
 |RecordType|✅||
 |RedirectWhitelistUrl|✅||
+|RegisteredExternalService|❌|Not supported, but support could be added|
 |RelatedRecordAssocCriteria|❌|Not supported, but support could be added|
+|RelationshipGraphDefinition|❌|Not supported, but support could be added|
 |RemoteSiteSetting|✅||
 |Report|✅||
 |ReportFolder|✅||
@@ -389,6 +411,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |SalesAgreementSettings|✅||
 |SalesWorkQueueSettings|✅||
 |SamlSsoConfig|✅||
+|SchedulingObjective|❌|Not supported, but support could be added|
 |SchedulingRule|✅||
 |SchemaSettings|✅||
 |ScoreCategory|❌|Not supported, but support could be added|
@@ -421,6 +444,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |StandardValueSetTranslation|✅||
 |StaticResource|✅||
 |StnryAssetEnvSrcCnfg|✅||
+|StreamingAppDataConnector|❌|Not supported, but support could be added|
+|SubscriptionManagementSettings|✅||
 |SurveySettings|✅||
 |SvcCatalogCategory|✅||
 |SvcCatalogFulfillmentFlow|✅||
@@ -453,6 +478,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |VehicleAssetEmssnSrcCnfg|✅||
 |ViewDefinition|✅||
 |VirtualVisitConfig|❌|Not supported, but support could be added|
+|VoiceSettings|✅||
+|WarrantyLifecycleMgmtSettings|✅||
 |WaveApplication|✅||
 |WaveComponent|✅||
 |WaveDashboard|✅||
@@ -480,41 +507,12 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 
 
 
-## Next Release (v55)
-v55 introduces the following new types.  Here's their current level of support
+## Next Release (v56)
+v56 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
-|AssessmentQuestion|❌|Not supported, but support could be added|
-|AssessmentQuestionSet|❌|Not supported, but support could be added|
-|BotTemplate|❌|Not supported, but support could be added|
-|CallCtrAgentFavTrfrDest|❌|Not supported, but support could be added|
-|CustomAddressFieldSettings|✅||
-|DataImportManagementSettings|✅||
-|DecisionMatrixDefinition|✅||
-|DecisionMatrixDefinitionVersion|✅||
-|DigitalExperience|❌|Not supported, but support could be added (but not for tracking)|
-|DigitalExperienceBundle|❌|Not supported, but support could be added (but not for tracking)|
-|DigitalExperienceBundleSetting|❌|Not supported, but support could be added (but not for tracking)|
-|ExpressionSetDefinition|✅||
-|ExpressionSetDefinitionVersion|✅||
-|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
-|FlowTest|✅||
-|ForecastingFilter|❌|Not supported, but support could be added|
-|ForecastingFilterCondition|❌|Not supported, but support could be added|
-|IndustriesAutomotiveSettings|✅||
-|InvLatePymntRiskCalcSettings|✅||
-|MarketSegmentDefinition|❌|Not supported, but support could be added (but not for tracking)|
-|MeetingsSettings|✅||
-|MessagingChannel|❌|Not supported, but support could be added (but not for tracking)|
-|PaymentsManagementEnabledSettings|✅||
-|RegisteredExternalService|❌|Not supported, but support could be added|
-|RelationshipGraphDefinition|❌|Not supported, but support could be added|
-|SchedulingObjective|❌|Not supported, but support could be added (but not for tracking)|
-|StreamingAppDataConnector|❌|Not supported, but support could be added|
-|SubscriptionManagementSettings|✅||
-|VoiceSettings|✅||
-|WarrantyLifecycleMgmtSettings|✅||
+|DigitalExperienceConfig|❌|Not supported, but support could be added (but not for tracking)|
 
 ## Additional Types
 


### PR DESCRIPTION
What does this PR do?
throws an sfdxError with data property for id on timeout.

I'm making a separate WI for SDR to use error/messages from core rather than its own framework.

What issues does this PR fix or reference?
[@W-10978703@](https://gus.lightning.force.com/a07EE00000ujyy4YAA)

for QA...SDR is emitting error.code 1 for backward compatibility.  I think the logic on plugin-source should set incompletes to 69 based on the mdapi status...but that's worth verifying