### PR TITLE
fix: only emit events once per lifecycle

### DIFF
--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 263.16896799999813
+    "duration": 338.2604289999872
   },
   {
     "name": "sourceToMdapi",
-    "duration": 6221.79634700001
+    "duration": 10037.080420000013
   },
   {
     "name": "sourceToZip",
-    "duration": 5822.086768000008
+    "duration": 6153.247639999987
   },
   {
     "name": "mdapiToSource",
-    "duration": 4840.970211999986
+    "duration": 5962.892909999995
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 611.8538340000086
+    "duration": 650.104994000023
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10831.910629999998
+    "duration": 10624.100027000008
   },
   {
     "name": "sourceToZip",
-    "duration": 9510.525854000007
+    "duration": 9675.212842999987
   },
   {
     "name": "mdapiToSource",
-    "duration": 7041.551112999994
+    "duration": 7507.290072000003
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-CPU-E5-2673-v4-2-30GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 1035.1475429999991
+    "duration": 1056.6362640000007
   },
   {
     "name": "sourceToMdapi",
-    "duration": 16139.942532999994
+    "duration": 17650.56812000001
   },
   {
     "name": "sourceToZip",
-    "duration": 12259.295870000002
+    "duration": 15290.788772999978
   },
   {
     "name": "mdapiToSource",
-    "duration": 15514.132654999994
+    "duration": 12925.659993000008
   }
 ]


### PR DESCRIPTION
### What does this PR do?
only emits the "beyond max api version" event once to prevent 
```
 ➜  sfdx force:source:deploy -p force-app --apiversion=57.0 
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(Use `node --trace-warnings ...` to show where the warning was created)
Deploying v55.0 metadata to test-y2wsfd5m2no3@example.com using the v56.0 SOAP API
Deploy ID: 0Af8G00000UQfwNSAT
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
DEPLOY PROGRESS | ███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | 6/89 Components(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
```
### What issues does this PR fix or reference?

#https://github.com/forcedotcom/cli/issues/1878, @W-12375309@

### Functionality After

```
 ➜  sfdx force:source:deploy -p force-app --apiversion=57.0 
(node:71680) Warning: The requested API version (57.0) is higher than the org supports.  Using 56.0.
(Use `node --trace-warnings ...` to show where the warning was created)
```
