### PR TITLE
fix: await SVS promises to write to manifest

### DIFF
--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -43,7 +43,7 @@ export class ConnectionResolver {
     for (const type of Object.values(defaultRegistry.types)) {
       componentPromises.push(this.listMembers({ type: type.name }));
     }
-    for await (const componentResult of componentPromises) {
+    (await Promise.all(componentPromises)).map((componentResult) => {
       for (const component of componentResult) {
         let componentType: MetadataType;
         if (typeof component.type === 'string' && component.type.length) {
@@ -65,7 +65,7 @@ export class ConnectionResolver {
           );
         }
       }
-    }
+    });
 
     for (const componentType of componentTypes) {
       const childTypes = componentType.children?.types;

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 205.9563119999948
+    "duration": 198.92172899999423
   },
   {
     "name": "sourceToMdapi",
-    "duration": 4378.968104
+    "duration": 5480.34475400002
   },
   {
     "name": "sourceToZip",
-    "duration": 4546.189135999972
+    "duration": 4789.906298000016
   },
   {
     "name": "mdapiToSource",
-    "duration": 3211.6969230000104
+    "duration": 3239.999051999999
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 400.98173400000087
+    "duration": 399.53083800000604
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7388.940780999983
+    "duration": 7351.337771999999
   },
   {
     "name": "sourceToZip",
-    "duration": 6964.524367000005
+    "duration": 6310.047179999994
   },
   {
     "name": "mdapiToSource",
-    "duration": 4194.718434999988
+    "duration": 4046.419279999973
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 671.8695390000066
+    "duration": 671.900335000013
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10004.596346000035
+    "duration": 10744.23318500002
   },
   {
     "name": "sourceToZip",
-    "duration": 8548.78807000001
+    "duration": 9120.372635999986
   },
   {
     "name": "mdapiToSource",
-    "duration": 7116.019726000028
+    "duration": 7370.606044000015
   }
 ]


### PR DESCRIPTION
### What does this PR do?
fixes creating a manifest with StandardValueSets

### What issues does this PR fix or reference?

[#<Insert GitHub Issue>](https://github.com/forcedotcom/cli/issues/1877), @W-12402176@

### Functionality Before
`source:manifest:generate --fromorg` wouldn't add `StandardValueSet` metadata to the manifest

### Functionality After

`STandardValueSet` metadata is in the manifest
