### PR TITLE
fix: support jsforce 2.0

### DIFF
--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -44,7 +44,7 @@ export class ConnectionResolver {
     for await (const componentResult of componentPromises) {
       for (const component of componentResult) {
         let componentType: MetadataType;
-        if (typeof component.type === 'string') {
+        if (typeof component.type === 'string' && component.type.length) {
           componentType = this.registry.getTypeByName(component.type);
         } else {
           // fix { type: { "$": { "xsi:nil": "true" } } }


### PR DESCRIPTION
### What does this PR do?

support jsforce 2.0 which handles `{ type: { "$": { "xsi:nil": "true" } } }` types differently:
`return isNillValue(value) ? nillable ? null : '' : String(value);`

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
