### PR TITLE
Sm/coft-deploy-fix

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -531,14 +531,24 @@ v57 introduces the following new types.  Here's their current level of support
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
 |ActionableListDefinition|❌|Not supported, but support could be added|
+|CampaignTemplateDefinition|❌|Not supported, but support could be added|
 |ClauseCatgConfiguration|❌|Not supported, but support could be added|
+|DisclosureDefinition|❌|Not supported, but support could be added|
+|DisclosureDefinitionVersion|❌|Not supported, but support could be added|
 |DisclosureType|❌|Not supported, but support could be added|
 |ExternalClientApplication|✅||
+|ExternalDocStorageConfig|❌|Not supported, but support could be added|
+|Gear|❌|Not supported, but support could be added|
 |GearDescriptor|❌|Not supported, but support could be added|
+|GearLifecycle|❌|Not supported, but support could be added|
 |GearRule|❌|Not supported, but support could be added|
+|GearRuleTest|❌|Not supported, but support could be added|
 |IdentityProviderSettings|✅||
+|LightningPropertyTypeBundle|❌|Not supported, but support could be added (but not for tracking)|
+|LocationUse|❌|Not supported, but support could be added|
 |OmniSupervisorConfig|❌|Not supported, but support could be added (but not for tracking)|
 |ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
+|WaveAnalyticAssetCollection|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -106,20 +106,23 @@ export class DeployResult implements MetadataTransferResult {
 
       if (baseResponse.state === ComponentStatus.Failed) {
         const diagnostic = this.diagnosticUtil.parseDeployDiagnostic(component, message);
-        const response = Object.assign(baseResponse, diagnostic) as FileResponse;
+        const response = { ...baseResponse, diagnostic } as FileResponse;
         responses.push(response);
       } else {
         // components with children are already taken care of through the messages,
         // so don't walk their content directories.
-        if (content && !type.children) {
+        if (
+          content &&
+          (!type.children || Object.values(type.children.types).some((t) => t.unaddressableWithoutParent))
+        ) {
           for (const filePath of component.walkContent()) {
-            const response = Object.assign({}, baseResponse, { filePath }) as FileResponse;
+            const response = { ...baseResponse, filePath } as FileResponse;
             responses.push(response);
           }
         }
 
         if (xml) {
-          const response = Object.assign({}, baseResponse, { filePath: xml }) as FileResponse;
+          const response = { ...baseResponse, filePath: xml } as FileResponse;
           responses.push(response);
         }
       }

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -106,7 +106,7 @@ export class DeployResult implements MetadataTransferResult {
 
       if (baseResponse.state === ComponentStatus.Failed) {
         const diagnostic = this.diagnosticUtil.parseDeployDiagnostic(component, message);
-        const response = { ...baseResponse, diagnostic } as FileResponse;
+        const response = Object.assign(baseResponse, diagnostic) as FileResponse;
         responses.push(response);
       } else {
         // components with children are already taken care of through the messages,

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -43,7 +43,6 @@ export class MetadataConverter {
         (comps instanceof ComponentSet ? Array.from(comps.getSourceComponents()) : comps) as SourceComponent[]
       ).filter((comp) => comp.type.isAddressable !== false);
 
-      let manifestContents;
       const isSource = targetFormat === 'source';
       const tasks: Array<Promise<void>> = [];
 
@@ -57,14 +56,13 @@ export class MetadataConverter {
           if (output.packageName) {
             cs.fullName = output.packageName;
           }
-          manifestContents = await cs.getPackageXml();
           packagePath = this.getPackagePath(output);
           defaultDirectory = packagePath;
           writer = new StandardWriter(packagePath);
           if (!isSource) {
             const manifestPath = join(packagePath, MetadataConverter.PACKAGE_XML_FILE);
             tasks.push(
-              promises.writeFile(manifestPath, manifestContents),
+              promises.writeFile(manifestPath, await cs.getPackageXml()),
               ...cs.getTypesOfDestructiveChanges().map(async (destructiveChangesType) =>
                 // for each of the destructive changes in the component set, convert and write the correct metadata
                 // to each manifest
@@ -80,12 +78,11 @@ export class MetadataConverter {
           if (output.packageName) {
             cs.fullName = output.packageName;
           }
-          manifestContents = await cs.getPackageXml();
           packagePath = this.getPackagePath(output);
           defaultDirectory = packagePath;
           writer = new ZipWriter(packagePath);
           if (!isSource) {
-            writer.addToZip(manifestContents, MetadataConverter.PACKAGE_XML_FILE);
+            writer.addToZip(await cs.getPackageXml(), MetadataConverter.PACKAGE_XML_FILE);
             // for each of the destructive changes in the component set, convert and write the correct metadata
             // to each manifest
             for (const destructiveChangeType of cs.getTypesOfDestructiveChanges()) {

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -86,15 +86,8 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
       const triggerIsAChild = !!childTypeId;
       const strategy = this.type.strategies.decomposition;
 
-      if (triggerIsAChild) {
-        if (
-          strategy === DecompositionStrategy.TopLevel &&
-          this.type.children.types[childTypeId].unaddressableWithoutParent &&
-          isResolvingSource
-        ) {
-          // we can't deploy the child, so we need to return its parent component
-          return component;
-        } else if (strategy === DecompositionStrategy.FolderPerType || isResolvingSource) {
+      if (triggerIsAChild && !this.type.children.types[childTypeId].unaddressableWithoutParent) {
+        if (strategy === DecompositionStrategy.FolderPerType || isResolvingSource) {
           let parent = component;
           if (!parent) {
             parent = new SourceComponent(

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 325.82882699999027
+    "duration": 329.62463900004514
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7251.922354000009
+    "duration": 7505.23844700004
   },
   {
     "name": "sourceToZip",
-    "duration": 5983.844335000002
+    "duration": 6470.010548999999
   },
   {
     "name": "mdapiToSource",
-    "duration": 8623.723956000002
+    "duration": 5877.771837000037
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 664.5060110000195
+    "duration": 644.1402209999505
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11993.994738000038
+    "duration": 11856.592849999957
   },
   {
     "name": "sourceToZip",
-    "duration": 9293.955343000009
+    "duration": 10338.099250999978
   },
   {
     "name": "mdapiToSource",
-    "duration": 10224.62978399999
+    "duration": 8291.250971000001
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 1084.5274579999968
+    "duration": 1090.1220250000479
   },
   {
     "name": "sourceToMdapi",
-    "duration": 18790.406279999996
+    "duration": 17970.10952900001
   },
   {
     "name": "sourceToZip",
-    "duration": 16412.87079200003
+    "duration": 15943.596995999978
   },
   {
     "name": "mdapiToSource",
-    "duration": 16847.423238000018
+    "duration": 14545.061661000014
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 218.47389499998826
+    "duration": 227.84873699999298
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5293.27240300001
+    "duration": 5575.808999000001
   },
   {
     "name": "sourceToZip",
-    "duration": 4158.915987000015
+    "duration": 5121.344982999988
   },
   {
     "name": "mdapiToSource",
-    "duration": 6551.467303000012
+    "duration": 4306.255004000006
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 431.3132029999979
+    "duration": 464.14559599998756
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8141.630254999996
+    "duration": 8464.103521000012
   },
   {
     "name": "sourceToZip",
-    "duration": 6378.759560999984
+    "duration": 7716.617144000018
   },
   {
     "name": "mdapiToSource",
-    "duration": 7380.699353000004
+    "duration": 5273.308957000001
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 764.7591390000016
+    "duration": 782.2161900000065
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11849.736803999986
+    "duration": 12909.834803000005
   },
   {
     "name": "sourceToZip",
-    "duration": 10867.191843999986
+    "duration": 11247.063521999982
   },
   {
     "name": "mdapiToSource",
-    "duration": 14328.787168999988
+    "duration": 12979.326094000018
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 197.8062740000314
+    "duration": 208.06498400005512
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5338.978776999982
+    "duration": 5322.269709000015
   },
   {
     "name": "sourceToZip",
-    "duration": 4433.559571999998
+    "duration": 4832.698105999967
   },
   {
     "name": "mdapiToSource",
-    "duration": 6825.319519999961
+    "duration": 3625.784056000004
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 401.4154649999691
+    "duration": 397.36901500000386
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8158.042217999988
+    "duration": 7502.408032000007
   },
   {
     "name": "sourceToZip",
-    "duration": 6723.08442899998
+    "duration": 6753.71645300003
   },
   {
     "name": "mdapiToSource",
-    "duration": 7021.386991000036
+    "duration": 4371.168727000011
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 701.4275400000042
+    "duration": 708.7594559999998
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12828.85087699996
+    "duration": 10645.160910999984
   },
   {
     "name": "sourceToZip",
-    "duration": 9517.812057000003
+    "duration": 9419.763166999968
   },
   {
     "name": "mdapiToSource",
-    "duration": 13720.21484999999
+    "duration": 7377.691368
   }
 ]

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -8,7 +8,6 @@ import { join } from 'path';
 import { assert, expect } from 'chai';
 import { createSandbox } from 'sinon';
 import { Messages, SfError } from '@salesforce/core';
-
 import { decomposed, matchingContentFile, mixedContentDirectory, xmlInFolder } from '../mock';
 import { DECOMPOSED_COMPONENT } from '../mock/type-constants/customObjectConstant';
 import { COMPONENT } from '../mock/type-constants/apexClassConstant';
@@ -32,6 +31,10 @@ import {
   SourceComponent,
   VirtualTreeContainer,
 } from '../../src';
+import {
+  DECOMPOSED_TOP_LEVEL_CHILD_XML_PATHS,
+  DECOMPOSED_TOP_LEVEL_COMPONENT,
+} from '../mock/type-constants/customObjectTranslationConstant';
 import { DecomposedSourceAdapter } from '../../src/resolve/adapters';
 import { RegistryTestUtil } from './registryTestUtil';
 
@@ -420,6 +423,24 @@ describe('SourceComponent', () => {
         SfError,
         messages.getMessage('error_unexpected_child_type', [fsPath, type.name])
       );
+    });
+  });
+
+  describe('Un-addressable decomposed child (cot/cof)', () => {
+    it('gets parent when asked to resolve a child by filePath', () => {
+      const expectedTopLevel = DECOMPOSED_TOP_LEVEL_COMPONENT;
+      const adapter = new DecomposedSourceAdapter(
+        expectedTopLevel.type,
+        new RegistryAccess(),
+        undefined,
+        expectedTopLevel.tree
+      );
+
+      const result = adapter.getComponent(DECOMPOSED_TOP_LEVEL_CHILD_XML_PATHS[0], true);
+      // eslint-disable-next-line no-console
+      console.log(result);
+      expect(result.type).to.deep.equal(expectedTopLevel.type);
+      expect(result.xml).to.equal(expectedTopLevel.xml);
     });
   });
 

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -437,8 +437,6 @@ describe('SourceComponent', () => {
       );
 
       const result = adapter.getComponent(DECOMPOSED_TOP_LEVEL_CHILD_XML_PATHS[0], true);
-      // eslint-disable-next-line no-console
-      console.log(result);
       expect(result.type).to.deep.equal(expectedTopLevel.type);
       expect(result.xml).to.equal(expectedTopLevel.xml);
     });


### PR DESCRIPTION
### What does this PR do?
makes it possible to deploy just a CustomObjectFieldTranslation (decomposed child of customObjectTranslation)

Background:
COFT is not in the metadata api--it has to be rolled up into a COT to be deployed.
The following would not work:
1. `force:source:deploy -p [path to COFT]`
2. changing a COFT file locally and calling `force:source:push`

This now:
1. will resolve a CFT to its parent COFT when building componentSets
2. when a COT is deployed, will create FileReponses for each of the child CFT (we don't know which ones were deployed, so we mark them all.  These fileResponses also make sure that source tracking updates correctly for CFT)

### What issues does this PR fix or reference?
[@W-11811429@](https://gus.lightning.force.com/a07EE000017GLrbYAG)