### PR TITLE
fix: add handler for absent filename in mdt list

### DIFF
--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -96,6 +96,14 @@ export class ConnectionResolver {
       members = [];
     }
 
+    // if the Metadata Type doesn't return a correct fileName then help it out
+    for (const m of members) {
+      if (typeof m.fileName == 'object') {
+        const t = this.registry.getTypeByName(query.type);
+        m.fileName = `${t.directoryName}/${m.fullName}.${t.suffix}`;
+      }
+    }
+
     // Workaround because metadata.list({ type: 'StandardValueSet' }) returns []
     if (query.type === defaultRegistry.types.standardvalueset.name && members.length === 0) {
       const standardValueSetPromises = standardValueSet.fullnames.map(async (standardValueSetFullName) => {

--- a/test/resolve/connectionResolver.test.ts
+++ b/test/resolve/connectionResolver.test.ts
@@ -153,6 +153,29 @@ describe('ConnectionResolver', () => {
       ];
       expect(result.components).to.deep.equal(expected);
     });
+    it('should resolve components with invalid fileName returned by metadata api', async () => {
+      const metadataQueryStub = sandboxStub.stub(connection.metadata, 'list');
+      metadataQueryStub.withArgs({ type: 'SynonymDictionary' }).resolves([
+        {
+          ...StdFileProperty,
+          // @ts-ignore
+          fileName: { $: { 'xsi:nil': 'true' } },
+          fullName: '_Default',
+          // @ts-ignore
+          type: { $: { 'xsi:nil': 'true' } },
+        },
+      ]);
+
+      const resolver = new ConnectionResolver(connection);
+      const result = await resolver.resolve();
+      const expected: MetadataComponent[] = [
+        {
+          fullName: '_Default',
+          type: registry.types.synonymdictionary,
+        },
+      ];
+      expect(result.components).to.deep.equal(expected);
+    });
     it('should resolve components with folderContentType', async () => {
       const metadataQueryStub = sandboxStub.stub(connection.metadata, 'list');
 


### PR DESCRIPTION
### What does this PR do?
Some Metadata types return `<fileName xsi:nil="true"/>` in the XML response for `listMetadata`. In that case this should attempt to rebuild the fileName so that the downstream code doesn't crash.

### What issues does this PR fix or reference?

forcedotcom/cli/issues/1492

### Functionality Before

sfdx force:source:manifest:create --fromorg [org]
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object
    at new NodeError (node:internal/errors:371:5)
    at validateString (node:internal/validators:120:11)
    at extname (node:path:837:5)
    at extName (C:\Users\[username]\AppData\Local\sfdx\client\7.148.3-dbf0a7b\node_modules\@salesforce\source-deploy-retrieve\lib\src\utils\path.js:30:38)
    at ConnectionResolver.resolve (C:\Users\[username]\AppData\Local\sfdx\client\7.148.3-dbf0a7b\node_modules\@salesforce\source-deploy-retrieve\lib\src\resolve\connectionResolver.js:39:87)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Function.fromConnection (C:\Users\[username]\AppData\Local\sfdx\client\7.148.3-dbf0a7b\node_modules\@salesforce\source-deploy-retrieve\lib\src\collections\componentSet.js:141:26)
    at async Function.build (C:\Users\[username]\AppData\Local\sfdx\client\7.148.3-dbf0a7b\node_modules\@salesforce\source-deploy-retrieve\lib\src\collections\componentSetBuilder.js:90:40)
    at async createManifest (C:\Users\[username]\AppData\Local\sfdx\client\7.148.3-dbf0a7b\node_modules\@salesforce\plugin-source\lib\commands\force\source\manifest\create.js:51:30) {
  code: 'ERR_INVALID_ARG_TYPE'

### Functionality After

Should correctly build manifest files if the org leverages the `_default` SynonymDictionary


### Questions/Concerns

I don't think this strategy should need to be leveraged often, it could possibly be limited to only specific metadata that are determined to need it. 

This might be a bug in the Metadata API too and might be appropriate to open a case with that team as well?
