### PR TITLE
fix: support file responses for metadata format deploys

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -46,24 +46,48 @@ export class DeployResult implements MetadataTransferResult {
       const messages = this.getDeployMessages(this.response);
       const fileResponses: FileResponse[] = [];
 
-      for (const deployedComponent of this.components.getSourceComponents()) {
-        if (deployedComponent.type.children) {
-          for (const child of deployedComponent.getChildren()) {
-            const childMessages = messages.get(this.key(child));
-            if (childMessages) {
-              fileResponses.push(...this.createResponses(child, childMessages));
+      if (this.components) {
+        for (const deployedComponent of this.components.getSourceComponents()) {
+          if (deployedComponent.type.children) {
+            for (const child of deployedComponent.getChildren()) {
+              const childMessages = messages.get(this.key(child));
+              if (childMessages) {
+                fileResponses.push(...this.createResponses(child, childMessages));
+              }
             }
           }
+          const componentMessages = messages.get(this.key(deployedComponent));
+          if (componentMessages) {
+            fileResponses.push(...this.createResponses(deployedComponent, componentMessages));
+          }
         }
-        const componentMessages = messages.get(this.key(deployedComponent));
-        if (componentMessages) {
-          fileResponses.push(...this.createResponses(deployedComponent, componentMessages));
-        }
-      }
 
-      this.fileResponses = fileResponses.concat(this.deleteNotFoundToFileResponses(messages));
+        this.fileResponses = fileResponses.concat(this.deleteNotFoundToFileResponses(messages));
+      } else {
+        // if no this.components, this was likely a metadata format deploy so we need to process
+        // the componentSuccesses and componentFailures instead.
+        const successes = normalizeToArray(this.response.details.componentSuccesses);
+        const failures = normalizeToArray(this.response.details.componentFailures);
+        for (const component of [...successes, ...failures]) {
+          if (component.fullName === 'package.xml') continue;
+          const baseResponse: Partial<FileResponse> = {
+            fullName: component.fullName,
+            type: component.componentType,
+            state: this.getState(component),
+            filePath: component.fileName.replace(`zip${sep}`, ''),
+          };
+
+          if (baseResponse.state === ComponentStatus.Failed) {
+            baseResponse.error = component.problem;
+            baseResponse.problemType = component.problemType;
+          }
+
+          fileResponses.push(baseResponse as FileResponse);
+        }
+        this.fileResponses = fileResponses;
+      }
+      return this.fileResponses;
     }
-    return this.fileResponses;
   }
 
   private createResponses(component: SourceComponent, messages: DeployMessage[]): FileResponse[] {

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -86,8 +86,8 @@ export class DeployResult implements MetadataTransferResult {
         }
         this.fileResponses = fileResponses;
       }
-      return this.fileResponses;
     }
+    return this.fileResponses;
   }
 
   private createResponses(component: SourceComponent, messages: DeployMessage[]): FileResponse[] {

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -66,8 +66,8 @@ export class DeployResult implements MetadataTransferResult {
       } else {
         // if no this.components, this was likely a metadata format deploy so we need to process
         // the componentSuccesses and componentFailures instead.
-        const successes = normalizeToArray(this.response.details.componentSuccesses);
-        const failures = normalizeToArray(this.response.details.componentFailures);
+        const successes = normalizeToArray(this.response.details?.componentSuccesses || []);
+        const failures = normalizeToArray(this.response.details?.componentFailures || []);
         for (const component of [...successes, ...failures]) {
           if (component.fullName === 'package.xml') continue;
           const baseResponse: Partial<FileResponse> = {


### PR DESCRIPTION
### What does this PR do?

Supports file responses for metadata format deploys that have no component set

### What issues does this PR fix or reference?

@W-10748958@
