### PR TITLE
Added AIUsecaseDefinition Metadata Type to Metadata Registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -16,6 +16,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+  "aiusecasedefinition": {
+      "id": "aiusecasedefinition",
+      "name": "AIUsecaseDefinition",
+      "suffix": "aiUsecaseDefinitions",
+      "directoryName": "aiUsecaseDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "mlpredictiondefinition": {
       "id": "mlpredictiondefinition",
       "name": "MLPredictionDefinition",
@@ -3025,6 +3033,7 @@
   "suffixes": {
     "ai": "aiapplication",
     "aiapplicationconfig": "aiapplicationconfig",
+    "aiUsecaseDefinitions": "aiusecasedefinition",
     "mlDataDefinition": "mldatadefinition",
     "icon": "icon",
     "businessProcessGroup": "businessprocessgroup",


### PR DESCRIPTION
### What does this PR do?
Adds a new MetadataType called 'AIUsecaseDefinition' to the registry.

### What issues does this PR fix or reference?

@W-11214437@

### Functionality Before

force:mdapi:deploy didn't work for AIUsecaseDefinition MetadataType

### Functionality After

force:mdapi:deploy works for AIUsecaseDefinition MetadataType
