### PR TITLE
feat(adding experiencepropertytype bundle): support for ExperiencePropertyType Bundle

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3379,6 +3379,17 @@
       "directoryName": "productSpecificationTypeDefinitions",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "experiencepropertytypebundle": {
+      "id": "experiencepropertytypebundle",
+      "name": "ExperiencePropertyTypeBundle",
+      "directoryName": "experiencePropertyTypeBundles",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "supportsPartialDelete": true,
+      "strategies": {
+        "adapter": "bundle"
+      }
     }
   },
   "suffixes": {
@@ -3777,7 +3788,8 @@
     "siteDotComSites": "sitedotcom",
     "appointmentSchedulingPolicies": "appointmentschedulingpolicy",
     "appointmentAssignmentPolicies": "appointmentassignmentpolicy",
-    "emailservices": "emailservicesfunction"
+    "emailservices": "emailservicesfunction",
+    "experiencePropertyTypeBundles": "experiencepropertytypebundle"
   },
   "childTypes": {
     "customlabel": "customlabels",

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -303,7 +303,7 @@ export class MetadataResolver {
     if (this.tree.isDirectory(fsPath)) {
       return;
     }
-    return ['DigitalExperience']
+    return ['DigitalExperience', 'ExperiencePropertyTypeBundle']
       .map((type) => this.registry.getTypeByName(type))
       .find((type) => fsPath.split(sep).includes(type.directoryName))?.name;
   }

--- a/src/utils/filePathGenerator.ts
+++ b/src/utils/filePathGenerator.ts
@@ -84,9 +84,10 @@ export const filePathsFromMetadataComponent = (
     ];
   }
 
-  // lwc, aura, waveTemplate
+  // lwc, aura, waveTemplate, experiencePropertyType
   if (type.strategies?.adapter === 'bundle') {
     const mappings = new Map<string, string>([
+      ['ExperiencePropertyTypeBundle', join(packageDirWithTypeDir, `${fullName}${sep}schema.json`)],
       ['WaveTemplateBundle', join(packageDirWithTypeDir, `${fullName}${sep}template-info.json`)],
       ['LightningComponentBundle', join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.js${META_XML_SUFFIX}`)],
       ['AuraDefinitionBundle', join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.cmp${META_XML_SUFFIX}`)],

--- a/test/nuts/scale/eda.nut.ts
+++ b/test/nuts/scale/eda.nut.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { performance } from 'node:perf_hooks';
 import * as path from 'path';
+import { performance } from 'node:perf_hooks';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import { MetadataResolver } from '../../../src';
 import { MetadataConverter } from '../../../src';

--- a/test/nuts/scale/lotsOfClasses.nut.ts
+++ b/test/nuts/scale/lotsOfClasses.nut.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { performance } from 'node:perf_hooks';
 import * as path from 'path';
+import { performance } from 'node:perf_hooks';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import * as fs from 'graceful-fs';
 import { MetadataResolver } from '../../../src';

--- a/test/nuts/scale/lotsOfClassesOneDir.nut.ts
+++ b/test/nuts/scale/lotsOfClassesOneDir.nut.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { performance } from 'node:perf_hooks';
 import * as path from 'path';
+import { performance } from 'node:perf_hooks';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
 import * as fs from 'graceful-fs';
 import { MetadataResolver } from '../../../src';


### PR DESCRIPTION
### What does this PR do?

With this PR we are adding a new metadata bundle ExperiencePropertyType. This bundle is very similar to waveTemplates. We dont have *meta.xml file, the bundles entirely contains JSON files.

### What issues does this PR fix or reference?

With this PR we are adding a new metadata bundle ExperiencePropertyType. [W-12502730]

### Functionality Before

Before this change sfdx source-tracking/packaging doesn't support ExperiencePropertyType bundle.

### Functionality After

After this change sfdx source-tracking/packaging will support ExperiencePropertyType bundle.
