### PR TITLE
chore: Support DigitalExperienceBundle, DigitalExperience and DigitalExperienceConfig MD types in SDR

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v56 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 465/511 supported metadata types.
+Currently, there are 469/512 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -170,9 +170,9 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |DelegateGroup|✅||
 |DeploymentSettings|✅||
 |DevHubSettings|✅||
-|DigitalExperience|❌|Not supported, but support could be added (but not for tracking)|
-|DigitalExperienceBundle|❌|Not supported, but support could be added (but not for tracking)|
-|DigitalExperienceConfig|❌|Not supported, but support could be added (but not for tracking)|
+|DigitalExperience|⚠️|Supports deploy/retrieve but not source tracking|
+|DigitalExperienceBundle|⚠️|Supports deploy/retrieve but not source tracking|
+|DigitalExperienceConfig|⚠️|Supports deploy/retrieve but not source tracking|
 |DiscoveryAIModel|✅||
 |DiscoveryGoal|✅||
 |DiscoverySettings|✅||
@@ -374,6 +374,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |PathAssistantSettings|✅||
 |PaymentGatewayProvider|✅||
 |PaymentsManagementEnabledSettings|✅||
+|PaymentsSettings|✅||
 |PermissionSet|✅||
 |PermissionSetGroup|✅||
 |PermissionSetLicenseDefinition|✅||
@@ -529,6 +530,7 @@ v57 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|ActionableListDefinition|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -531,6 +531,9 @@ v57 introduces the following new types.  Here's their current level of support
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
 |ActionableListDefinition|❌|Not supported, but support could be added|
+|ExternalClientApplication|❌|Not supported, but support could be added|
+|GearDescriptor|❌|Not supported, but support could be added|
+|ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -523,6 +523,14 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
         if (parentInWildcard) {
           return true;
         }
+        const partialWildcardKey = this.simpleKey({
+          fullName: `${parent.fullName}.${ComponentSet.WILDCARD}`,
+          type: component.type,
+        });
+        const parentInPartialWildcard = this.components.has(partialWildcardKey);
+        if (parentInPartialWildcard) {
+          return true;
+        }
       }
     }
 

--- a/src/convert/transformers/defaultMetadataTransformer.ts
+++ b/src/convert/transformers/defaultMetadataTransformer.ts
@@ -88,11 +88,11 @@ export class DefaultMetadataTransformer extends BaseMetadataTransformer {
     let xmlDestination = component.getPackageRelativePath(component.xml, targetFormat);
 
     // quirks:
-    // - append or strip the -meta.xml suffix to the path if there's no content
+    // - append or strip the -meta.xml suffix to the path if there's no content and if it's not DigitalExperienceBundle
     //  for folder components:
     //    - remove file extension but preserve -meta.xml suffix if folder type and to 'metadata format'
     //    - insert file extension behind the -meta.xml suffix if folder type and to 'source format'
-    if (!component.content) {
+    if (!component.content && !['digitalexperiencebundle'].includes(component.type.id)) {
       if (targetFormat === 'metadata') {
         xmlDestination = folderContentType
           ? xmlDestination.replace(`.${suffix}`, '')

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3064,7 +3064,7 @@
       "suffix": "digitalExperienceConfig",
       "directoryName": "digitalExperienceConfigs",
       "inFolder": false,
-      "strictDirectoryName": true
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3426,8 +3426,7 @@
     "siteDotComSites": "sitedotcom",
     "appointmentSchedulingPolicies": "appointmentschedulingpolicy",
     "appointmentAssignmentPolicies": "appointmentassignmentpolicy",
-    "emailservices": "emailservicesfunction",
-    "digitalExperienceConfigs": "digitalexperienceconfig"
+    "emailservices": "emailservicesfunction"
   },
   "childTypes": {
     "customlabel": "customlabels",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3027,6 +3027,44 @@
       "directoryName": "IdentityVerificationProcDefs",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "digitalexperiencebundle": {
+      "id": "digitalexperiencebundle",
+      "name": "DigitalExperienceBundle",
+      "directoryName": "digitalExperiences",
+      "inFolder": false,
+      "supportsWildcardAndName": true,
+      "suffix": "digitalExperience",
+      "children": {
+        "types": {
+          "digitalexperience": {
+            "id": "digitalexperience",
+            "name": "DigitalExperience",
+            "directoryName": "digitalExperiences",
+            "suffix": "digitalExperience",
+            "strategies": {
+              "adapter": "digitalExperience"
+            }
+          }
+        },
+        "suffixes": {
+          "digitalExperience": "digitalexperience"
+        },
+        "directories": {
+          "digitalExperiences": "digitalexperience"
+        }
+      },
+      "strategies": {
+        "adapter": "digitalExperience"
+      }
+    },
+    "digitalexperienceconfig": {
+      "id": "digitalexperienceconfig",
+      "name": "DigitalExperienceConfig",
+      "suffix": "digitalExperienceConfig",
+      "directoryName": "digitalExperienceConfigs",
+      "inFolder": false,
+      "strictDirectoryName": true
     }
   },
   "suffixes": {
@@ -3362,7 +3400,9 @@
     "dwl": "dataweaveresource",
     "aq": "assessmentquestion",
     "aqs": "assessmentquestionset",
-    "identityverificationprocdef": "identityverificationprocdef"
+    "identityverificationprocdef": "identityverificationprocdef",
+    "digitalExperience": "digitalexperiencebundle",
+    "digitalExperienceConfig": "digitalexperienceconfig"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",
@@ -3386,7 +3426,8 @@
     "siteDotComSites": "sitedotcom",
     "appointmentSchedulingPolicies": "appointmentschedulingpolicy",
     "appointmentAssignmentPolicies": "appointmentassignmentpolicy",
-    "emailservices": "emailservicesfunction"
+    "emailservices": "emailservicesfunction",
+    "digitalExperienceConfigs": "digitalexperienceconfig"
   },
   "childTypes": {
     "customlabel": "customlabels",
@@ -3420,6 +3461,7 @@
     "sharingcriteriarule": "sharingrules",
     "botversion": "bot",
     "customfieldtranslation": "customobjecttranslation",
-    "mktdatatranfield": "mktdatatranobject"
+    "mktdatatranfield": "mktdatatranobject",
+    "digitalexperience": "digitalexperiencebundle"
   }
 }

--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -24,7 +24,6 @@ export const features = [
   'MANAGETIMELINE', // is not a valid Features value
   'HEALTHCLOUDBETA', // is not a valid Features value
   'PARDOTADVANCED', // org:create throws a C-9999 when this is not excluded
-  'MCONTENTMETADATA',
   'EMBEDDEDSERVICEMESSAGING',
   'ARCGRAPHCOMMUNITY',
   'UNIFIEDHEALTHSCORING',

--- a/src/registry/registryAccess.ts
+++ b/src/registry/registryAccess.ts
@@ -129,4 +129,20 @@ export class RegistryAccess {
     }
     return this.aliasTypes;
   }
+
+  /**
+   * Return the parent metadata type from the registry for the given child type
+   *
+   * @param childName - Child metadata type name
+   * @returns Parent metadata type object
+   */
+  public getParentType(childName: string): MetadataType {
+    let parent: MetadataType;
+    const lower = childName.toLowerCase().trim();
+    if (this.registry.childTypes[lower]) {
+      const parentTypeId = this.registry.childTypes[lower];
+      parent = this.registry.types[parentTypeId];
+    }
+    return parent;
+  }
 }

--- a/src/resolve/adapters/baseSourceAdapter.ts
+++ b/src/resolve/adapters/baseSourceAdapter.ts
@@ -47,7 +47,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
     if (!rootMetadata) {
       const rootMetadataPath = this.getRootMetadataXmlPath(path);
       if (rootMetadataPath) {
-        rootMetadata = parseMetadataXml(rootMetadataPath);
+        rootMetadata = this.parseMetadataXml(rootMetadataPath);
       }
     }
     if (rootMetadata && this.forceIgnore.denies(rootMetadata.path)) {
@@ -89,7 +89,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
    * @param path File path of a metadata component
    */
   protected parseAsRootMetadataXml(path: SourcePath): MetadataXml {
-    const metaXml = parseMetadataXml(path);
+    const metaXml = this.parseMetadataXml(path);
     if (metaXml) {
       let isRootMetadataXml = false;
       if (this.type.strictDirectoryName) {
@@ -114,6 +114,10 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
     if (!this.allowMetadataWithContent()) {
       return this.parseAsContentMetadataXml(path);
     }
+  }
+
+  protected parseMetadataXml(path: SourcePath): MetadataXml {
+    return parseMetadataXml(path);
   }
 
   /**

--- a/src/resolve/adapters/digitalExperienceSourceAdapter.ts
+++ b/src/resolve/adapters/digitalExperienceSourceAdapter.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { dirname, join, sep } from 'path';
+import { META_XML_SUFFIX } from '../../common';
+import { SourceComponent } from '..';
+import { MetadataXml } from '../types';
+import { baseName, parentName } from '../../utils';
+import { SourcePath } from '../../common';
+import { BundleSourceAdapter } from './bundleSourceAdapter';
+
+/**
+ * Source Adapter for DigitalExperience metadata types. This metadata type is a bundled type of the format
+ *
+ * __Example Structure__:
+ *
+ *```text
+ * site/
+ * ├── foos/
+ * |   ├── sfdc_cms__appPage/
+ * |   |   ├── mainAppPage/
+ * |   |   |  ├── _meta.json
+ * |   |   |  ├── content.json
+ * |   ├── sfdc_cms__view/
+ * |   |   ├── view1/
+ * |   |   |  ├── _meta.json
+ * |   |   |  ├── content.json
+ * |   |   |  ├── fr.json
+ * |   |   |  ├── en.json
+ * |   |   ├── view2/
+ * |   |   |  ├── _meta.json
+ * |   |   |  ├── content.json
+ * |   |   |  ├── ar.json
+ * |   ├── foos.digitalExperience-meta.xml
+ * content/
+ * ├── bars/
+ * |   ├── bars.digitalExperience-meta.xml
+ * ```
+ *
+ * In the above structure the metadata xml file ending with "digitalExperience-meta.xml" belongs to DigitalExperienceBundle MD type.
+ * The "_meta.json" files are child metadata files of DigitalExperienceBundle belonging to DigitalExperience MD type. The rest of the files in the
+ * corresponding folder are the contents to the DigitalExperience metadata. So, incase of DigitalExperience the metadata file is a JSON file
+ * and not an XML file
+ */
+export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
+  protected getRootMetadataXmlPath(trigger: string): string {
+    if (this.isBundleType()) {
+      return this.getBundleMetadataXmlPath(trigger);
+    }
+    return join(dirname(trigger), '_meta.json');
+  }
+
+  /**
+   * @param contentPath This hook is called only after trimPathToContent() is called. so this will always be a folder strcture
+   * @returns name of type/apiName format
+   */
+  protected calculateNameFromPath(contentPath: string): string {
+    return `${parentName(contentPath)}${sep}${baseName(contentPath)}`;
+  }
+
+  protected trimPathToContent(path: string): string {
+    if (this.isBundleType()) {
+      return;
+    }
+    return dirname(path);
+  }
+
+  protected populate(trigger: string, component?: SourceComponent): SourceComponent {
+    if (this.isBundleType()) {
+      // for top level types we don't need to resolve parent
+      return component;
+    }
+    const source = super.populate(trigger, component);
+    const parentType = this.registry.getParentType(this.type.id);
+    const parent = new SourceComponent(
+      {
+        name: this.getBundleName(source.content),
+        type: parentType,
+        xml: this.getBundleMetadataXmlPath(source.content),
+      },
+      this.tree,
+      this.forceIgnore
+    );
+    return new SourceComponent(
+      {
+        name: this.calculateNameFromPath(source.content),
+        type: this.type,
+        content: source.content,
+        parent,
+        parentType,
+      },
+      this.tree,
+      this.forceIgnore
+    );
+  }
+
+  protected parseMetadataXml(path: SourcePath): MetadataXml {
+    const xml = super.parseMetadataXml(path);
+    if (xml) {
+      return {
+        fullName: this.getBundleName(path),
+        suffix: xml.suffix,
+        path: xml.path,
+      };
+    }
+  }
+
+  private getBundleName(contentPath: string): string {
+    const bundlePath = this.getBundleMetadataXmlPath(contentPath);
+    return `${parentName(dirname(bundlePath))}${sep}${parentName(bundlePath)}`;
+  }
+
+  private getBundleMetadataXmlPath(path: string): string {
+    if (this.isBundleType() && path.endsWith(META_XML_SUFFIX)) {
+      // if this is the bundle type and it ends with -meta.xml, then this is the bundle metadata xml path
+      return path;
+    }
+    const pathParts = path.split(sep);
+    const typeFolderIndex = pathParts.lastIndexOf(this.type.directoryName);
+    // 3 because we want 'digitaExperiences' directory, 'baseType' directory and 'bundleName' directory
+    const basePath = pathParts.slice(0, typeFolderIndex + 3).join(sep);
+    const bundleFileName = pathParts[typeFolderIndex + 2];
+    const suffix = this.isBundleType() ? this.type.suffix : this.registry.getParentType(this.type.id).suffix;
+    return `${basePath}${sep}${bundleFileName}.${suffix}${META_XML_SUFFIX}`;
+  }
+
+  private isBundleType(): boolean {
+    return this.type.id === 'digitalexperiencebundle';
+  }
+}

--- a/src/resolve/adapters/sourceAdapterFactory.ts
+++ b/src/resolve/adapters/sourceAdapterFactory.ts
@@ -14,6 +14,7 @@ import { DecomposedSourceAdapter } from './decomposedSourceAdapter';
 import { MatchingContentSourceAdapter } from './matchingContentSourceAdapter';
 import { MixedContentSourceAdapter } from './mixedContentSourceAdapter';
 import { DefaultSourceAdapter } from './defaultSourceAdapter';
+import { DigitalExperienceSourceAdapter } from './digitalExperienceSourceAdapter';
 
 enum AdapterId {
   Bundle = 'bundle',
@@ -21,6 +22,7 @@ enum AdapterId {
   Default = 'default',
   MatchingContentFile = 'matchingContentFile',
   MixedContent = 'mixedContent',
+  DigitalExperience = 'digitalExperience',
 }
 
 Messages.importMessagesDirectory(__dirname);
@@ -48,6 +50,8 @@ export class SourceAdapterFactory {
         return new MixedContentSourceAdapter(type, this.registry, forceIgnore, this.tree);
       case AdapterId.Default:
         return new DefaultSourceAdapter(type, this.registry, forceIgnore, this.tree);
+      case AdapterId.DigitalExperience:
+        return new DigitalExperienceSourceAdapter(type, this.registry, forceIgnore, this.tree);
       case undefined:
         return new DefaultSourceAdapter(type, this.registry, forceIgnore, this.tree);
       default:

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -215,6 +215,14 @@ export class MetadataResolver {
       resolvedType = this.registry.getTypeBySuffix(extName(fsPath));
     }
 
+    // attempt 4 - try treating the content as metadata
+    if (!resolvedType) {
+      const metadata = this.parseAsMetadata(fsPath);
+      if (metadata) {
+        resolvedType = this.registry.getTypeByName(metadata);
+      }
+    }
+
     return resolvedType;
   }
 
@@ -297,9 +305,24 @@ export class MetadataResolver {
     return folderName;
   }
 
+  /**
+   * If this file should be considered as a metadata file then return the metadata type
+   */
+  private parseAsMetadata(fsPath: string): string {
+    if (this.tree.isDirectory(fsPath)) {
+      return;
+    }
+    return ['DigitalExperience']
+      .map((type) => this.registry.getTypeByName(type))
+      .find((type) => fsPath.split(sep).includes(type.directoryName))?.name;
+  }
+
   private isMetadata(fsPath: string): boolean {
     return (
-      !!parseMetadataXml(fsPath) || this.parseAsContentMetadataXml(fsPath) || !!this.parseAsFolderMetadataXml(fsPath)
+      !!parseMetadataXml(fsPath) ||
+      this.parseAsContentMetadataXml(fsPath) ||
+      !!this.parseAsFolderMetadataXml(fsPath) ||
+      !!this.parseAsMetadata(fsPath)
     );
   }
 }

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -211,7 +211,13 @@ export class SourceComponent implements MetadataComponent {
     // the file resides in for the new destination. This also applies to inFolder types:
     // (report, dashboard, emailTemplate, document) and their folder container types:
     // (reportFolder, dashboardFolder, emailFolder, documentFolder)
-    if (!suffix || inFolder || folderContentType) {
+    // It also applies to DigitalExperienceBundle types as we need to maintain the folder structure
+    if (
+      !suffix ||
+      inFolder ||
+      folderContentType ||
+      ['digitalexperiencebundle', 'digitalexperience'].includes(this.type.id)
+    ) {
       return trimUntil(fsPath, directoryName, true);
     }
 

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -176,6 +176,18 @@ describe('ComponentSet', () => {
         expect(result).to.be.true;
       });
 
+      it('should resolve partial wildcard members by default', async () => {
+        const set = await ComponentSet.fromManifest({
+          manifestPath: manifestFiles.ONE_PARTIAL_WILDCARD.name,
+          registry: registryAccess,
+          tree: manifestFiles.TREE,
+        });
+
+        const result = set.has({ fullName: 'site/foo.*', type: 'DigitalExperience' });
+
+        expect(result).to.be.true;
+      });
+
       it('should resolve wildcard members when forceAddWildcards = true', async () => {
         const set = await ComponentSet.fromManifest({
           manifestPath: manifestFiles.ONE_WILDCARD.name,

--- a/test/convert/transformers/defaultMetadataTransformer.test.ts
+++ b/test/convert/transformers/defaultMetadataTransformer.test.ts
@@ -74,6 +74,28 @@ describe('DefaultMetadataTransformer', () => {
       expect(await transformer.toMetadataFormat(component)).to.deep.equal(expectedInfos);
     });
 
+    it('should not remove file extension and preserve -meta.xml for DigitalExperienceBundle', async () => {
+      const component = SourceComponent.createVirtualComponent({
+        name: 'site/foo',
+        type: registry.types.digitalexperiencebundle,
+        xml: join(
+          'path',
+          'to',
+          registry.types.digitalexperiencebundle.directoryName,
+          'site',
+          'foo',
+          `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`
+        ),
+      });
+      const expectedInfos: WriteInfo[] = [
+        {
+          source: component.tree.stream(component.xml),
+          output: join(component.type.directoryName, 'site', 'foo', `foo.${component.type.suffix}${META_XML_SUFFIX}`),
+        },
+      ];
+      expect(await transformer.toMetadataFormat(component)).to.deep.equal(expectedInfos);
+    });
+
     it('should remove file extension and preserve -meta.xml for folder components', async () => {
       const component = FOLDER_COMPONENT;
       const expectedInfos: WriteInfo[] = [
@@ -189,6 +211,33 @@ describe('DefaultMetadataTransformer', () => {
         },
       ];
 
+      expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
+    });
+
+    it('should not remove file extension and preserve -meta.xml for DigitalExperienceBundle', async () => {
+      const component = SourceComponent.createVirtualComponent({
+        name: 'site/foo',
+        type: registry.types.digitalexperiencebundle,
+        xml: join(
+          DEFAULT_PACKAGE_ROOT_SFDX,
+          registry.types.digitalexperiencebundle.directoryName,
+          'site',
+          'foo',
+          `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`
+        ),
+      });
+      const expectedInfos: WriteInfo[] = [
+        {
+          source: component.tree.stream(component.xml),
+          output: join(
+            DEFAULT_PACKAGE_ROOT_SFDX,
+            component.type.directoryName,
+            'site',
+            'foo',
+            `foo.${component.type.suffix}${META_XML_SUFFIX}`
+          ),
+        },
+      ];
       expect(await transformer.toSourceFormat(component)).to.deep.equal(expectedInfos);
     });
 

--- a/test/mock/manifestConstants.ts
+++ b/test/mock/manifestConstants.ts
@@ -82,6 +82,18 @@ export const ONE_WILDCARD: VirtualFile = {
 </Package>\n`),
 };
 
+export const ONE_PARTIAL_WILDCARD: VirtualFile = {
+  name: 'one-partial-wildcard.xml',
+  data: Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>site/foo.*</members>
+        <name>${registry.types.digitalexperiencebundle.children.types.digitalexperience.name}</name>
+    </types>
+    <version>${testApiVersionAsString}</version>
+</Package>\n`),
+};
+
 export const TREE = new VirtualTreeContainer([
   {
     dirPath: '.',
@@ -91,6 +103,7 @@ export const TREE = new VirtualTreeContainer([
       BASIC,
       ONE_OF_EACH,
       ONE_WILDCARD,
+      ONE_PARTIAL_WILDCARD,
       ONE_FOLDER_MEMBER,
       IN_FOLDER_WITH_CONTENT,
     ],

--- a/test/registry/registryAccess.test.ts
+++ b/test/registry/registryAccess.test.ts
@@ -93,4 +93,20 @@ describe('RegistryAccess', () => {
       expect(registryAccess.getFolderContentTypes()).to.not.deep.include(registry.types.emailtemplatefolder);
     });
   });
+
+  describe('getParentType', () => {
+    it('should return a valid parent for a child metadata type', () => {
+      expect(
+        registryAccess.getParentType(registry.types.digitalexperiencebundle.children.types.digitalexperience.id)
+      ).to.be.equal(registry.types.digitalexperiencebundle);
+      expect(registryAccess.getParentType(registry.types.customobject.children.types.customfield.id)).to.be.equal(
+        registry.types.customobject
+      );
+    });
+
+    it('should return undefined parent for a top level metadata type', () => {
+      expect(registryAccess.getParentType(registry.types.experiencebundle.id)).to.be.undefined;
+      expect(registryAccess.getParentType(registry.types.digitalexperienceconfig.id)).to.be.undefined;
+    });
+  });
 });

--- a/test/registry/registryValidation.test.ts
+++ b/test/registry/registryValidation.test.ts
@@ -110,6 +110,7 @@ describe('Registry Validation', () => {
         // things that use the suffix .settings (!)
         'IndustriesManufacturingSettings',
         'ObjectHierarchyRelationship',
+        'DigitalExperienceBundle', // no suffix for DigitalExperience child md type
       ];
 
       const suffixMap = new Map<string, string>();
@@ -244,9 +245,14 @@ describe('Registry Validation', () => {
     describe('valid, known adapters', () => {
       typesWithStrategies.forEach((type) => {
         it(`${type.id} has a valid adapter`, () => {
-          expect(['default', 'mixedContent', 'bundle', 'matchingContentFile', 'decomposed']).includes(
-            type.strategies.adapter
-          );
+          expect([
+            'default',
+            'mixedContent',
+            'bundle',
+            'matchingContentFile',
+            'decomposed',
+            'digitalExperience',
+          ]).includes(type.strategies.adapter);
         });
       });
     });

--- a/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
+++ b/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { join } from 'path';
+import { expect } from 'chai';
+import {
+  RegistryAccess,
+  registry,
+  VirtualTreeContainer,
+  ForceIgnore,
+  SourceComponent,
+  MetadataXml,
+} from '../../../src';
+import { DigitalExperienceSourceAdapter } from '../../../src/resolve/adapters/digitalExperienceSourceAdapter';
+import { META_XML_SUFFIX } from '../../../src/common';
+
+describe('DigitalExperienceSourceAdapter', () => {
+  /**
+   * Stub class used for unit testing protected methods
+   */
+  class DigitalExperienceSourceAdapterStub extends DigitalExperienceSourceAdapter {
+    public getRootMetadataXmlPath(trigger: string): string {
+      return super.getRootMetadataXmlPath(trigger);
+    }
+    public calculateNameFromPath(contentPath: string): string {
+      return super.calculateNameFromPath(contentPath);
+    }
+    public trimPathToContent(path: string): string {
+      return super.trimPathToContent(path);
+    }
+    public populate(trigger: string, component?: SourceComponent): SourceComponent {
+      return super.populate(trigger, component);
+    }
+    public parseMetadataXml(path: string): MetadataXml {
+      return super.parseMetadataXml(path);
+    }
+  }
+
+  const BASE_PATH = join('path', 'to', registry.types.digitalexperiencebundle.directoryName);
+
+  const BUNDLE_NAME = join('site', 'foo');
+  const BUNDLE_PATH = join(BASE_PATH, BUNDLE_NAME);
+  const BUNDLE_META_FILE = join(BUNDLE_PATH, `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`);
+
+  const HOME_VIEW_NAME = join('sfdc_cms__view', 'home');
+  const HOME_VIEW_PATH = join(BUNDLE_PATH, HOME_VIEW_NAME);
+  const HOME_VIEW_CONTENT_FILE = join(HOME_VIEW_PATH, 'content.json');
+  const HOME_VIEW_META_FILE = join(HOME_VIEW_PATH, '_meta.json');
+  const HOME_VIEW_FRENCH_VARIANT_FILE = join(HOME_VIEW_PATH, 'fr.json');
+
+  const registryAccess = new RegistryAccess();
+  const forceIgnore = new ForceIgnore();
+  const tree = VirtualTreeContainer.fromFilePaths([
+    BUNDLE_META_FILE,
+    HOME_VIEW_CONTENT_FILE,
+    HOME_VIEW_META_FILE,
+    HOME_VIEW_FRENCH_VARIANT_FILE,
+  ]);
+
+  const bundleAdapter = new DigitalExperienceSourceAdapterStub(
+    registry.types.digitalexperiencebundle,
+    registryAccess,
+    forceIgnore,
+    tree
+  );
+
+  const digitalExperienceAdapter = new DigitalExperienceSourceAdapterStub(
+    registry.types.digitalexperiencebundle.children.types.digitalexperience,
+    registryAccess,
+    forceIgnore,
+    tree
+  );
+
+  describe('getRootMetadataXmlPath', () => {
+    it('should return metadata file for content.json', () => {
+      expect(digitalExperienceAdapter.getRootMetadataXmlPath(HOME_VIEW_CONTENT_FILE)).to.be.equal(HOME_VIEW_META_FILE);
+      expect(bundleAdapter.getRootMetadataXmlPath(HOME_VIEW_CONTENT_FILE)).to.be.equal(BUNDLE_META_FILE);
+    });
+
+    it('should return metadata file for variant file', () => {
+      expect(digitalExperienceAdapter.getRootMetadataXmlPath(HOME_VIEW_FRENCH_VARIANT_FILE)).to.be.equal(
+        HOME_VIEW_META_FILE
+      );
+      expect(bundleAdapter.getRootMetadataXmlPath(HOME_VIEW_FRENCH_VARIANT_FILE)).to.be.equal(BUNDLE_META_FILE);
+    });
+
+    it('should return metadata file for _meta.json file', () => {
+      expect(digitalExperienceAdapter.getRootMetadataXmlPath(HOME_VIEW_META_FILE)).to.be.equal(HOME_VIEW_META_FILE);
+      expect(bundleAdapter.getRootMetadataXmlPath(HOME_VIEW_META_FILE)).to.be.equal(BUNDLE_META_FILE);
+    });
+
+    it('should return metadata file for bundle', () => {
+      expect(bundleAdapter.getRootMetadataXmlPath(BUNDLE_META_FILE)).to.be.equal(BUNDLE_META_FILE);
+    });
+  });
+
+  describe('calculateNameFromPath', () => {
+    it('should return content full name in proper format', () => {
+      expect(digitalExperienceAdapter.calculateNameFromPath(HOME_VIEW_PATH)).to.be.equal(HOME_VIEW_NAME);
+    });
+
+    it('should return space full name in proper format', () => {
+      expect(bundleAdapter.calculateNameFromPath(BUNDLE_PATH)).to.be.equal(BUNDLE_NAME);
+    });
+  });
+
+  describe('trimPathToContent', () => {
+    it('should get the content folder for contents', () => {
+      expect(digitalExperienceAdapter.trimPathToContent(HOME_VIEW_CONTENT_FILE)).to.be.equal(HOME_VIEW_PATH);
+      expect(digitalExperienceAdapter.trimPathToContent(HOME_VIEW_FRENCH_VARIANT_FILE)).to.be.equal(HOME_VIEW_PATH);
+      expect(digitalExperienceAdapter.trimPathToContent(HOME_VIEW_META_FILE)).to.be.equal(HOME_VIEW_PATH);
+    });
+
+    it('returns undefined for DEB', () => {
+      expect(bundleAdapter.trimPathToContent(BUNDLE_META_FILE)).to.be.undefined;
+    });
+  });
+
+  describe('populate', () => {
+    it('returns the same component for DEB', () => {
+      const component = SourceComponent.createVirtualComponent({
+        name: BUNDLE_NAME,
+        type: registry.types.digitalexperiencebundle,
+        xml: BUNDLE_META_FILE,
+      });
+      expect(bundleAdapter.populate('', component)).to.be.equal(component);
+      expect(bundleAdapter.populate('', undefined)).to.be.undefined;
+    });
+  });
+
+  it('constructs proper parent for contents', () => {
+    const parent = new SourceComponent(
+      {
+        name: BUNDLE_NAME,
+        type: registry.types.digitalexperiencebundle,
+        xml: BUNDLE_META_FILE,
+      },
+      tree,
+      forceIgnore
+    );
+    const component = new SourceComponent(
+      {
+        name: HOME_VIEW_NAME,
+        type: registry.types.digitalexperiencebundle.children.types.digitalexperience,
+        content: HOME_VIEW_PATH,
+        parent,
+        parentType: registry.types.digitalexperiencebundle,
+      },
+      tree,
+      forceIgnore
+    );
+    expect(digitalExperienceAdapter.populate(HOME_VIEW_CONTENT_FILE, undefined)).to.deep.equal(component);
+    expect(digitalExperienceAdapter.populate(HOME_VIEW_META_FILE, undefined)).to.deep.equal(component);
+    expect(digitalExperienceAdapter.populate(HOME_VIEW_FRENCH_VARIANT_FILE, undefined)).to.deep.equal(component);
+  });
+
+  describe('parseMetadataXml', () => {
+    it('returns proper name in MetadataXml', () => {
+      const xml = {
+        fullName: BUNDLE_NAME,
+        suffix: registry.types.digitalexperiencebundle.suffix,
+        path: BUNDLE_META_FILE,
+      };
+      expect(bundleAdapter.parseMetadataXml(BUNDLE_META_FILE)).to.deep.equal(xml);
+    });
+  });
+});

--- a/test/resolve/adapters/sourceAdapterFactory.test.ts
+++ b/test/resolve/adapters/sourceAdapterFactory.test.ts
@@ -15,6 +15,7 @@ import {
   MixedContentSourceAdapter,
 } from '../../../src/resolve/adapters';
 import { SourceAdapterFactory } from '../../../src/resolve/adapters/sourceAdapterFactory';
+import { DigitalExperienceSourceAdapter } from '../../../src/resolve/adapters/digitalExperienceSourceAdapter';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.load('@salesforce/source-deploy-retrieve', 'sdr', ['error_missing_adapter']);
@@ -52,6 +53,16 @@ describe('SourceAdapterFactory', () => {
     const type = registry.types.apexclass;
     const adapter = factory.getAdapter(type);
     expect(adapter).to.deep.equal(new MatchingContentSourceAdapter(type, registryAccess, undefined, tree));
+  });
+
+  it('Should return DigitalExperienceSourceAdapter for digitalExperience AdapterId', () => {
+    const type = registry.types.digitalexperiencebundle;
+    const adapter = factory.getAdapter(type);
+    expect(adapter).to.deep.equal(new DigitalExperienceSourceAdapter(type, registryAccess, undefined, tree));
+
+    const childType = registry.types.digitalexperiencebundle.children.types.digitalexperience;
+    const childAdapter = factory.getAdapter(childType);
+    expect(childAdapter).to.deep.equal(new DigitalExperienceSourceAdapter(childType, registryAccess, undefined, tree));
   });
 
   it('Should return BundleSourceAdapter for bundle AdapterId', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -202,6 +202,33 @@ describe('MetadataResolver', () => {
         expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
       });
 
+      it('Should determine type for DigitalExperience metadata file (_meta.json file)', () => {
+        const parent = join('unpackaged', 'digitalExperiences', 'site', 'foo');
+        const parent_meta_file = join(parent, 'foo.digitalExperience-meta.xml');
+        const path = join(parent, 'sfdc_cms__view', 'home', '_meta.json');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([path, parent_meta_file]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const parentComponent = new SourceComponent(
+          {
+            name: join('site', 'foo'),
+            type: registry.types.digitalexperiencebundle,
+            xml: parent_meta_file,
+          },
+          treeContainer
+        );
+        const expectedComponent = new SourceComponent(
+          {
+            name: join('sfdc_cms__view', 'home'),
+            type: registry.types.digitalexperiencebundle.children.types.digitalexperience,
+            content: dirname(path),
+            parent: parentComponent,
+            parentType: registry.types.digitalexperiencebundle,
+          },
+          treeContainer
+        );
+        expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
+      });
+
       it('Should determine type for path of mixed content type', () => {
         const path = mixedContentDirectory.MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1];
         const access = testUtil.createMetadataResolver([

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -105,6 +105,43 @@ describe('SourceComponent', () => {
     expect(relPath2).to.equal(expectedPath2);
   });
 
+  it('should return correct relative path for DigitalExperienceBundle', () => {
+    const registry = new RegistryAccess();
+    const debType = registry.getTypeByName('DigitalExperienceBundle');
+    const cmp = new SourceComponent({ name: debType.name, type: debType });
+
+    const metaFile = join('my', 'pkg', 'digitalExperiences', 'site', 'foo', 'foo.digitalExperience-meta.xml');
+    const expectedPath = join('digitalExperiences', 'site', 'foo', 'foo.digitalExperience-meta.xml');
+    expect(cmp.getPackageRelativePath(metaFile, 'metadata')).to.equal(expectedPath);
+  });
+
+  it('should return correct relative path for DigitalExperience', () => {
+    const registry = new RegistryAccess();
+    const deType = registry.getTypeByName('DigitalExperience');
+    const cmp = new SourceComponent({ name: deType.name, type: deType });
+
+    const contentFile = join(
+      'my',
+      'pkg',
+      'digitalExperiences',
+      'site',
+      'foo',
+      'sfdc_cms__view',
+      'home',
+      'content.json'
+    );
+    const expectedContentPath = join('digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home', 'content.json');
+    expect(cmp.getPackageRelativePath(contentFile, 'metadata')).to.equal(expectedContentPath);
+
+    const metaFile = join('my', 'pkg', 'digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home', '_meta.json');
+    const expectedMetaPath = join('digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home', '_meta.json');
+    expect(cmp.getPackageRelativePath(metaFile, 'metadata')).to.equal(expectedMetaPath);
+
+    const variantFile = join('my', 'pkg', 'digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home', 'fr.json');
+    const expectedVariantPath = join('digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home', 'fr.json');
+    expect(cmp.getPackageRelativePath(variantFile, 'metadata')).to.equal(expectedVariantPath);
+  });
+
   describe('parseXml', () => {
     afterEach(() => env.restore());
 


### PR DESCRIPTION
### What does this PR do?
Support DigitalExperienceBundle, DigitalExperience, and DigitalExperienceConfig MD types in SDR (without support for source tracking commands)

### What issues does this PR fix or reference?

@W-11492368@

### Functionality Before

1. sfdx force:source and force:mdapi commands didn't support DigitalExperienceBundle, DigitalExperience, and DigitalExperienceConfig MD types 
2. Partial wildcards retrievals for child types were not supported 

### Functionality After

1. sfdx force:source and force:mdapi commands support DigitalExperienceBundle, DigitalExperience, and DigitalExperienceConfig MD types (without support for force:source:pull, force:source:push and force:source:list)
2. Partial wildcards retrievals for child types are now supported 
