### PR TITLE
fix: include string errors during convert

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -8,6 +8,7 @@ import { Readable, PassThrough } from 'stream';
 import { dirname, join, normalize } from 'path';
 import { Messages, SfError } from '@salesforce/core';
 import { promises } from 'graceful-fs';
+import { isString } from '@salesforce/ts-types';
 import { SourceComponent } from '../resolve';
 import { ensureDirectoryExists } from '../utils/fileSystemHandler';
 import { SourcePath } from '../common';
@@ -133,13 +134,9 @@ export class MetadataConverter {
         result.converted = (writer as StandardWriter).converted;
       }
       return result;
-    } catch (e) {
-      throw new SfError(
-        messages.getMessage('error_failed_convert', [(e as Error).message]),
-        'ConversionError',
-        [],
-        e as Error
-      );
+    } catch (err: unknown) {
+      const error = isString(err) ? new Error(err) : (err as Error);
+      throw new SfError(messages.getMessage('error_failed_convert', [error.message]), 'ConversionError', [], error);
     }
   }
 }

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -134,8 +134,11 @@ export class MetadataConverter {
         result.converted = (writer as StandardWriter).converted;
       }
       return result;
-    } catch (err: unknown) {
-      const error = isString(err) ? new Error(err) : (err as Error);
+    } catch (err) {
+      if (!(err instanceof Error) && !isString(err)) {
+        throw err;
+      }
+      const error = isString(err) ? new Error(err) : err;
       throw new SfError(messages.getMessage('error_failed_convert', [error.message]), 'ConversionError', [], error);
     }
   }

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 210.39633800002048
+    "duration": 206.68928799999412
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5190.605087999953
+    "duration": 6456.049191999991
   },
   {
     "name": "sourceToZip",
-    "duration": 5046.684008000011
+    "duration": 5368.473570999995
   },
   {
     "name": "mdapiToSource",
-    "duration": 3791.2770250000176
+    "duration": 3560.2728149999894
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 398.8911160000134
+    "duration": 405.7750340000057
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7309.452422000002
+    "duration": 8594.81496599999
   },
   {
     "name": "sourceToZip",
-    "duration": 6389.23871299997
+    "duration": 6676.589412000001
   },
   {
     "name": "mdapiToSource",
-    "duration": 4392.979124999954
+    "duration": 4316.212134000001
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 705.668066000042
+    "duration": 687.1548699999985
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10346.86518199998
+    "duration": 11603.490995
   },
   {
     "name": "sourceToZip",
-    "duration": 9459.739873999963
+    "duration": 9733.591315000027
   },
   {
     "name": "mdapiToSource",
-    "duration": 7394.224102000007
+    "duration": 7484.829251999996
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 213.7825759999978
+    "duration": 206.5693120000069
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5289.9098340000055
+    "duration": 4943.071838999982
   },
   {
     "name": "sourceToZip",
-    "duration": 4398.704352999994
+    "duration": 4826.46210199999
   },
   {
     "name": "mdapiToSource",
-    "duration": 3303.2481379999954
+    "duration": 3256.713862000004
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 379.1175959999964
+    "duration": 384.5527920000022
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6856.218376000004
+    "duration": 6970.504320000007
   },
   {
     "name": "sourceToZip",
-    "duration": 6599.707263999997
+    "duration": 6130.4723740000045
   },
   {
     "name": "mdapiToSource",
-    "duration": 3755.471351999993
+    "duration": 4920.01653100003
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 661.3176870000025
+    "duration": 681.8188979999977
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10528.364352999983
+    "duration": 10472.678083999956
   },
   {
     "name": "sourceToZip",
-    "duration": 9075.544647000002
+    "duration": 8984.845709999965
   },
   {
     "name": "mdapiToSource",
-    "duration": 6548.90436700001
+    "duration": 10057.14215899998
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Adds the error message to the new error when the caught error is a String.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1420
@W-12099973@

### Functionality Before

```
sfdx force:source:deploy -p force-app/main/default/classes/PagedResult.cls
*** Deploying with SOAP API v56.0 ***
ERROR running force:source:deploy:  Component conversion failed: undefined
```

### Functionality After

```
sfdx force:source:deploy -p force-app/main/default/classes/PagedResult.cls
*** Deploying with SOAP API v56.0 ***
ERROR running force:source:deploy:  Component conversion failed: error converting stream - Error: ENOENT: no such file or directory, open '.../ebikes-lwc/force-app/main/default/classes/PagedResult.cls-meta.xml'
```
