### PR TITLE
fix: handle forceignored files for partial bundle deletes

### DIFF
--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 198.92172899999423
+    "duration": 201.8317119999847
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5480.34475400002
+    "duration": 5212.310863999999
   },
   {
     "name": "sourceToZip",
-    "duration": 4789.906298000016
+    "duration": 4445.575450000004
   },
   {
     "name": "mdapiToSource",
-    "duration": 3239.999051999999
+    "duration": 3315.664082000003
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 399.53083800000604
+    "duration": 386.01345800000126
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7351.337771999999
+    "duration": 7513.356621999992
   },
   {
     "name": "sourceToZip",
-    "duration": 6310.047179999994
+    "duration": 7082.083527999988
   },
   {
     "name": "mdapiToSource",
-    "duration": 4046.419279999973
+    "duration": 4097.553186000005
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 671.900335000013
+    "duration": 673.9338029999926
   },
   {
     "name": "sourceToMdapi",
-    "duration": 10744.23318500002
+    "duration": 9793.518339000002
   },
   {
     "name": "sourceToZip",
-    "duration": 9120.372635999986
+    "duration": 9209.843548000004
   },
   {
     "name": "mdapiToSource",
-    "duration": 7370.606044000015
+    "duration": 7044.565040000016
   }
 ]


### PR DESCRIPTION
### What does this PR do?
when handling partial bundle delete retrieves, ignore any forceignored files/directories.  E.g., the `__tests__` dir of an LWC

### What issues does this PR fix or reference?

#1904
@W-12460543@
