### PR TITLE
fix: only delete non-forceignored sub-directories

### DIFF
--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "componentSetCreate",
+    "duration": 206.49349700001767
+  },
+  {
+    "name": "sourceToMdapi",
+    "duration": 5455.362960000028
+  },
+  {
+    "name": "sourceToZip",
+    "duration": 5237.455126999994
+  },
+  {
+    "name": "mdapiToSource",
+    "duration": 3759.678862999979
+  }
+]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "componentSetCreate",
+    "duration": 407.67415299999993
+  },
+  {
+    "name": "sourceToMdapi",
+    "duration": 7544.196715999977
+  },
+  {
+    "name": "sourceToZip",
+    "duration": 6185.875728999992
+  },
+  {
+    "name": "mdapiToSource",
+    "duration": 4336.305462999997
+  }
+]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "componentSetCreate",
+    "duration": 704.1282699999865
+  },
+  {
+    "name": "sourceToMdapi",
+    "duration": 10994.699290999997
+  },
+  {
+    "name": "sourceToZip",
+    "duration": 9647.811220000003
+  },
+  {
+    "name": "mdapiToSource",
+    "duration": 8051.59345700001
+  }
+]


### PR DESCRIPTION
### What does this PR do?
When retrieving bundle type metadata that has some pieces of the bundle deleted (or it looks that way because there are more local files than what was retrieved), only delete the pieces that are not forceignored.

### What issues does this PR fix or reference?

@W-12460543@
https://github.com/forcedotcom/cli/issues/1904

### Functionality Before
would delete the entire component and replace with what was retrieved if there was any file within the component locally that was not retrieved, even if forceignored.

### Functionality After
Removes pieces of a component only if they are not forceignored and they were not part of the retrieve.
