### PR TITLE
Enable CLI support for ExtlClntAppOauthConfigurablePolicies, ExtlClntAppMobileSettings

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -581,7 +581,7 @@ v57 introduces the following new types.  Here's their current level of support
 - MatchingRule
 - MarketingResourceType
 - ExtlClntAppOauthConfigurablePolicies
-- ExtlClntAppMobileConfigurablePolices
+- ExtlClntAppMobileConfigurablePolicies
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -533,6 +533,7 @@ v57 introduces the following new types.  Here's their current level of support
 |ActionableListDefinition|❌|Not supported, but support could be added|
 |AffinityScoreDefinition|❌|Not supported, but support could be added|
 |ClauseCatgConfiguration|✅||
+|CommerceRuleSettings|✅||
 |DisclosureDefinition|✅||
 |DisclosureDefinitionVersion|✅||
 |DisclosureType|✅||
@@ -540,12 +541,13 @@ v57 introduces the following new types.  Here's their current level of support
 |ExternalClientAppSettings|✅||
 |ExternalClientApplication|✅||
 |ExternalDocStorageConfig|❌|Not supported, but support could be added|
-|ExtlClntAppMobileSet|✅||
-|ExtlClntAppOauthPlcyCnfg|✅||
+|ExtlClntAppMobileSettings|✅||
+|ExtlClntAppOauthPlcyCnfg|❌|Not supported, but support could be added|
+|ExtlClntAppOauthSettings|✅||
 |IdentityProviderSettings|✅||
 |IntegrationProviderDef|❌|Not supported, but support could be added|
 |LocationUse|❌|Not supported, but support could be added|
-|OmniSupervisorConfig|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniSupervisorConfig|✅||
 |PipelineInspMetricConfig|❌|Not supported, but support could be added|
 |ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
 |ServiceProcess|❌|Not supported, but support could be added|
@@ -578,7 +580,8 @@ v57 introduces the following new types.  Here's their current level of support
 - CustomFieldTranslation
 - MatchingRule
 - MarketingResourceType
-- ExtlClntAppOauthSettings
+- ExtlClntAppOauthConfigurablePolicies
+- ExtlClntAppMobileConfigurablePolices
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -581,7 +581,6 @@ v57 introduces the following new types.  Here's their current level of support
 - MatchingRule
 - MarketingResourceType
 - ExtlClntAppOauthConfigurablePolicies
-- ExtlClntAppMobileConfigurablePolicies
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1407,14 +1407,6 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobileconfigurablepolicies": {
-      "id": "extlclntappmobileconfigurablepolicies",
-      "name": "ExtlClntAppMobileConfigurablePolicies",
-      "suffix": "ecaMobPlcy",
-      "directoryName": "mobPolicies",
-      "inFolder": false,
-      "strictDirectoryName": false
-    },
     "appmenu": {
       "id": "appmenu",
       "name": "AppMenu",
@@ -3384,7 +3376,6 @@
     "connectedApp": "connectedapp",
     "eca": "externalclientapplication",
     "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
-    "ecaMobPlcy": "extlclntappmobileconfigurablepolicies",
     "ecaMob": "extlclntappmobilesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "appMenu": "appmenu",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1407,9 +1407,9 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobileconfigurablepolices": {
-      "id": "extlclntappmobileconfigurablepolices",
-      "name": "ExtlClntAppMobileConfigurablePolices",
+    "extlclntappmobileconfigurablepolicies": {
+      "id": "extlclntappmobileconfigurablepolicies",
+      "name": "ExtlClntAppMobileConfigurablePolicies",
       "suffix": "ecaMobPlcy",
       "directoryName": "mobPolicies",
       "inFolder": false,
@@ -3384,7 +3384,7 @@
     "connectedApp": "connectedapp",
     "eca": "externalclientapplication",
     "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
-    "ecaMobPlcy": "extlclntappmobileconfigurablepolices",
+    "ecaMobPlcy": "extlclntappmobileconfigurablepolicies",
     "ecaMob": "extlclntappmobilesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "appMenu": "appmenu",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1378,15 +1378,15 @@
     "externalclientapplication": {
       "id": "externalclientapplication",
       "name": "ExternalClientApplication",
-      "suffix": "externalClientApp",
+      "suffix": "eca",
       "directoryName": "externalClientApps",
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappoauthplcycnfg": {
-      "id": "extlclntappoauthplcycnfg",
-      "name": "ExtlClntAppOauthPlcyCnfg",
-      "suffix": "oauthPolicy",
+    "extlclntappoauthconfigurablepolicies": {
+      "id": "extlclntappoauthconfigurablepolicies",
+      "name": "ExtlClntAppOauthConfigurablePolicies",
+      "suffix": "ecaOauthPlcy",
       "directoryName": "oauthPolicies",
       "inFolder": false,
       "strictDirectoryName": false
@@ -1394,16 +1394,24 @@
     "extlclntappoauthsettings": {
       "id": "extlclntappoauthsettings",
       "name": "ExtlClntAppOauthSettings",
-      "suffix": "oauth",
+      "suffix": "ecaOauth",
       "directoryName": "extlClntAppOauthSettings",
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobileset": {
-      "id": "extlclntappmobileset",
-      "name": "ExtlClntAppMobileSet",
-      "suffix": "extlClntAppMobileSet",
-      "directoryName": "extlClntAppMobileSets",
+    "extlclntappmobilesettings": {
+      "id": "extlclntappmobilesettings",
+      "name": "ExtlClntAppMobileSettings",
+      "suffix": "ecaMob",
+      "directoryName": "extlClntAppMobileSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappmobileconfigurablepolices": {
+      "id": "extlclntappmobileconfigurablepolices",
+      "name": "ExtlClntAppMobileConfigurablePolices",
+      "suffix": "ecaMobPlcy",
+      "directoryName": "mobPolicies",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -3374,10 +3382,11 @@
     "entitlementTemplate": "entitlementtemplate",
     "notiftype": "customnotificationtype",
     "connectedApp": "connectedapp",
-    "externalClientApp": "externalclientapplication",
-    "oauthPolicy": "extlclntappoauthplcycnfg",
-    "extlClntAppMobileSet": "extlclntappmobileset",
-    "oauth": "extlclntappoauthsettings",
+    "eca": "externalclientapplication",
+    "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
+    "ecaMobPlcy": "extlclntappmobileconfigurablepolices",
+    "ecaMob": "extlclntappmobilesettings",
+    "ecaOauth": "extlclntappoauthsettings",
     "appMenu": "appmenu",
     "delegateGroup": "delegategroup",
     "network": "network",

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 227.53589899999497
+    "duration": 212.75168799998937
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5797.005348999999
+    "duration": 4968.247083999973
   },
   {
     "name": "sourceToZip",
-    "duration": 4814.342231000002
+    "duration": 4913.3930489999475
   },
   {
     "name": "mdapiToSource",
-    "duration": 3835.130170999997
+    "duration": 3678.5225419999915
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 470.6312699999835
+    "duration": 427.1703989999951
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7751.746233000013
+    "duration": 8699.61532500002
   },
   {
     "name": "sourceToZip",
-    "duration": 6782.484058000002
+    "duration": 7062.340872999979
   },
   {
     "name": "mdapiToSource",
-    "duration": 4625.043036999996
+    "duration": 4507.392125000013
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 729.9692550000036
+    "duration": 708.247853000008
   },
   {
     "name": "sourceToMdapi",
-    "duration": 9952.340448999981
+    "duration": 11350.272353000008
   },
   {
     "name": "sourceToZip",
-    "duration": 10424.467409000004
+    "duration": 10826.725208999997
   },
   {
     "name": "mdapiToSource",
-    "duration": 7663.856468000013
+    "duration": 9852.030005000008
   }
 ]


### PR DESCRIPTION
### What does this PR do?

Enable CLI support for ExtlClntAppOauthConfigurationPolicies, ExtlClntAppMobileSettings. MD names are refactored from ExtlClntAppOauthPlcyCnfg and ExtlClntAppMobileSet respectively.

### What issues does this PR fix or reference?

[W-11950652](https://gus.lightning.force.com/a07EE000019d9dwYAA)

### Functionality Before

sfdx force:source and force:mdapi commands didn't support MD type for ExtlClntAppOauthConfigurationPolicies, ExtlClntAppMobileSettings

### Functionality After

sfdx force:source and force:mdapi commands supports MD type for ExtlClntAppOauthConfigurationPolicies, ExtlClntAppMobileSettings