### PR TITLE
Enable CLI support for ExtlClntAppMobileConfigurablePolicies

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -529,18 +529,17 @@ v57 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
+|ActionLauncherItemDef|❌|Not supported, but support could be added|
 |ActionableListDefinition|❌|Not supported, but support could be added|
-|AffinityScoreDefinition|❌|Not supported, but support could be added|
 |AppExplorationDataConsent|❌|Not supported, but support could be added|
 |ClaimFinancialSettings|✅||
 |ClauseCatgConfiguration|✅||
 |DisclosureDefinition|✅||
 |DisclosureDefinitionVersion|✅||
 |DisclosureType|✅||
-|EngagementMessagingSettings|✅||
 |ExternalClientAppSettings|✅||
 |ExternalClientApplication|✅||
-|ExtlClntAppMobilePolicies|❌|Not supported, but support could be added|
+|ExtlClntAppMobileConfigurablePolicies|✅||
 |ExtlClntAppMobileSettings|✅||
 |ExtlClntAppOauthConfigurablePolicies|✅||
 |ExtlClntAppOauthSettings|✅||
@@ -549,6 +548,7 @@ v57 introduces the following new types.  Here's their current level of support
 |LocationUse|❌|Not supported, but support could be added|
 |OmniSupervisorConfig|✅||
 |PaymentsIngestEnabledSettings|✅||
+|PersonAccountOwnerPowerUser|❌|Not supported, but support could be added|
 |PipelineInspMetricConfig|❌|Not supported, but support could be added|
 |ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
 |ServiceProcess|❌|Not supported, but support could be added|

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1391,6 +1391,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "extlclntappmobileconfigurablepolicies": {
+      "id": "extlclntappmobileconfigurablepolicies",
+      "name": "ExtlClntAppMobileConfigurablePolicies",
+      "suffix": "ecaMobPlcy",
+      "directoryName": "mobilePolicies",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "extlclntappoauthsettings": {
       "id": "extlclntappoauthsettings",
       "name": "ExtlClntAppOauthSettings",
@@ -3404,6 +3412,7 @@
     "connectedApp": "connectedapp",
     "eca": "externalclientapplication",
     "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
+    "ecaMobPlcy": "extlclntappmobileconfigurablepolicies",
     "ecaMob": "extlclntappmobilesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "appMenu": "appmenu",


### PR DESCRIPTION
### What does this PR do?
Enable CLI support for ExtlClntAppMobileConfigurablePolicies

### What issues does this PR fix or reference?
[W-12060270](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001CsO4cYAF/view)

### Functionality Before
sfdx force:source and force:mdapi commands didn't support MD type for ExtlClntAppOauthConfigurationPolicies, ExtlClntAppMobileSettings

### Functionality After
sfdx force:source and force:mdapi commands supports MD type for ExtlClntAppOauthConfigurationPolicies, ExtlClntAppMobileSettings
