### PR TITLE
Enable CLI support for FuelType, FuelTypeSustnUom, SustainabilityUom, SustnUomConversion

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v57 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 495/534 supported metadata types.
+Currently, there are 497/534 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -266,7 +266,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ForecastingType|✅||
 |ForecastingTypeSource|✅||
 |FormulaSettings|✅||
-|FuelType|❌|Not supported, but support could be added|
+|FuelType|✅||
 |FuelTypeSustnUom|❌|Not supported, but support could be added|
 |FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
 |GatewayProviderPaymentMethodType|✅||
@@ -483,7 +483,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |StreamingAppDataConnector|✅||
 |SubscriptionManagementSettings|✅||
 |SurveySettings|✅||
-|SustainabilityUom|❌|Not supported, but support could be added|
+|SustainabilityUom|✅||
 |SustnUomConversion|❌|Not supported, but support could be added|
 |SvcCatalogCategory|✅||
 |SvcCatalogFulfillmentFlow|✅||

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v57 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 497/534 supported metadata types.
+Currently, there are 499/534 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -267,7 +267,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ForecastingTypeSource|✅||
 |FormulaSettings|✅||
 |FuelType|✅||
-|FuelTypeSustnUom|❌|Not supported, but support could be added|
+|FuelTypeSustnUom|✅||
 |FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
 |GatewayProviderPaymentMethodType|✅||
 |GlobalValueSet|✅||
@@ -484,7 +484,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |SubscriptionManagementSettings|✅||
 |SurveySettings|✅||
 |SustainabilityUom|✅||
-|SustnUomConversion|❌|Not supported, but support could be added|
+|SustnUomConversion|✅||
 |SvcCatalogCategory|✅||
 |SvcCatalogFulfillmentFlow|✅||
 |SvcCatalogItemDef|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1961,6 +1961,20 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "fueltype": {
+      "id": "fueltype",
+      "name": "FuelType",
+      "suffix": "fuelType",
+      "directoryName": "fuelTypes",
+      "strictDirectoryName": false
+    },
+    "sustainabilityuom": {
+      "id": "sustainabilityuom",
+      "name": "SustainabilityUom",
+      "suffix": "sustainabilityUom",
+      "directoryName": "sustainabilityUoms",
+      "strictDirectoryName": false
+    },
     "botblock": {
       "id": "botblock",
       "name": "BotBlock",
@@ -3483,6 +3497,8 @@
     "disclosureType": "disclosuretype",
     "disclosureDefinition": "disclosuredefinition",
     "disclosureDefinitionVersion": "disclosuredefinitionversion",
+    "sustainabilityUom": "sustainabilityuom",
+    "fuelType": "fueltype",
     "botBlock": "botblock",
     "botVersion": "botversion",
     "animationRule": "animationrule",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1966,6 +1966,15 @@
       "name": "FuelType",
       "suffix": "fuelType",
       "directoryName": "fuelTypes",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "fueltypesustnuom": {
+      "id": "fueltypesustnuom",
+      "name": "FuelTypeSustnUom",
+      "suffix": "fuelTypeSustnUom",
+      "directoryName": "fuelTypeSustnUoms",
+      "inFolder": false,
       "strictDirectoryName": false
     },
     "sustainabilityuom": {
@@ -1973,6 +1982,15 @@
       "name": "SustainabilityUom",
       "suffix": "sustainabilityUom",
       "directoryName": "sustainabilityUoms",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "sustnuomconversion": {
+      "id": "sustnuomconversion",
+      "name": "SustnUomConversion",
+      "suffix": "sustnUomConversion",
+      "directoryName": "sustnUomConversions",
+      "inFolder": false,
       "strictDirectoryName": false
     },
     "botblock": {
@@ -3497,8 +3515,10 @@
     "disclosureType": "disclosuretype",
     "disclosureDefinition": "disclosuredefinition",
     "disclosureDefinitionVersion": "disclosuredefinitionversion",
-    "sustainabilityUom": "sustainabilityuom",
     "fuelType": "fueltype",
+    "fuelTypeSustnUom": "fueltypesustnuom",
+    "sustainabilityUom": "sustainabilityuom",
+    "sustnUomConversion": "sustnuomconversion",
     "botBlock": "botblock",
     "botVersion": "botversion",
     "animationRule": "animationrule",

--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -55,9 +55,6 @@ export const metadataTypes = [
   'ScoreRange',
   'WorkflowFlowAction',
 
-  // org spins up fine, but describe is empty
-  'SustainabilityUom',
-
   // the metadata coverage report seems to be missing a setting:
   // A scratch org was created with username test-o87upqyaagax@example.com, but the settings failed to deploy due to: enableInsights
   'ReferencedDashboard',


### PR DESCRIPTION
### What does this PR do?
Enable CLI support for FuelType, FuelTypeSustnUom, SustainabilityUom and SustnUomConversion setup entities

### What issues does this PR fix or reference?

@[W-11973061](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001A9o6FYAR/view)@

### Functionality Before
sfdx force:source and force:mdapi commands didn't support FuelType, FuelTypeSustnUom, SustainabilityUom, and SustnUomConversion MD types

### Functionality After
sfdx force:source and force:mdapi commands support FuelType, FuelTypeSustnUom, SustainabilityUom and SustnUomConversion MD types
