### PR TITLE
Fix resolve parent

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -176,11 +176,11 @@ export class MetadataResolver {
           ['mixedContent', 'bundle'].includes(type.strategies?.adapter) ||
           // the file suffix (in source or mdapi format) matches the type suffix we think it is
           (type.suffix && [type.suffix, `${type.suffix}${META_XML_SUFFIX}`].some((s) => fsPath.endsWith(s))) ||
-          // the type has children and the path also includes THAT directory
+          // the type has children and the file suffix (in source format) matches a child type suffix of the type we think it is
           (type.children?.types &&
             Object.values(type.children?.types)
-              .map((childType) => childType.directoryName)
-              .some((dirName) => pathParts.includes(dirName)))
+              .map((childType) => `${childType.suffix}${META_XML_SUFFIX}`)
+              .some((s) => fsPath.endsWith(s)))
       );
   }
 


### PR DESCRIPTION
What does this PR do?
Fix function resolveTypeFromStrictFolder for children of decomposed component types with decomposition topLevel e.g. (customobjecttranslation, bot)

(I'm unsure about dataMappingObjectDefinitions because I can't test it.)

What issues does this PR fix or reference?
@W-0@

Functionality Before
resolver.getComponentsFromPath doesn't resolve parent component for child types e.g. customfieldtranslation, botversion

Functionality After
resolver.getComponentsFromPath resolves parent component correctly for child types e.g. customfieldtranslation, botversion

The current solution doesn't match with decomposed component types with decomposition topLevel as the childType.directoryName is not part of the file path fspath.