### PR TITLE
Sm/static resource transformer bug

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -532,6 +532,7 @@ v57 introduces the following new types.  Here's their current level of support
 |:---|:---|:---|
 |ActionableListDefinition|❌|Not supported, but support could be added|
 |AffinityScoreDefinition|❌|Not supported, but support could be added|
+|ClaimFinancialSettings|✅||
 |ClauseCatgConfiguration|✅||
 |CommerceRuleSettings|✅||
 |DisclosureDefinition|✅||
@@ -541,8 +542,9 @@ v57 introduces the following new types.  Here's their current level of support
 |ExternalClientAppSettings|✅||
 |ExternalClientApplication|✅||
 |ExternalDocStorageConfig|❌|Not supported, but support could be added|
+|ExtlClntAppMobilePolicies|❌|Not supported, but support could be added|
 |ExtlClntAppMobileSettings|✅||
-|ExtlClntAppOauthPlcyCnfg|❌|Not supported, but support could be added|
+|ExtlClntAppOauthConfigurablePolicies|✅||
 |ExtlClntAppOauthSettings|✅||
 |IdentityProviderSettings|✅||
 |IntegrationProviderDef|❌|Not supported, but support could be added|
@@ -580,7 +582,6 @@ v57 introduces the following new types.  Here's their current level of support
 - CustomFieldTranslation
 - MatchingRule
 - MarketingResourceType
-- ExtlClntAppOauthConfigurablePolicies
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -39,7 +39,9 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
   public async toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]> {
     const { content, type, xml } = component;
 
-    // archiver/zip.finalize is async.  If you await it, bad things happen https://github.com/forcedotcom/cli/issues/1791
+    // archiver/zip.finalize looks like it is async, because it extends streams, but it is not meant to be used that way
+    // the typings on it are misleading and unintended.  More info https://github.com/archiverjs/node-archiver/issues/476
+    // If you await it, bad things happen, like the convert process exiting silently.  https://github.com/forcedotcom/cli/issues/1791
     // leave the void as it is
     // eslint-disable-next-line @typescript-eslint/require-await
     const zipIt = async (): Promise<Archiver> => {

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -39,6 +39,9 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
   public async toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]> {
     const { content, type, xml } = component;
 
+    // archiver/zip.finalize is async.  If you await it, bad things happen https://github.com/forcedotcom/cli/issues/1791
+    // leave the void as it is
+    // eslint-disable-next-line @typescript-eslint/require-await
     const zipIt = async (): Promise<Archiver> => {
       // toolbelt was using level 9 for static resources, so we'll do the same.
       // Otherwise, you'll see errors like https://github.com/forcedotcom/cli/issues/1098
@@ -53,7 +56,7 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
           zip.append(replacementStream, { name: relative(content, path) });
         }
       }
-      await zip.finalize();
+      void zip.finalize();
       return zip;
     };
 

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 258.7272329999978
+    "duration": 240.1729839999898
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7064.5000979999895
+    "duration": 5893.712117000003
   },
   {
     "name": "sourceToZip",
-    "duration": 5043.188347000003
+    "duration": 6712.079133000007
   },
   {
     "name": "mdapiToSource",
-    "duration": 4514.134340000019
+    "duration": 4511.380858000019
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 479.82419299997855
+    "duration": 505.1115040000004
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8941.918268000009
+    "duration": 10536.354740999988
   },
   {
     "name": "sourceToZip",
-    "duration": 10533.41592499998
+    "duration": 7629.889922000002
   },
   {
     "name": "mdapiToSource",
-    "duration": 5452.256045999995
+    "duration": 5711.929862999998
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8171M-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 830.0290470000182
+    "duration": 848.9497269999993
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12821.065571999992
+    "duration": 14420.913567999989
   },
   {
     "name": "sourceToZip",
-    "duration": 11678.985925000015
+    "duration": 12225.230517000018
   },
   {
     "name": "mdapiToSource",
-    "duration": 13113.897208999988
+    "duration": 14027.158036999987
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 212.75168799998937
+    "duration": 211.11101899998903
   },
   {
     "name": "sourceToMdapi",
-    "duration": 4968.247083999973
+    "duration": 5271.692285000012
   },
   {
     "name": "sourceToZip",
-    "duration": 4913.3930489999475
+    "duration": 4380.870213999995
   },
   {
     "name": "mdapiToSource",
-    "duration": 3678.5225419999915
+    "duration": 3751.995666999981
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 427.1703989999951
+    "duration": 442.0649090000079
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8699.61532500002
+    "duration": 7637.912526
   },
   {
     "name": "sourceToZip",
-    "duration": 7062.340872999979
+    "duration": 7133.890660000005
   },
   {
     "name": "mdapiToSource",
-    "duration": 4507.392125000013
+    "duration": 4296.643390000012
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 708.247853000008
+    "duration": 714.2424170000013
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11350.272353000008
+    "duration": 10538.031634999992
   },
   {
     "name": "sourceToZip",
-    "duration": 10826.725208999997
+    "duration": 9512.72887000002
   },
   {
     "name": "mdapiToSource",
-    "duration": 9852.030005000008
+    "duration": 8187.150167999993
   }
 ]


### PR DESCRIPTION
### What does this PR do?
fix archiver behavior for static resource transformer
(restores the original `void` that existed before https://github.com/forcedotcom/source-deploy-retrieve/pull/748/files#diff-5fabcc81716c0b97d040b6024b6c1d0b69eda8af160f20434429e6c60e736782L48)

### What issues does this PR fix or reference?

[@W-12009115@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001BWmniYAD/view)
https://github.com/forcedotcom/cli/issues/1791

QA notes: see most excellent repro on customer issue 