### PR TITLE
fix: add supportsPartialDelete property to registry

### DIFF
--- a/contributing/metadata.md
+++ b/contributing/metadata.md
@@ -40,6 +40,8 @@ yarn update-registry
 
 inFolderTypes and types with childXml in their describe are not supported. You **want** to explore the various strategies for those (see the [SDR Handbook](../HANDBOOK.md) in this repo) and [create tests](#integration-testing) to validate that your types are being handled correctly.
 
+For types that contain multiple files (e.g., bundles such as LWC, Aura, ExperienceBundle) where deleting 1 file should not delete the entire component you should set `supportsPartialDelete` on the type definition. For an example of this see the `ExperienceBundle` definition in `metadataRegistry.json`.
+
 For those situations, refer to another existing type in the registry that you want yours to behave like.
 
 If that's confusing, it's a great time to reach out to the CLI team.

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -112,6 +112,7 @@
       "directoryName": "staticresources",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsPartialDelete": true,
       "strategies": {
         "adapter": "mixedContent",
         "transformer": "staticResource"
@@ -134,6 +135,7 @@
       "directoryName": "experiences",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsPartialDelete": true,
       "strategies": {
         "adapter": "mixedContent"
       }
@@ -163,6 +165,7 @@
       "directoryName": "aura",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsPartialDelete": true,
       "strategies": {
         "adapter": "bundle"
       }
@@ -173,6 +176,7 @@
       "directoryName": "lwc",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsPartialDelete": true,
       "strategies": {
         "adapter": "bundle"
       }
@@ -1123,6 +1127,7 @@
       "directoryName": "waveTemplates",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsPartialDelete": true,
       "strategies": {
         "adapter": "bundle"
       }
@@ -3149,6 +3154,7 @@
       "directoryName": "digitalExperiences",
       "inFolder": false,
       "supportsWildcardAndName": true,
+      "supportsPartialDelete": true,
       "suffix": "digitalExperience",
       "children": {
         "types": {
@@ -3157,6 +3163,7 @@
             "name": "DigitalExperience",
             "directoryName": "digitalExperiences",
             "suffix": "digitalExperience",
+            "supportsPartialDelete": true,
             "strategies": {
               "adapter": "digitalExperience"
             }

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -107,6 +107,13 @@ export interface MetadataType {
   supportsWildcardAndName?: boolean;
 
   /**
+   * Whether the component can be partially deleted, such as metadata types that are made up of multiple files.
+   *
+   * __Examples:__ `LightningComponentBundle`, `ExperienceBundle`, `StaticResource`, and `DigitalExperienceBundle`
+   */
+  supportsPartialDelete?: boolean;
+
+  /**
    * Whenever this type is requested, return the aliasFor type instead
    */
   aliasFor?: string;

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 208.82503900000302
+    "duration": 210.39633800002048
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5328.710877000005
+    "duration": 5190.605087999953
   },
   {
     "name": "sourceToZip",
-    "duration": 4558.531627999997
+    "duration": 5046.684008000011
   },
   {
     "name": "mdapiToSource",
-    "duration": 3743.332764999999
+    "duration": 3791.2770250000176
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 411.48967700000503
+    "duration": 398.8911160000134
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7345.381353000004
+    "duration": 7309.452422000002
   },
   {
     "name": "sourceToZip",
-    "duration": 6448.000429000007
+    "duration": 6389.23871299997
   },
   {
     "name": "mdapiToSource",
-    "duration": 4334.501111999998
+    "duration": 4392.979124999954
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 702.9038010000077
+    "duration": 705.668066000042
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11136.298905999982
+    "duration": 10346.86518199998
   },
   {
     "name": "sourceToZip",
-    "duration": 9683.790960999992
+    "duration": 9459.739873999963
   },
   {
     "name": "mdapiToSource",
-    "duration": 7760.184852999984
+    "duration": 7394.224102000007
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 204.47363700001733
+    "duration": 213.7825759999978
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5412.804032000015
+    "duration": 5289.9098340000055
   },
   {
     "name": "sourceToZip",
-    "duration": 4819.043937999988
+    "duration": 4398.704352999994
   },
   {
     "name": "mdapiToSource",
-    "duration": 3371.17130300001
+    "duration": 3303.2481379999954
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 387.4656890000042
+    "duration": 379.1175959999964
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7353.538902
+    "duration": 6856.218376000004
   },
   {
     "name": "sourceToZip",
-    "duration": 6650.080034999992
+    "duration": 6599.707263999997
   },
   {
     "name": "mdapiToSource",
-    "duration": 3867.6471079999756
+    "duration": 3755.471351999993
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 695.9927700000117
+    "duration": 661.3176870000025
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11379.586171999981
+    "duration": 10528.364352999983
   },
   {
     "name": "sourceToZip",
-    "duration": 9850.32331899996
+    "duration": 9075.544647000002
   },
   {
     "name": "mdapiToSource",
-    "duration": 12537.999031000014
+    "duration": 6548.90436700001
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Adds a `supportsPartialDelete` property to registry entries to denote that a metadata type should do a deploy when only part of the files that make up the metadata are deleted, rather than a delete.

### What issues does this PR fix or reference?
@W-11385865@
@W-11828599@

