### PR TITLE
feat: replacements in output

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -533,6 +533,7 @@ v57 introduces the following new types.  Here's their current level of support
 |ActionableListDefinition|❌|Not supported, but support could be added|
 |AffinityScoreDefinition|❌|Not supported, but support could be added|
 |ClauseCatgConfiguration|❌|Not supported, but support could be added|
+|CommerceRuleSettings|✅||
 |DisclosureDefinition|❌|Not supported, but support could be added|
 |DisclosureDefinitionVersion|❌|Not supported, but support could be added|
 |DisclosureType|❌|Not supported, but support could be added|
@@ -540,8 +541,9 @@ v57 introduces the following new types.  Here's their current level of support
 |ExternalClientAppSettings|✅||
 |ExternalClientApplication|✅||
 |ExternalDocStorageConfig|❌|Not supported, but support could be added|
-|ExtlClntAppMobileSet|❌|Not supported, but support could be added|
+|ExtlClntAppMobileSettings|✅||
 |ExtlClntAppOauthPlcyCnfg|❌|Not supported, but support could be added|
+|ExtlClntAppOauthSettings|✅||
 |IdentityProviderSettings|✅||
 |IntegrationProviderDef|❌|Not supported, but support could be added|
 |LocationUse|❌|Not supported, but support could be added|

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -64,7 +64,6 @@ interface FileResponseFailure extends FileResponseBase {
 }
 
 export type FileResponse = FileResponseSuccess | FileResponseFailure;
-
 export interface MetadataTransferResult {
   response: MetadataRequestStatus;
   components: ComponentSet;

--- a/src/convert/types.ts
+++ b/src/convert/types.ts
@@ -110,6 +110,7 @@ export type ConvertResult = {
 export type MarkedReplacement = {
   toReplace: string | RegExp;
   replaceWith: string;
+  matchedFilename: string;
   singleFile?: boolean;
 };
 
@@ -138,3 +139,8 @@ type ReplacementTarget =
       /** When putting regex into json, you have to use an extra backslash to escape your regex backslashes because JSON also treats backslash as an escape character */
       regexToReplace: string;
     };
+
+export type ReplacementEvent = {
+  filename: string;
+  replaced: string;
+};

--- a/test/convert/replacements.test.ts
+++ b/test/convert/replacements.test.ts
@@ -92,7 +92,7 @@ describe('marking replacements on a component', () => {
     expect(result).to.deep.equal({
       [cmp.xml]: [
         {
-          matchedFilename: 'path/to/classes/myComponent.cls-meta.xml',
+          matchedFilename: cmp.xml,
           toReplace: /.*foo.*/g,
           replaceWith: 'bar',
           singleFile: true,
@@ -129,7 +129,7 @@ describe('marking replacements on a component', () => {
     expect(result).to.deep.equal({
       [cmp.xml]: [
         {
-          matchedFilename: 'path/to/classes/myComponent.cls-meta.xml',
+          matchedFilename: cmp.xml,
           toReplace: 'foo',
           replaceWith: 'bar',
           singleFile: false,
@@ -137,7 +137,7 @@ describe('marking replacements on a component', () => {
       ],
       [cmp.content]: [
         {
-          matchedFilename: 'path/to/classes/myComponent.cls',
+          matchedFilename: cmp.content,
           toReplace: 'foo',
           replaceWith: 'bar',
           singleFile: false,
@@ -153,7 +153,7 @@ describe('marking replacements on a component', () => {
     expect(result).to.deep.equal({
       [cmp.xml]: [
         {
-          matchedFilename: 'path/to/classes/myComponent.cls-meta.xml',
+          matchedFilename: cmp.xml,
           toReplace: 'foo',
           replaceWith: 'bar',
           singleFile: true,
@@ -161,7 +161,7 @@ describe('marking replacements on a component', () => {
       ],
       [cmp.content]: [
         {
-          matchedFilename: 'path/to/classes/myComponent.cls',
+          matchedFilename: cmp.content,
           toReplace: 'foo',
           replaceWith: 'bar',
           singleFile: true,

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 217.24560199998086
+    "duration": 217.22331100000883
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6034.749643999967
+    "duration": 5528.8957320000045
   },
   {
     "name": "sourceToZip",
-    "duration": 4773.798967999988
+    "duration": 4973.436105999979
   },
   {
     "name": "mdapiToSource",
-    "duration": 3753.1327789999777
+    "duration": 3836.91319500003
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 445.2519559999928
+    "duration": 412.3087709999527
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8093.97652299999
+    "duration": 7418.153514000005
   },
   {
     "name": "sourceToZip",
-    "duration": 6444.346208999981
+    "duration": 6142.985255000007
   },
   {
     "name": "mdapiToSource",
-    "duration": 4924.401616999996
+    "duration": 4409.731972999987
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 751.4006550000049
+    "duration": 702.3643789999769
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11578.667857999972
+    "duration": 11670.428872999968
   },
   {
     "name": "sourceToZip",
-    "duration": 9852.379058999999
+    "duration": 10227.489082999993
   },
   {
     "name": "mdapiToSource",
-    "duration": 8332.220241000003
+    "duration": 10798.030672999972
   }
 ]


### PR DESCRIPTION
### What does this PR do?
when replacements happen in the replacement stream, emit events
aggregate those up to the metadataApiDeploy class and, when done, set them on the DeployResult so that library consumers can know what occurred.
 
@W-11949818@