### PR TITLE
Enable CLI support for ExtlClntAppOauthPlcyCnfg, ExtlClntAppOauthSettings, ExtlClntAppMobileSet 

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -532,7 +532,6 @@ v57 introduces the following new types.  Here's their current level of support
 |:---|:---|:---|
 |ActionableListDefinition|❌|Not supported, but support could be added|
 |AffinityScoreDefinition|❌|Not supported, but support could be added|
-|CampaignTemplateDefinition|❌|Not supported, but support could be added|
 |ClauseCatgConfiguration|✅||
 |DisclosureDefinition|✅||
 |DisclosureDefinitionVersion|✅||
@@ -541,8 +540,8 @@ v57 introduces the following new types.  Here's their current level of support
 |ExternalClientAppSettings|✅||
 |ExternalClientApplication|✅||
 |ExternalDocStorageConfig|❌|Not supported, but support could be added|
-|ExtlClntAppMobileSet|❌|Not supported, but support could be added|
-|ExtlClntAppOauthPlcyCnfg|❌|Not supported, but support could be added|
+|ExtlClntAppMobileSet|✅||
+|ExtlClntAppOauthPlcyCnfg|✅||
 |IdentityProviderSettings|✅||
 |IntegrationProviderDef|❌|Not supported, but support could be added|
 |LocationUse|❌|Not supported, but support could be added|
@@ -579,6 +578,7 @@ v57 introduces the following new types.  Here's their current level of support
 - CustomFieldTranslation
 - MatchingRule
 - MarketingResourceType
+- ExtlClntAppOauthSettings
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1383,6 +1383,30 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "extlclntappoauthplcycnfg": {
+      "id": "extlclntappoauthplcycnfg",
+      "name": "ExtlClntAppOauthPlcyCnfg",
+      "suffix": "oauthPolicy",
+      "directoryName": "oauthPolicies",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappoauthsettings": {
+      "id": "extlclntappoauthsettings",
+      "name": "ExtlClntAppOauthSettings",
+      "suffix": "oauth",
+      "directoryName": "extlClntAppOauthSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappmobileset": {
+      "id": "extlclntappmobileset",
+      "name": "ExtlClntAppMobileSet",
+      "suffix": "extlClntAppMobileSet",
+      "directoryName": "extlClntAppMobileSets",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "appmenu": {
       "id": "appmenu",
       "name": "AppMenu",
@@ -3351,6 +3375,9 @@
     "notiftype": "customnotificationtype",
     "connectedApp": "connectedapp",
     "externalClientApp": "externalclientapplication",
+    "oauthPolicy": "extlclntappoauthplcycnfg",
+    "extlClntAppMobileSet": "extlclntappmobileset",
+    "extlClntAppOauthSettings": "extlclntappoauthsettings",
     "appMenu": "appmenu",
     "delegateGroup": "delegategroup",
     "network": "network",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3377,7 +3377,7 @@
     "externalClientApp": "externalclientapplication",
     "oauthPolicy": "extlclntappoauthplcycnfg",
     "extlClntAppMobileSet": "extlclntappmobileset",
-    "extlClntAppOauthSettings": "extlclntappoauthsettings",
+    "oauth": "extlclntappoauthsettings",
     "appMenu": "appmenu",
     "delegateGroup": "delegategroup",
     "network": "network",

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 211.98616599995876
+    "duration": 227.53589899999497
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5675.445168000006
+    "duration": 5797.005348999999
   },
   {
     "name": "sourceToZip",
-    "duration": 4325.303721999982
+    "duration": 4814.342231000002
   },
   {
     "name": "mdapiToSource",
-    "duration": 3837.6363589999964
+    "duration": 3835.130170999997
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 414.30975700001
+    "duration": 411.68149899999844
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8222.016792999988
+    "duration": 8466.343819000002
   },
   {
     "name": "sourceToZip",
-    "duration": 6871.310621000011
+    "duration": 6411.866650000011
   },
   {
     "name": "mdapiToSource",
-    "duration": 4824.338472999982
+    "duration": 5187.5936060000095
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 710.4652360000182
+    "duration": 734.0428379999939
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11589.544998999976
+    "duration": 13081.072366000008
   },
   {
     "name": "sourceToZip",
-    "duration": 11294.996881
+    "duration": 10285.210365000006
   },
   {
     "name": "mdapiToSource",
-    "duration": 13089.373708
+    "duration": 12955.521213
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Enable CLI support for ExtlClntAppOauthPlcyCnfg, ExtlClntAppOauthSettings, ExtlClntAppMobileSet 

### What issues does this PR fix or reference?
#[W-11950652](https://gus.lightning.force.com/a07EE000019d9dwYAA)

### Functionality Before
sfdx force:source and force:mdapi commands didn't support MD type for ExtlClntAppOauthPlcyCnfg, ExtlClntAppOauthSettings, ExtlClntAppMobileSet 

### Functionality After
sfdx force:source and force:mdapi commands supports MD type for ExtlClntAppOauthPlcyCnfg, ExtlClntAppOauthSettings, ExtlClntAppMobileSet 