### PR TITLE
fix: show individual cft in a retrieve

### DIFF
--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -100,7 +100,7 @@ export class RetrieveResult implements MetadataTransferResult {
         state: this.localComponents.has(retrievedComponent) ? ComponentStatus.Changed : ComponentStatus.Created,
       };
 
-      if (!type.children) {
+      if (!type.children || Object.values(type.children.types).some((t) => t.unaddressableWithoutParent)) {
         for (const filePath of retrievedComponent.walkContent()) {
           this.fileResponses.push(Object.assign({}, baseResponse, { filePath }));
         }

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 227.84873699999298
+    "duration": 217.93947700003628
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5575.808999000001
+    "duration": 5880.5675030000275
   },
   {
     "name": "sourceToZip",
-    "duration": 5121.344982999988
+    "duration": 5136.219725999981
   },
   {
     "name": "mdapiToSource",
-    "duration": 4306.255004000006
+    "duration": 4138.7591559999855
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 464.14559599998756
+    "duration": 431.07157500006724
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8464.103521000012
+    "duration": 8174.430239000008
   },
   {
     "name": "sourceToZip",
-    "duration": 7716.617144000018
+    "duration": 7697.708233000012
   },
   {
     "name": "mdapiToSource",
-    "duration": 5273.308957000001
+    "duration": 4943.100770000019
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 782.2161900000065
+    "duration": 748.0606320000952
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12909.834803000005
+    "duration": 12974.12760899996
   },
   {
     "name": "sourceToZip",
-    "duration": 11247.063521999982
+    "duration": 10737.532497000066
   },
   {
     "name": "mdapiToSource",
-    "duration": 12979.326094000018
+    "duration": 12639.02305800002
   }
 ]


### PR DESCRIPTION
### What does this PR do?
customFieldTranslations weren't showing up in FileResponses for retrieve.  the corrected logic from Deploy is now in Retrieve.

### What issues does this PR fix or reference?
kinda a followup for https://github.com/forcedotcom/source-deploy-retrieve/pull/726
so @W-11811429@