### PR TITLE
Adds new MetadataTypes 'DataPackageKitDefinition', 'DataSourceBundleDefinition', 'DataPackageKitObject', 'DataStreamTemplate', 'DataSrcDataModelFieldMap' to the registry.

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -509,28 +509,30 @@ v56 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|AIUsecaseDefinition|❌|Not supported, but support could be added (but not for tracking)|
 |AccountingFieldMapping|❌|Not supported, but support could be added|
 |AccountingSettings|✅||
 |BotBlock|❌|Not supported, but support could be added|
+|BotBlockVersion|❌|Not supported, but support could be added|
 |CollectionsDashboardSettings|✅||
 |CustomizablePropensityScoringSettings|✅||
-|DataPackageKitDefinition|❌|Not supported, but support could be added|
-|DataPackageKitObject|❌|Not supported, but support could be added|
-|DataSourceBundleDefinition|❌|Not supported, but support could be added|
-|DataSrcDataModelFieldMap|❌|Not supported, but support could be added|
-|DataStreamTemplate|❌|Not supported, but support could be added|
+|DataPackageKitDefinition|✅||
+|DataPackageKitObject|✅||
+|DataSourceBundleDefinition|✅||
+|DataSrcDataModelFieldMap|✅||
+|DataStreamTemplate|✅||
 |ExplainabilityMsgActionDefinition|❌|Not supported, but support could be added|
 |ExpressionSetObjectAlias|❌|Not supported, but support could be added|
 |FuelType|❌|Not supported, but support could be added|
 |FuelTypeSustnUom|❌|Not supported, but support could be added|
 |IncludeEstTaxInQuoteSettings|✅||
+|MarketSegmentReference|❌|Not supported, but support could be added (but not for tracking)|
 |MfgServiceConsoleSettings|✅||
 |OauthOidcSettings|✅||
-|SearchExperience|❌|Not supported, but support could be added|
-|SearchExperienceField|❌|Not supported, but support could be added|
-|SearchExperienceObject|❌|Not supported, but support could be added|
+|ReportingTypeConfig|❌|Not supported, but support could be added|
 |SustainabilityUom|❌|Not supported, but support could be added|
 |SustnUomConversion|❌|Not supported, but support could be added|
+|UserAccessPolicy|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2425,6 +2425,41 @@
       "directoryName": "dataStreamDefinitions",
       "strictDirectoryName": false
     },
+    "datapackagekitdefinition": {
+      "id": "datapackagekitdefinition",
+      "name": "DataPackageKitDefinition",
+      "suffix": "dataPackageKitDefinition",
+      "directoryName": "dataPackageKitDefinitions",
+      "strictDirectoryName": false
+    },
+    "datasourcebundledefinition": {
+      "id": "datasourcebundledefinition",
+      "name": "DataSourceBundleDefinition",
+      "suffix": "dataSourceBundleDefinition",
+      "directoryName": "dataSourceBundleDefinitions",
+      "strictDirectoryName": false
+    },
+    "datapackagekitobject": {
+      "id": "datapackagekitobject",
+      "name": "DataPackageKitObject",
+      "suffix": "DataPackageKitObject",
+      "directoryName": "DataPackageKitObjects",
+      "strictDirectoryName": false
+    },
+    "datastreamtemplate": {
+      "id": "datastreamtemplate",
+      "name": "DataStreamTemplate",
+      "suffix": "dataStreamTemplate",
+      "directoryName": "dataStreamTemplates",
+      "strictDirectoryName": false
+    },
+    "datasrcdatamodelfieldmap": {
+      "id": "datasrcdatamodelfieldmap",
+      "name": "DataSrcDataModelFieldMap",
+      "suffix": "dataSrcDataModelFieldMap",
+      "directoryName": "dataSrcDataModelFieldMaps",
+      "strictDirectoryName": false
+    },
     "mktdatatranobject": {
       "id": "mktdatatranobject",
       "name": "MktDataTranObject",
@@ -3285,6 +3320,11 @@
     "accountForecastSetting": "accountforecastsettings",
     "fieldServiceMobileExtension": "fieldservicemobileextension",
     "dataStreamDefinition": "datastreamdefinition",
+    "dataPackageKitDefinition": "datapackagekitdefinition",
+    "dataSourceBundleDefinition": "datasourcebundledefinition",
+    "DataPackageKitObject" : "datapackagekitobject",
+    "dataStreamTemplate":"datastreamtemplate",
+    "dataSrcDataModelFieldMap":"datasrcdatamodelfieldmap",
     "ChannelObjectLinkingRule": "channelobjectlinkingrule",
     "ConversationVendorInformation": "conversationvendorinfo",
     "ConversationVendorFieldDefinition": "conversationvendorfielddef",


### PR DESCRIPTION
### What does this PR do?
Adds new MetadataTypes 'DataPackageKitDefinition', 'DataSourceBundleDefinition', 'DataPackageKitObject', 'DataStreamTemplate', 'DataSrcDataModelFieldMap' to the registry.
### What issues does this PR fix or reference?
@W-11116265@
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

force:mdapi:deploy didn't work for 'DataPackageKitDefinition', 'DataSourceBundleDefinition', 'DataPackageKitObject', 'DataStreamTemplate', 'DataSrcDataModelFieldMap' meta data types

### Functionality After

force:mdapi:deploy works for 'DataPackageKitDefinition', 'DataSourceBundleDefinition', 'DataPackageKitObject', 'DataStreamTemplate', 'DataSrcDataModelFieldMap' meta data types
