### PR TITLE
fix: add a better error message with invalid manifests

### DIFF
--- a/.github/workflows/perfScaleNut.yml
+++ b/.github/workflows/perfScaleNut.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
           cache: yarn
       - run: npm install -g sfdx-cli --omit=dev
       - run: yarn install

--- a/.github/workflows/registryCheck.yml
+++ b/.github/workflows/registryCheck.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-        with:
-          node-version: latest
       - run: yarn install
       - run: yarn build
       - run: yarn test:registry

--- a/.github/workflows/registryCheckPreview.yml
+++ b/.github/workflows/registryCheckPreview.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-        with:
-          node-version: latest
       - run: yarn install
       - run: yarn build
       - run: yarn metadata:preview

--- a/src/resolve/manifestResolver.ts
+++ b/src/resolve/manifestResolver.ts
@@ -63,7 +63,16 @@ export class ManifestResolver {
     const apiVersion = parsedManifest.version;
 
     for (const typeMembers of packageTypeMembers) {
-      const typeName = typeMembers.name;
+      let typeName = typeMembers.name;
+      // protect against empty/invalid typeMember definitions in the manifest
+      if (typeof typeName !== 'string' || typeName.length === 0) {
+        if (typeof typeName === 'object') {
+          typeName = JSON.stringify(typeName);
+        }
+        const err = new Error(`Invalid types definition in manifest file: ${manifestPath}\nFound: "${typeName ?? ''}"`);
+        err.name = 'InvalidManifest';
+        throw err;
+      }
       const type = this.registry.getTypeByName(typeName);
       const parentType = type.folderType ? this.registry.getTypeByName(type.folderType) : undefined;
       const members = ensureArray(typeMembers.members);

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 214.46215100004338
+    "duration": 211.98616599995876
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6232.359846999985
+    "duration": 5675.445168000006
   },
   {
     "name": "sourceToZip",
-    "duration": 4866.491668000002
+    "duration": 4325.303721999982
   },
   {
     "name": "mdapiToSource",
-    "duration": 4188.821088000026
+    "duration": 3837.6363589999964
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 428.76088600000367
+    "duration": 414.30975700001
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8602.956126999983
+    "duration": 8222.016792999988
   },
   {
     "name": "sourceToZip",
-    "duration": 6805.6596850000205
+    "duration": 6871.310621000011
   },
   {
     "name": "mdapiToSource",
-    "duration": 5127.636436000001
+    "duration": 4824.338472999982
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 776.4044480000157
+    "duration": 710.4652360000182
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12145.154593000014
+    "duration": 11589.544998999976
   },
   {
     "name": "sourceToZip",
-    "duration": 11030.154324000003
+    "duration": 11294.996881
   },
   {
     "name": "mdapiToSource",
-    "duration": 12548.084606999997
+    "duration": 13089.373708
   }
 ]


### PR DESCRIPTION
### What does this PR do?
throw an error during manifest parsing when a metadata type appears invalid, indicating a bad manifest file.

### What issues does this PR fix or reference?
@W-11927256@

### Functionality Before
"Cannot read property 'toLowerCase' of undefined"
https://github.com/forcedotcom/cli/issues/1187

### Functionality After
Invalid types definition in manifest file: package.xml
Found: ""

Testing:
Create a manifest file with an empty `<types></types>` definition inside and run `sfdx force:source:retrieve -x package.xml`