### PR TITLE
Sm/service-ai-setup-definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
             yarn build
       - run:
           name: Nuts
+          no_output_timeout: 20m
           command: |
             <<parameters.test_command>>
 

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -529,7 +529,6 @@ v56 introduces the following new types.  Here's their current level of support
 |FuelType|❌|Not supported, but support could be added|
 |FuelTypeSustnUom|❌|Not supported, but support could be added|
 |IncludeEstTaxInQuoteSettings|✅||
-|MarketSegmentReference|❌|Not supported, but support could be added (but not for tracking)|
 |MfgServiceConsoleSettings|✅||
 |OauthOidcSettings|✅||
 |PortalDelegablePermissionSet|❌|Not supported, but support could be added|

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v55 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 459/491 supported metadata types.
+Currently, there are 461/491 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -415,8 +415,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ScoreCategory|❌|Not supported, but support could be added|
 |SearchSettings|✅||
 |SecuritySettings|✅||
-|ServiceAISetupDefinition|❌|Not supported, but support could be added|
-|ServiceAISetupField|❌|Not supported, but support could be added|
+|ServiceAISetupDefinition|✅||
+|ServiceAISetupField|✅||
 |ServiceChannel|✅||
 |ServiceCloudVoiceSettings|✅||
 |ServicePresenceStatus|✅||
@@ -532,6 +532,7 @@ v56 introduces the following new types.  Here's their current level of support
 |MarketSegmentReference|❌|Not supported, but support could be added (but not for tracking)|
 |MfgServiceConsoleSettings|✅||
 |OauthOidcSettings|✅||
+|PortalDelegablePermissionSet|❌|Not supported, but support could be added|
 |ReportingTypeConfig|❌|Not supported, but support could be added|
 |SustainabilityUom|❌|Not supported, but support could be added|
 |SustnUomConversion|❌|Not supported, but support could be added|

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1,5 +1,21 @@
 {
   "types": {
+    "serviceaisetupdefinition": {
+      "id": "serviceaisetupdefinition",
+      "name": "ServiceAISetupDefinition",
+      "suffix": "serviceAISetupDescription",
+      "directoryName": "serviceAISetupDescriptions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "serviceaisetupfield": {
+      "id": "serviceaisetupfield",
+      "name": "ServiceAISetupField",
+      "suffix": "serviceAISetupField",
+      "directoryName": "serviceAISetupFields",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "aiapplication": {
       "id": "aiapplication",
       "name": "AIApplication",
@@ -16,7 +32,7 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-  "aiusecasedefinition": {
+    "aiusecasedefinition": {
       "id": "aiusecasedefinition",
       "name": "AIUsecaseDefinition",
       "suffix": "aiUsecaseDefinitions",
@@ -3066,6 +3082,8 @@
     }
   },
   "suffixes": {
+    "serviceAISetupDescription": "serviceaisetupdefinition",
+    "serviceAISetupField": "serviceaisetupfield",
     "ai": "aiapplication",
     "aiapplicationconfig": "aiapplicationconfig",
     "aiUsecaseDefinitions": "aiusecasedefinition",
@@ -3331,9 +3349,9 @@
     "dataStreamDefinition": "datastreamdefinition",
     "dataPackageKitDefinition": "datapackagekitdefinition",
     "dataSourceBundleDefinition": "datasourcebundledefinition",
-    "DataPackageKitObject" : "datapackagekitobject",
-    "dataStreamTemplate":"datastreamtemplate",
-    "dataSrcDataModelFieldMap":"datasrcdatamodelfieldmap",
+    "DataPackageKitObject": "datapackagekitobject",
+    "dataStreamTemplate": "datastreamtemplate",
+    "dataSrcDataModelFieldMap": "datasrcdatamodelfieldmap",
     "ChannelObjectLinkingRule": "channelobjectlinkingrule",
     "ConversationVendorInformation": "conversationvendorinfo",
     "ConversationVendorFieldDefinition": "conversationvendorfielddef",


### PR DESCRIPTION
### What does this PR do?
2 new metadata types.  Because we can't create a scratch org with Bots enabled properly, I could do this using the automated describe process, so I resorted to peeking in https://codesearch.data.sfdc.net/source/xref/app_main_core/app/main/core/md-common-impl/test/func/java/resources/metadatatypedata/common/ServiceAISetupField/toDeploy/ to get the example manifest/xml files.  They're just the basic type.

### What issues does this PR fix or reference?

@W-11402393@