### PR TITLE
fix: handle namespaces on lwc markup

### DIFF
--- a/contributing/metadata.md
+++ b/contributing/metadata.md
@@ -197,7 +197,7 @@ You can use an existing org for the metadata describe portion of the script by
 
     1. A sfdx project must exists in local.
       `sfdx force:project:create --projectname <projectname> --defaultpackagedir <directory> -x`
-    2. An authorised devhub org must exists
+    2. An authorized devhub org must exists
       `sfdx force:auth:web:login -a <alias> -r <localhost url> -d`
     3. A scratch org must exists with alias `registryBuilder`
       1. Update `project-scratch-def.json` as per your requirements.

--- a/contributing/metadata.md
+++ b/contributing/metadata.md
@@ -193,7 +193,7 @@ You can use an existing org for the metadata describe portion of the script by
 
 ### Steps to add your metadata in registry
 
-## prerequisites:
+## Prerequisites
 
     1. A sfdx project must exists in local.
       `sfdx force:project:create --projectname <projectname> --defaultpackagedir <directory> -x`
@@ -203,7 +203,7 @@ You can use an existing org for the metadata describe portion of the script by
       1. Update `project-scratch-def.json` as per your requirements.
       2. `sfdx force:org:create -f config/project-scratch-def.json -a registryBuilder -t scratch -s`
 
-## Steps:
+## Steps
 
     1. Fork SourceDeployRetrieve github repo
       (https://github.com/forcedotcom/source-deploy-retrieve)

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -232,7 +232,7 @@ export class DeployResult implements MetadataTransferResult {
     switch (message.componentType) {
       case registry.types.lightningcomponentbundle.name:
         // remove the markup scheme from fullName, including c: or custom namespaces
-        message.fullName = message.fullName.replace(/markup:\/\/[A-z|a-z|0-9|_]+:/, '');
+        message.fullName = message.fullName.replace(/markup:\/\/[a-z|0-9|_]+:/i, '');
         break;
       case registry.types.document.name:
         // strip document extension from fullName

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -232,7 +232,7 @@ export class DeployResult implements MetadataTransferResult {
     switch (message.componentType) {
       case registry.types.lightningcomponentbundle.name:
         // remove the markup scheme from fullName, including c: or custom namespaces
-        message.fullName = message.fullName.replace(/markup:\/\/[a-z|0-9|_]+:/, '');
+        message.fullName = message.fullName.replace(/markup:\/\/[A-z|a-z|0-9|_]+:/, '');
         break;
       case registry.types.document.name:
         // strip document extension from fullName

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -231,8 +231,8 @@ export class DeployResult implements MetadataTransferResult {
     }
     switch (message.componentType) {
       case registry.types.lightningcomponentbundle.name:
-        // remove the markup scheme from fullName
-        message.fullName = message.fullName.replace(/markup:\/\/c:/, '');
+        // remove the markup scheme from fullName, including c: or custom namespaces
+        message.fullName = message.fullName.replace(/markup:\/\/[a-z|0-9|_]+:/, '');
         break;
       case registry.types.document.name:
         // strip document extension from fullName


### PR DESCRIPTION
### What does this PR do?
remove custom (non `c:`) namespaces from componentFailures in the workaround code 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1602
@W-11385290@

### Functionality Before
reported failed LWC deployments as successes if there was a custom namespace.