### PR TITLE
chore: auto-update metadata coverage in METADATA_SUPPORT.md

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v55 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 456/491 supported metadata types.
+Currently, there are 458/491 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -49,8 +49,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |AppointmentSchedulingPolicy|✅||
 |ApprovalProcess|✅||
 |ArchiveSettings|✅||
-|AssessmentQuestion|❌|Not supported, but support could be added|
-|AssessmentQuestionSet|❌|Not supported, but support could be added|
+|AssessmentQuestion|✅||
+|AssessmentQuestionSet|✅||
 |AssignmentRules|✅||
 |AssistantContextItem|✅||
 |AssistantDefinition|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2985,6 +2985,22 @@
       "directoryName": "OmniInteractionAccessConfig",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "assessmentquestion": {
+      "id": "assessmentquestion",
+      "name": "AssessmentQuestion",
+      "suffix": "aq",
+      "directoryName": "AssessmentQuestions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "assessmentquestionset": {
+      "id": "assessmentquestionset",
+      "name": "AssessmentQuestionSet",
+      "suffix": "aqs",
+      "directoryName": "AssessmentQuestionSets",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3313,7 +3329,9 @@
     "explainabilityActionVersion": "explainabilityactionversion",
     "advAcctForecastDimSource": "advacctforecastdimsource",
     "careLimitType": "carelimittype",
-    "omniInteractionAccessConfig": "omniinteractionaccessconfig"
+    "omniInteractionAccessConfig": "omniinteractionaccessconfig",
+    "aq": "assessmentquestion",
+    "aqs": "assessmentquestionset"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?
Adds source tracking for metadata entities: AssessmentQuestion and AssessmentQuestionSet.

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wmV7ZYAU/view
@W-11123876@

### Functionality Before
sfdx force:source commands did not work for AssessmentQuestion and AssessmentQuestionSet metadata entities.

### Functionality After
sfdx force:source commands should work for AssessmentQuestion and AssessmentQuestionSet metadata entities.
