### PR TITLE
chore: don't skip types with `ARCGRAPHCOMMUNITY` feat

### DIFF
--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -25,7 +25,6 @@ export const features = [
   'HEALTHCLOUDBETA', // is not a valid Features value
   'PARDOTADVANCED', // org:create throws a C-9999 when this is not excluded
   'EMBEDDEDSERVICEMESSAGING',
-  'ARCGRAPHCOMMUNITY',
   'UNIFIEDHEALTHSCORING',
   'HEALTHCLOUDADDON',
   'EINSTEINDOCREADER',

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 198.8547019999969
+    "duration": 197.8062740000314
   },
   {
     "name": "sourceToMdapi",
-    "duration": 4847.048569999999
+    "duration": 5338.978776999982
   },
   {
     "name": "sourceToZip",
-    "duration": 4199.123152
+    "duration": 4433.559571999998
   },
   {
     "name": "mdapiToSource",
-    "duration": 6244.696370000005
+    "duration": 6825.319519999961
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 396.22317000001203
+    "duration": 401.4154649999691
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7735.950589999993
+    "duration": 8158.042217999988
   },
   {
     "name": "sourceToZip",
-    "duration": 6392.808273000002
+    "duration": 6723.08442899998
   },
   {
     "name": "mdapiToSource",
-    "duration": 6644.384497999999
+    "duration": 7021.386991000036
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 691.8688379999949
+    "duration": 701.4275400000042
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10319.902906000003
+    "duration": 12828.85087699996
   },
   {
     "name": "sourceToZip",
-    "duration": 9858.309108999994
+    "duration": 9517.812057000003
   },
   {
     "name": "mdapiToSource",
-    "duration": 9608.116079999978
+    "duration": 13720.21484999999
   }
 ]


### PR DESCRIPTION
### What does this PR do?

removes `ARCGRAPHCOMMUNITY` feature from blocklist

### What issues does this PR fix or reference?

@W-0@

### Functionality Before

update-script skips md types with that feature

### Functionality After

update-script don't skip them.
