### PR TITLE
fix: correct apiVersion and sourceApiVersion values before transfer and send events

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -1,10 +1,10 @@
 # Supported CLI Metadata Types
 
-This list compares metadata types found in Salesforce v56 with the [metadata registry file](./src/registry/metadataRegistry.json) included in this repository.
+This list compares metadata types found in Salesforce v57 with the [metadata registry file](./src/registry/metadataRegistry.json) included in this repository.
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 482/511 supported metadata types.
+Currently, there are 495/534 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -23,8 +23,10 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |AccountingModelConfig|❌|Not supported, but support could be added|
 |AccountingSettings|✅||
 |AcctMgrTargetSettings|✅||
+|ActionLauncherItemDef|❌|Not supported, but support could be added|
 |ActionLinkGroupTemplate|✅||
 |ActionPlanTemplate|✅||
+|ActionableListDefinition|❌|Not supported, but support could be added|
 |ActionsSettings|✅||
 |ActivationPlatform|✅||
 |ActivitiesSettings|✅||
@@ -44,6 +46,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ApexTrigger|✅||
 |AppAnalyticsSettings|✅||
 |AppExperienceSettings|✅||
+|AppExplorationDataConsent|❌|Not supported, but support could be added|
 |AppMenu|✅||
 |ApplicationRecordTypeConfig|✅||
 |ApplicationSubtypeDefinition|✅||
@@ -106,6 +109,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ChatterEmailsMDSettings|✅||
 |ChatterExtension|✅||
 |ChatterSettings|✅||
+|ClauseCatgConfiguration|✅||
 |CleanDataService|✅||
 |CollectionsDashboardSettings|✅||
 |CommandAction|✅||
@@ -169,9 +173,12 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |DelegateGroup|✅||
 |DeploymentSettings|✅||
 |DevHubSettings|✅||
-|DigitalExperience|⚠️|Supports deploy/retrieve but not source tracking|
-|DigitalExperienceBundle|⚠️|Supports deploy/retrieve but not source tracking|
-|DigitalExperienceConfig|⚠️|Supports deploy/retrieve but not source tracking|
+|DigitalExperience|✅||
+|DigitalExperienceBundle|✅||
+|DigitalExperienceConfig|✅||
+|DisclosureDefinition|✅||
+|DisclosureDefinitionVersion|✅||
+|DisclosureType|✅||
 |DiscoveryAIModel|✅||
 |DiscoveryGoal|✅||
 |DiscoverySettings|✅||
@@ -222,6 +229,8 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ExpressionSetDefinitionVersion|✅||
 |ExpressionSetObjectAlias|❌|Not supported, but support could be added|
 |ExternalAIModel|❌|Not supported, but support could be added|
+|ExternalClientAppSettings|✅||
+|ExternalClientApplication|✅||
 |ExternalCredential|✅||
 |ExternalDataConnector|✅||
 |ExternalDataSource|✅||
@@ -229,6 +238,10 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ExternalDataTranField|❌|Not supported, but support could be added|
 |ExternalDataTranObject|❌|Not supported, but support could be added|
 |ExternalServiceRegistration|✅||
+|ExtlClntAppMobileConfigurablePolicies|✅||
+|ExtlClntAppMobileSettings|✅||
+|ExtlClntAppOauthConfigurablePolicies|✅||
+|ExtlClntAppOauthSettings|✅||
 |FeatureParameterBoolean|✅||
 |FeatureParameterDate|✅||
 |FeatureParameterInteger|✅||
@@ -267,6 +280,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |IPAddressRange|✅||
 |Icon|✅||
 |IdeasSettings|✅||
+|IdentityProviderSettings|✅||
 |IdentityVerificationProcDef|✅||
 |IframeWhiteListUrlSettings|✅||
 |InboundCertificate|✅||
@@ -279,6 +293,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |IndustriesManufacturingSettings|✅||
 |IndustriesSettings|✅||
 |InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
+|IntegrationProviderDef|❌|Not supported, but support could be added|
 |InterestTaggingSettings|✅||
 |InternalDataConnector|✅||
 |InvLatePymntRiskCalcSettings|✅||
@@ -305,6 +320,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |LiveChatDeployment|✅||
 |LiveChatSensitiveDataRule|✅||
 |LiveMessageSettings|✅||
+|LocationUse|❌|Not supported, but support could be added|
 |LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
 |MLDataDefinition|✅||
 |MLPredictionDefinition|✅||
@@ -356,6 +372,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |OmniInteractionAccessConfig|⚠️|Supports deploy/retrieve but not source tracking|
 |OmniInteractionConfig|⚠️|Supports deploy/retrieve but not source tracking|
 |OmniScript|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniSupervisorConfig|✅||
 |OmniUiCard|⚠️|Supports deploy/retrieve but not source tracking|
 |OnlineSalesSettings|✅||
 |OpportunityInsightsSettings|✅||
@@ -372,13 +389,16 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |PathAssistant|✅||
 |PathAssistantSettings|✅||
 |PaymentGatewayProvider|✅||
+|PaymentsIngestEnabledSettings|✅||
 |PaymentsManagementEnabledSettings|✅||
 |PaymentsSettings|✅||
 |PermissionSet|✅||
 |PermissionSetGroup|✅||
 |PermissionSetLicenseDefinition|✅||
+|PersonAccountOwnerPowerUser|❌|Not supported, but support could be added|
 |PicklistSettings|✅||
 |PicklistValue|❌|Not supported, but support could be added|
+|PipelineInspMetricConfig|❌|Not supported, but support could be added|
 |PlatformCachePartition|✅||
 |PlatformEventChannel|✅||
 |PlatformEventChannelMember|✅||
@@ -393,6 +413,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |PrivacySettings|✅||
 |ProductAttributeSet|✅||
 |ProductSettings|✅||
+|ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
 |Profile|✅||
 |ProfilePasswordPolicy|✅||
 |ProfileSessionSetting|✅||
@@ -437,6 +458,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ServiceChannel|✅||
 |ServiceCloudVoiceSettings|✅||
 |ServicePresenceStatus|✅||
+|ServiceProcess|❌|Not supported, but support could be added|
 |ServiceSetupAssistantSettings|✅||
 |SharingCriteriaRule|✅||
 |SharingGuestRule|✅||
@@ -497,6 +519,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |VirtualVisitConfig|❌|Not supported, but support could be added|
 |VoiceSettings|✅||
 |WarrantyLifecycleMgmtSettings|✅||
+|WaveAnalyticAssetCollection|❌|Not supported, but support could be added|
 |WaveApplication|✅||
 |WaveComponent|✅||
 |WaveDashboard|✅||
@@ -524,35 +547,11 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 
 
 
-## Next Release (v57)
-v57 introduces the following new types.  Here's their current level of support
+## Next Release (v58)
+v58 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
-|ActionLauncherItemDef|❌|Not supported, but support could be added|
-|ActionableListDefinition|❌|Not supported, but support could be added|
-|AppExplorationDataConsent|❌|Not supported, but support could be added|
-|ClaimFinancialSettings|✅||
-|ClauseCatgConfiguration|✅||
-|DisclosureDefinition|✅||
-|DisclosureDefinitionVersion|✅||
-|DisclosureType|✅||
-|ExternalClientAppSettings|✅||
-|ExternalClientApplication|✅||
-|ExtlClntAppMobileConfigurablePolicies|✅||
-|ExtlClntAppMobileSettings|✅||
-|ExtlClntAppOauthConfigurablePolicies|✅||
-|ExtlClntAppOauthSettings|✅||
-|IdentityProviderSettings|✅||
-|IntegrationProviderDef|❌|Not supported, but support could be added|
-|LocationUse|❌|Not supported, but support could be added|
-|OmniSupervisorConfig|✅||
-|PaymentsIngestEnabledSettings|✅||
-|PersonAccountOwnerPowerUser|❌|Not supported, but support could be added|
-|PipelineInspMetricConfig|❌|Not supported, but support could be added|
-|ProductSpecificationTypeDefinition|❌|Not supported, but support could be added|
-|ServiceProcess|❌|Not supported, but support could be added|
-|WaveAnalyticAssetCollection|❌|Not supported, but support could be added|
 
 ## Additional Types
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^3.32.6",
+    "@salesforce/core": "^3.32.8",
     "@salesforce/kit": "^1.8.0",
     "@salesforce/ts-types": "^1.7.1",
     "archiver": "^5.3.1",

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -313,16 +313,18 @@ export class MetadataApiDeploy extends MetadataTransfer<MetadataApiDeployStatus,
   protected async pre(): Promise<AsyncResult> {
     const LifecycleInstance = Lifecycle.getInstance();
     const connection = await this.getConnection();
+    const apiVersion = connection.getApiVersion();
+
     // store for use in the scopedPostDeploy event
     this.orgId = connection.getAuthInfoFields().orgId;
 
     // If we have a ComponentSet but no version info, use the apiVersion from the Connection.
     if (this.components) {
       // this is the SOAP/REST API version of the connection
-      this.components.apiVersion ??= connection.getApiVersion();
+      this.components.apiVersion ??= apiVersion;
 
       // this is used as the version in the manifest (package.xml).
-      this.components.sourceApiVersion ??= connection.getApiVersion();
+      this.components.sourceApiVersion ??= apiVersion;
     }
 
     // only do event hooks if source, (NOT a metadata format) deploy
@@ -353,7 +355,6 @@ export class MetadataApiDeploy extends MetadataTransfer<MetadataApiDeployStatus,
 
     // Debug output for API version and source API version used for deploy
     if (this.components?.apiVersion) {
-      const apiVersion = this.components?.apiVersion;
       const manifestVersion = this.components?.sourceApiVersion ?? apiVersion;
       const webService = rest ? 'REST' : 'SOAP';
 

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -245,7 +245,7 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
     }
 
     // Debug output for API version used for retrieve
-    const manifestVersion = manifestData.version ?? requestBody.apiVersion;
+    const manifestVersion = manifestData.version;
     this.logger.debug(`Retrieving source in v${manifestVersion} shape using SOAP v${apiVersion}`);
     await Lifecycle.getInstance().emit('apiVersionRetrieve', { manifestVersion, apiVersion });
 

--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -207,7 +207,11 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
     }
 
     const connection = await this.getConnection();
+    const apiVersion = connection.getApiVersion();
     this.orgId = connection.getAuthInfoFields().orgId;
+
+    this.components.apiVersion ??= apiVersion;
+    this.components.sourceApiVersion ??= apiVersion;
 
     // only do event hooks if source, (NOT a metadata format) retrieve
     if (this.options.components) {
@@ -217,9 +221,13 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
       } as ScopedPreRetrieve);
     }
 
+    const manifestData = (await this.components.getObject()).Package;
+
     const requestBody: RetrieveRequest = {
-      apiVersion: this.components.apiVersion ?? (await connection.retrieveMaxApiVersion()),
-      unpackaged: (await this.components.getObject()).Package,
+      // This apiVersion is only used when the version in the package.xml (manifestData) is not defined.
+      // see docs here: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_retrieve_request.htm
+      apiVersion: this.components.sourceApiVersion ?? (await connection.retrieveMaxApiVersion()),
+      unpackaged: manifestData,
     };
 
     // if we're retrieving with packageNames add it
@@ -235,6 +243,11 @@ export class MetadataApiRetrieve extends MetadataTransfer<MetadataApiRetrieveSta
     if (this.options.singlePackage) {
       requestBody.singlePackage = this.options.singlePackage;
     }
+
+    // Debug output for API version used for retrieve
+    const manifestVersion = manifestData.version ?? requestBody.apiVersion;
+    this.logger.debug(`Retrieving source in v${manifestVersion} shape using SOAP v${apiVersion}`);
+    await Lifecycle.getInstance().emit('apiVersionRetrieve', { manifestVersion, apiVersion });
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore required callback

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -205,7 +205,9 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
 
     const resolveIncludeSet = options.resolveSourcePaths ? new ComponentSet([], options.registry) : undefined;
     const result = new ComponentSet([], options.registry);
-    result.apiVersion = manifest.apiVersion;
+
+    result.logger.debug(`Setting sourceApiVersion of ${manifest.apiVersion} on ComponentSet from manifest`);
+    result.sourceApiVersion = manifest.apiVersion;
     result.fullName = manifest.fullName;
 
     const addComponent = (component: MetadataComponent, deletionType?: DestructiveChangesType): void => {

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -311,14 +311,22 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       throw new SfError(messages.getMessage('error_no_source_to_deploy'), 'ComponentSetError');
     }
 
+    if (
+      typeof options.usernameOrConnection !== 'string' &&
+      this.apiVersion &&
+      this.apiVersion !== options.usernameOrConnection.version
+    ) {
+      options.usernameOrConnection.setApiVersion(this.apiVersion);
+      this.logger.debug(
+        `Received conflicting apiVersion values for deploy. Using option=${this.apiVersion}, Ignoring apiVersion on connection=${options.usernameOrConnection.version}.`
+      );
+    }
+
     const operationOptions = Object.assign({}, options, {
       components: this,
       registry: this.registry,
       apiVersion: this.apiVersion,
     });
-    // if (!options.apiVersion && !this.apiVersion && !this.sourceApiVersion) {
-    //   operationOptions.apiVersion = `${await getCurrentApiVersion()}.0`;
-    // }
 
     const mdapiDeploy = new MetadataApiDeploy(operationOptions);
     await mdapiDeploy.start();
@@ -338,6 +346,17 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       registry: this.registry,
       apiVersion: this.apiVersion,
     });
+
+    if (
+      typeof options.usernameOrConnection !== 'string' &&
+      this.apiVersion &&
+      this.apiVersion !== options.usernameOrConnection.version
+    ) {
+      options.usernameOrConnection.setApiVersion(this.apiVersion);
+      this.logger.debug(
+        `Received conflicting apiVersion values for retrieve. Using option=${this.apiVersion}, Ignoring apiVersion on connection=${options.usernameOrConnection.version}.`
+      );
+    }
 
     const mdapiRetrieve = new MetadataApiRetrieve(operationOptions);
     await mdapiRetrieve.start();

--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -168,13 +168,10 @@ export class ComponentSetBuilder {
       }
     }
 
-    if (apiversion) {
-      componentSet.apiVersion = apiversion;
-    }
-
-    if (sourceapiversion) {
-      componentSet.sourceApiVersion = sourceapiversion;
-    }
+    componentSet.apiVersion ??= apiversion;
+    componentSet.sourceApiVersion ??= sourceapiversion;
+    logger.debug(`ComponentSet apiVersion = ${componentSet.apiVersion}`);
+    logger.debug(`ComponentSet sourceApiVersion = ${componentSet.sourceApiVersion}`);
 
     return componentSet;
   }

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -373,7 +373,8 @@ describe('MetadataApiRetrieve', () => {
         await operation.start();
         const result = await operation.pollStatus();
         const expected = new RetrieveResult(response, toRetrieve, toRetrieve);
-        expect(result).to.deep.equalInAnyOrder(expected);
+        expect(result.response).to.deep.equalInAnyOrder(expected.response);
+        expect(result.components.toArray()).to.deep.equalInAnyOrder(expected.components.toArray());
       });
 
       it('should construct a result object with no components when components are forceIgnored', async () => {

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -45,6 +45,7 @@ describe('ComponentSet', () => {
     const componentSetVersion = '53.0';
     const sourceApiVersion = '52.0';
     const manifestVersion = '51.0';
+    const sourcepath = join(process.cwd(), 'test', 'nuts', 'local', 'replacements', 'testProj');
 
     let connection: Connection;
     let lifecycleEmitStub: sinon.SinonStub;
@@ -93,7 +94,7 @@ describe('ComponentSet', () => {
 
     describe('retrieve', () => {
       it('should default to max version supported by the target org', async () => {
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'] });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath] });
         await stubConnection();
         await componentSet.retrieve({ output: '', usernameOrConnection: connection });
 
@@ -108,7 +109,7 @@ describe('ComponentSet', () => {
       });
 
       it('should use the version in the sfdx config', async () => {
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'] });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath] });
         stubConfig();
         await stubConnection();
         await componentSet.retrieve({ output: '', usernameOrConnection: connection });
@@ -127,7 +128,7 @@ describe('ComponentSet', () => {
         // This usecase is when you call ComponentSet.retrieve() passing in a
         // connection object rather than an org username. The request is made using the apiVersion
         // from the ComponentSet.
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'], apiversion: componentSetVersion });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath], apiversion: componentSetVersion });
         stubConfig();
         await stubConnection();
         await componentSet.retrieve({ output: '', usernameOrConnection: connection });
@@ -146,7 +147,7 @@ describe('ComponentSet', () => {
         // This usecase is when you call ComponentSet.retrieve() passing in an org
         // username rather than a connection. The request is made using the apiVersion
         // from the ComponentSet.
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'], apiversion: componentSetVersion });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath], apiversion: componentSetVersion });
         stubConfig();
         await stubConnection();
         // Have to stub `Connection.create()` because passing an org username will result
@@ -166,7 +167,7 @@ describe('ComponentSet', () => {
 
       it('should use the sourceApiVersion from a ComponentSet', async () => {
         componentSet = await ComponentSetBuilder.build({
-          sourcepath: ['.'],
+          sourcepath: [sourcepath],
           apiversion: componentSetVersion,
           sourceapiversion: sourceApiVersion,
         });
@@ -190,7 +191,7 @@ describe('ComponentSet', () => {
           apiVersion: manifestVersion,
         });
         componentSet = await ComponentSetBuilder.build({
-          manifest: { directoryPaths: ['.'], manifestPath: '.' },
+          manifest: { directoryPaths: [sourcepath], manifestPath: '.' },
           apiversion: componentSetVersion,
           sourceapiversion: sourceApiVersion,
         });
@@ -217,7 +218,7 @@ describe('ComponentSet', () => {
       };
 
       it('should default to max version supported by the target org', async () => {
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'] });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath] });
         await stubConnection();
         await componentSet.deploy({ usernameOrConnection: connection });
 
@@ -230,7 +231,7 @@ describe('ComponentSet', () => {
       });
 
       it('should use the version in the sfdx config', async () => {
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'] });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath] });
         stubConfig();
         await stubConnection();
         await componentSet.deploy({ usernameOrConnection: connection });
@@ -247,7 +248,7 @@ describe('ComponentSet', () => {
         // This usecase is when you call ComponentSet.retrieve() passing in a
         // connection object rather than an org username. The request is made using the apiVersion
         // from the ComponentSet.
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'], apiversion: componentSetVersion });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath], apiversion: componentSetVersion });
         stubConfig();
         await stubConnection();
         await componentSet.deploy({ usernameOrConnection: connection });
@@ -268,7 +269,7 @@ describe('ComponentSet', () => {
         // This usecase is when you call ComponentSet.retrieve() passing in an org
         // username rather than a connection. The request is made using the apiVersion
         // from the ComponentSet.
-        componentSet = await ComponentSetBuilder.build({ sourcepath: ['.'], apiversion: componentSetVersion });
+        componentSet = await ComponentSetBuilder.build({ sourcepath: [sourcepath], apiversion: componentSetVersion });
         stubConfig();
         await stubConnection();
         // Have to stub `Connection.create()` because passing an org username will result
@@ -290,7 +291,7 @@ describe('ComponentSet', () => {
 
       it('should use the sourceApiVersion from a ComponentSet', async () => {
         componentSet = await ComponentSetBuilder.build({
-          sourcepath: ['.'],
+          sourcepath: [sourcepath],
           apiversion: componentSetVersion,
           sourceapiversion: sourceApiVersion,
         });
@@ -316,7 +317,7 @@ describe('ComponentSet', () => {
           apiVersion: manifestVersion,
         });
         componentSet = await ComponentSetBuilder.build({
-          manifest: { directoryPaths: ['.'], manifestPath: '.' },
+          manifest: { directoryPaths: [sourcepath], manifestPath: '.' },
           apiversion: componentSetVersion,
           sourceapiversion: sourceApiVersion,
         });

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 324.71387500001583
+    "duration": 319.0109829999856
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7122.961764000007
+    "duration": 6513.529799000011
   },
   {
     "name": "sourceToZip",
-    "duration": 6274.939941999997
+    "duration": 4981.738588999986
   },
   {
     "name": "mdapiToSource",
-    "duration": 5758.478280999989
+    "duration": 5392.311745999992
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 651.9775850000151
+    "duration": 589.6669420000399
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10889.311952999997
+    "duration": 10443.746392000001
   },
   {
     "name": "sourceToZip",
-    "duration": 9392.743359000015
+    "duration": 9044.706978000002
   },
   {
     "name": "mdapiToSource",
-    "duration": 7095.85508899999
+    "duration": 6968.501856999996
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 1033.0352329999732
+    "duration": 1047.5124270000379
   },
   {
     "name": "sourceToMdapi",
-    "duration": 16734.752318999992
+    "duration": 15948.696778000041
   },
   {
     "name": "sourceToZip",
-    "duration": 15027.624977999978
+    "duration": 13894.535199999984
   },
   {
     "name": "mdapiToSource",
-    "duration": 12297.485982999991
+    "duration": 15508.926563000015
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 215.10148500002106
+    "duration": 215.97936900000786
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6324.387126000016
+    "duration": 6050.905942000012
   },
   {
     "name": "sourceToZip",
-    "duration": 4527.281878000009
+    "duration": 4974.103418000013
   },
   {
     "name": "mdapiToSource",
-    "duration": 3955.334657999978
+    "duration": 3734.206409000006
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 206.68928799999412
+    "duration": 215.10148500002106
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6456.049191999991
+    "duration": 6324.387126000016
   },
   {
     "name": "sourceToZip",
-    "duration": 5368.473570999995
+    "duration": 4527.281878000009
   },
   {
     "name": "mdapiToSource",
-    "duration": 3560.2728149999894
+    "duration": 3955.334657999978
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 405.7750340000057
+    "duration": 426.7237620000087
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8594.81496599999
+    "duration": 8035.131137999997
   },
   {
     "name": "sourceToZip",
-    "duration": 6676.589412000001
+    "duration": 7169.142548999982
   },
   {
     "name": "mdapiToSource",
-    "duration": 4316.212134000001
+    "duration": 4294.328116999997
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 426.7237620000087
+    "duration": 408.8743680000189
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8035.131137999997
+    "duration": 9369.04411799999
   },
   {
     "name": "sourceToZip",
-    "duration": 7169.142548999982
+    "duration": 7376.75736399999
   },
   {
     "name": "mdapiToSource",
-    "duration": 4294.328116999997
+    "duration": 4596.248850000004
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 687.1548699999985
+    "duration": 731.9651210000156
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11603.490995
+    "duration": 11885.075555000047
   },
   {
     "name": "sourceToZip",
-    "duration": 9733.591315000027
+    "duration": 11272.088497000048
   },
   {
     "name": "mdapiToSource",
-    "duration": 7484.829251999996
+    "duration": 13583.194553999987
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 731.9651210000156
+    "duration": 712.6530869999551
   },
   {
     "name": "sourceToMdapi",
-    "duration": 11885.075555000047
+    "duration": 11910.565894
   },
   {
     "name": "sourceToZip",
-    "duration": 11272.088497000048
+    "duration": 13902.21678899997
   },
   {
     "name": "mdapiToSource",
-    "duration": 13583.194553999987
+    "duration": 13933.210705999983
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,7 +673,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^3.30.9", "@salesforce/core@^3.32.6":
+"@salesforce/core@^3.30.9":
   version "3.32.6"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.6.tgz#ee42663ffbf9db2478247fa7e6af3df652eebb5f"
   integrity sha512-+j9nXnVnK4H+YmRfhcmSW/RZu2XIM6zKlXImsy+XhWBV1zOvM1JZiQngj3pdrGck7hoMc68YfWP0UEVzmM/k+g==
@@ -685,6 +685,29 @@
     "@types/graceful-fs" "^4.1.5"
     "@types/semver" "^7.3.13"
     ajv "^8.11.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.19"
+    jsonwebtoken "8.5.1"
+    ts-retry-promise "^0.7.0"
+
+"@salesforce/core@^3.32.8":
+  version "3.32.8"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.8.tgz#21d97f75645f8928cacb04497e91d8b203753130"
+  integrity sha512-q6vvpaBmw/cCSff+MX+aWYLVP44AzEI8oMLk14g/sY2O+Bij0ZBtil5bjhjkQqp3dJnkwKgaqpnvYPsrXSUN1g==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.8.0"
+    "@salesforce/schemas" "^1.4.0"
+    "@salesforce/ts-types" "^1.5.21"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/semver" "^7.3.13"
+    ajv "^8.11.2"
     archiver "^5.3.0"
     change-case "^4.1.2"
     debug "^3.2.7"
@@ -1186,6 +1209,16 @@ ajv@^8.0.1, ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.11.2:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
+  integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
### What does this PR do?
Corrects the code that determines the apiVersion and sourceApiVersion before sending a deploy or retrieve.  Also emits an event with this data just before sending so that consumers can act upon it (e.g., display useful output).

The proper priority for determining the API version of the connection (items higher on the list take precedence) is:
1. `apiversion` command flag
2. `SFDX_API_VERSION` env var
3. local config var
4. global config var
5. highest version supported by the target org

The proper priority for determining the manifest version (items higher on the list take precedence) is:
1. `<version>` in package.xml 
2. `sourceApiVersion` in sfdx-project.json
3. `apiversion` command flag
4. `SFDX_API_VERSION` env var
5. local config var
6. global config var
7. highest version supported by the target org

### What issues does this PR fix or reference?
@W-12146860@

