### PR TITLE
fix: allow larger directories to be compressed, test in plugin-source

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -409,7 +409,7 @@ export class MetadataApiDeploy extends MetadataTransfer<MetadataApiDeployStatus,
       const zip = createArchive('zip', { zlib: { level: 9 } });
       // anywhere not at the root level is fine
       zip.directory(this.options.mdapiPath, 'zip');
-      await zip.finalize();
+      void zip.finalize();
       return stream2buffer(zip);
     }
     // read the zip into a buffer


### PR DESCRIPTION
### What does this PR do?
fixes `archiver` not finalizing larger directories in `MdapiDeploy`

### What issues does this PR fix or reference?

@W-11209280@

### Functionality Before
` ➜  sfdx force:mdapi:deploy -d src-converted -w 10`



### Functionality After

```
 ➜  ../../oss/plugin-source/bin/run force:mdapi:deploy -d src-converted -w 4
Deploy ID: 0AfJ000002FANRlKAP
*** Deploying with SOAP ***
```
