### PR TITLE
chore: auto-update metadata coverage in METADATA_SUPPORT.md

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v55 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 461/491 supported metadata types.
+Currently, there are 462/491 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -256,7 +256,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |IPAddressRange|✅||
 |Icon|✅||
 |IdeasSettings|✅||
-|IdentityVerificationProcDef|❌|Not supported, but support could be added|
+|IdentityVerificationProcDef|✅||
 |IframeWhiteListUrlSettings|✅||
 |InboundCertificate|✅||
 |InboundNetworkConnection|✅||
@@ -511,6 +511,7 @@ v56 introduces the following new types.  Here's their current level of support
 |:---|:---|:---|
 |AIUsecaseDefinition|⚠️|Supports deploy/retrieve but not source tracking|
 |AccountingFieldMapping|❌|Not supported, but support could be added|
+|AccountingModelConfig|❌|Not supported, but support could be added|
 |AccountingSettings|✅||
 |BotBlock|❌|Not supported, but support could be added|
 |BotBlockVersion|❌|Not supported, but support could be added|
@@ -524,7 +525,7 @@ v56 introduces the following new types.  Here's their current level of support
 |DigitalExperience|❌|Not supported, but support could be added (but not for tracking)|
 |DigitalExperienceBundle|❌|Not supported, but support could be added (but not for tracking)|
 |DigitalExperienceConfig|❌|Not supported, but support could be added (but not for tracking)|
-|ExplainabilityMsgActionDefinition|❌|Not supported, but support could be added|
+|ExplainabilityMsgTemplate|❌|Not supported, but support could be added|
 |ExpressionSetObjectAlias|❌|Not supported, but support could be added|
 |FuelType|❌|Not supported, but support could be added|
 |FuelTypeSustnUom|❌|Not supported, but support could be added|

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3079,6 +3079,14 @@
       "directoryName": "AssessmentQuestionSets",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "identityverificationprocdef": {
+      "id": "identityverificationprocdef",
+      "name": "IdentityVerificationProcDef",
+      "suffix": "identityverificationprocdef",
+      "directoryName": "IdentityVerificationProcDefs",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3419,7 +3427,8 @@
     "omniInteractionAccessConfig": "omniinteractionaccessconfig",
     "dwl": "dataweaveresource",
     "aq": "assessmentquestion",
-    "aqs": "assessmentquestionset"
+    "aqs": "assessmentquestionset",
+    "identityverificationprocdef": "identityverificationprocdef"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",

--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -45,9 +45,6 @@ export const metadataTypes = [
   // the following are not describable based on their features/settings, last checked 2/24/2022
   'DiscoveryStory',
   'EmployeeDataSyncProfile',
-  'IdentityVerificationProcDef',
-  'IdentityVerificationProcDtl',
-  'IdentityVerificationProcFld',
   'RelatedRecordAssocCriteria',
   'ScoreRange',
   'WorkflowFlowAction',


### PR DESCRIPTION
### What does this PR do?
Adds source tracking for metadata type: IdentityVerificationProcDef

### What issues does this PR fix or reference?

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000010hdsdYAA/view
@W-11382185@

### Functionality Before

sfdx force:source commands did not work for IdentityVerificationProcDef metadata entity.

### Functionality After

sfdx force:source commands should work for IdentityVerificationProcDef metadata entity.
