### PR TITLE
fix: remove pjson bump from 688

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "7.0.0",
+  "version": "6.3.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",


### PR DESCRIPTION
### What does this PR do?
fix the major version bump accidentally included in #688 and release as not major

### What issues does this PR fix or reference?