### PR TITLE
fix: static resources without content due to ignore produce nice error

### DIFF
--- a/src/resolve/adapters/mixedContentSourceAdapter.ts
+++ b/src/resolve/adapters/mixedContentSourceAdapter.ts
@@ -52,7 +52,8 @@ export class MixedContentSourceAdapter extends BaseSourceAdapter {
       contentPath = this.tree.find('content', baseName(contentPath), dirname(contentPath));
     }
 
-    if (!this.tree.exists(contentPath)) {
+    // Content path might be undefined for staticResource where all files are ignored and only the xml is included.
+    if (!contentPath || !this.tree.exists(contentPath)) {
       throw new SfError(
         messages.getMessage('error_expected_source_files', [trigger, this.type.name]),
         'ExpectedSourceFilesError'


### PR DESCRIPTION
### What does this PR do?
when forceignore causes *all* of the content in a static resource to be ignored, `tree.exists(undefied)` is called which makes an uglier error.

now it produces a helpful error about which component is causing the problem.

and has a UT for the behavior

### What issues does this PR fix or reference?
@W-11148485@
https://github.com/forcedotcom/cli/issues/1516