### PR TITLE
fix: don't strip last folder from dir when resolving projectDir

### DIFF
--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { dirname, join, resolve } from 'path';
+import { join, resolve } from 'path';
 import { getString, JsonArray, JsonMap } from '@salesforce/ts-types';
 import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '../common';
 import { ComponentSet } from '../collections';
@@ -273,7 +273,7 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
    */
   private getAllComponentsOfType(defaultDirectory: string, componentType: string): SourceComponent[] {
     // assumes that defaultDir is one level below project dir
-    const projectDir = resolve(dirname(defaultDirectory));
+    const projectDir = resolve(defaultDirectory);
     const unprocessedComponents = ComponentSet.fromSource({
       fsPaths: [projectDir],
       include: new ComponentSet([{ fullName: '*', type: componentType }]),

--- a/test/convert/convertContext.test.ts
+++ b/test/convert/convertContext.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Readable } from 'stream';
-import { join } from 'path';
+import { join, dirname } from 'path';
 
 import { createSandbox } from 'sinon';
 import chai = require('chai');
@@ -398,7 +398,7 @@ describe('Convert Transaction Constructs', () => {
         const context = new ConvertContext();
         const type = component.type;
 
-        // change the word first to 'updated'
+        // change the word 'third' to 'updated'
         const updatedChild3Xml = {
           ...nonDecomposed.CHILD_3_XML,
           value: nonDecomposed.CHILD_3_XML.value.replace('third', 'updated'),
@@ -417,7 +417,7 @@ describe('Convert Transaction Constructs', () => {
           state.exampleComponent = component;
         });
 
-        const result = await context.nonDecomposition.finalize(nonDecomposed.DEFAULT_DIR, TREE);
+        const result = await context.nonDecomposition.finalize(dirname(nonDecomposed.DEFAULT_DIR), TREE);
         expect(result).to.deep.equal([{ component, writeInfos }]);
       });
     });


### PR DESCRIPTION
### What does this PR do?
Fixes `NonDecompositionFinalizer` finalizer resolving metadata components from the top-level folder when passing a dir path that is **exactly** one level below the project dir.

When running `sfdx force:mdapi:convert -r mdapi -d src`

plugin-source sets the `outputDirectory` to:
`/Users/cdominguez/code/sfdx-project/src`

which then in this line:
https://github.com/forcedotcom/source-deploy-retrieve/blob/7804d447bb2905304b011f2f2ac16ce6037575f1/src/convert/convertContext.ts#L276

`dirname` strips the last folder after the last `/` so 

```ts
...
const defaultDirectory = '/Users/cdominguez/code/sfdx-project/src';
const projectDir = resolve(dirname(defaultDirectory));

// projectDir equals  '/Users/cdominguez/code/sfdx-project',  'src' was stripped from the path
```

and last SDR uses the projectDir to get the compSet from source, which walks the tree, scans customlabels in other folders with other dir (other src, mdapi, etc) and make this line return the wrong parentKey.
https://github.com/forcedotcom/source-deploy-retrieve/blob/7804d447bb2905304b011f2f2ac16ce6037575f1/src/convert/convertContext.ts#L215

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1540
@W-11186731@

### Functionality Before

`NonDecompositionFinalizer` scans components in root project dir which causes issues when components are found in other folders (`mdapi`, etc).

### Functionality After

![Screen Shot 2022-07-06 at 10 44 25](https://user-images.githubusercontent.com/6853656/177568539-b26bd673-b3ab-44c1-ab51-81c8c4a5f7a9.png)

