### PR TITLE
fix(mixedcontentsourceadapter.ts): Error during delete operation of experiencepropertytype metadata bundle

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3388,6 +3388,7 @@
       "inFolder": false,
       "strictDirectoryName": true,
       "supportsPartialDelete": true,
+      "metaFileSuffix": "schema.json",
       "strategies": {
         "adapter": "bundle"
       }

--- a/src/resolve/adapters/mixedContentSourceAdapter.ts
+++ b/src/resolve/adapters/mixedContentSourceAdapter.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { dirname, basename, sep } from 'path';
+import { dirname, basename, sep, join } from 'path';
 import { Messages, SfError } from '@salesforce/core';
 import { baseName } from '../../utils/path';
 import { SourcePath } from '../../common';
@@ -68,7 +68,7 @@ export class MixedContentSourceAdapter extends BaseSourceAdapter {
           name: baseName(contentPath),
           type: this.type,
           content: contentPath,
-          xml: this.type.id === 'experiencepropertytypebundle' ? `${contentPath}/schema.json` : undefined,
+          xml: this.type.metaFileSuffix && join(contentPath, this.type.metaFileSuffix),
         },
         this.tree,
         this.forceIgnore

--- a/src/resolve/adapters/mixedContentSourceAdapter.ts
+++ b/src/resolve/adapters/mixedContentSourceAdapter.ts
@@ -68,6 +68,7 @@ export class MixedContentSourceAdapter extends BaseSourceAdapter {
           name: baseName(contentPath),
           type: this.type,
           content: contentPath,
+          xml: this.type.id === 'experiencepropertytypebundle' ? `${contentPath}/schema.json` : undefined,
         },
         this.tree,
         this.forceIgnore

--- a/test/mock/index.ts
+++ b/test/mock/index.ts
@@ -13,6 +13,7 @@ export {
   mixedContentDirectory,
   mixedContentInFolder,
   mixedContentSingleFile,
+  experiencePropertyTypeContentSingleFile,
   decomposed,
   nonDecomposed,
   decomposedtoplevel,

--- a/test/mock/type-constants/experiencePropertyTypeBundleConstants.ts
+++ b/test/mock/type-constants/experiencePropertyTypeBundleConstants.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { join } from 'path';
+
+import { registry, SourceComponent } from '../../../src';
+
+/** Experience Property Type Bundle will be of the following shape.
+experiencePropertyTypeBundles/
+prop1/
+schema.json
+design.json
+ 
+ schema.json is always expected to be in the bundle, while design.json is optional.
+ 
+ Do note that we dont have any -meta.xml. We can consider schema.json as our meta XML file.
+ */
+
+// This is the type defined in metadataRegistry.json
+const type = registry.types.experiencepropertytypebundle;
+
+// This will be the root directory experiencePropertyTypeBundles.It is something like /path/to/experiencePropertyTypeBundles
+export const TYPE_DIRECTORY = join('path', 'to', type.directoryName);
+
+// This is the name of the property type we are creating.
+export const COMPONENT_NAME = 'prop1';
+
+// This is the schema.json and design.json paths inside the property type.
+export const CONTENT_NAMES = [type.metaFileSuffix, 'design.json'];
+
+// This is the complete path to the content. It is something like /path/to/experiencePropertyTypeBundles/prop1/schema.json.
+export const CONTENT_PATHS = CONTENT_NAMES.map((n) => join(TYPE_DIRECTORY, join(COMPONENT_NAME, n)));
+
+// Finally we construct our component.
+export const COMPONENT = SourceComponent.createVirtualComponent(
+  {
+    name: COMPONENT_NAME,
+    type,
+    content: join(TYPE_DIRECTORY, COMPONENT_NAME),
+    xml: CONTENT_PATHS[0],
+  },
+  [
+    {
+      dirPath: TYPE_DIRECTORY,
+      children: [COMPONENT_NAME],
+    },
+  ]
+);

--- a/test/mock/type-constants/index.ts
+++ b/test/mock/type-constants/index.ts
@@ -11,6 +11,7 @@ import * as document from './documentConstants';
 import * as mixedContentDirectory from './staticresourceConstant';
 import * as mixedContentInFolder from './documentFolderConstant';
 import * as mixedContentSingleFile from './staticresourceComponentConstant';
+import * as experiencePropertyTypeContentSingleFile from './experiencePropertyTypeBundleConstants';
 import * as decomposed from './customObjectConstant';
 import * as decomposedtoplevel from './customObjectTranslationConstant';
 import * as nonDecomposed from './customlabelsConstant';
@@ -32,4 +33,5 @@ export {
   nestedTypes,
   lwcBundle,
   digitalExperienceBundle,
+  experiencePropertyTypeContentSingleFile,
 };

--- a/test/resolve/adapters/mixedContentSourceAdapter.test.ts
+++ b/test/resolve/adapters/mixedContentSourceAdapter.test.ts
@@ -15,7 +15,7 @@ import {
   MIXED_CONTENT_DIRECTORY_CONTENT_PATH,
   MIXED_CONTENT_DIRECTORY_VIRTUAL_FS_NO_XML,
 } from '../../mock/type-constants/staticresourceConstant';
-import { mixedContentDirectory, mixedContentSingleFile } from '../../mock';
+import { mixedContentDirectory, mixedContentSingleFile, experiencePropertyTypeContentSingleFile } from '../../mock';
 
 const messages = Messages.load('@salesforce/source-deploy-retrieve', 'sdr', ['error_expected_source_files']);
 
@@ -65,6 +65,28 @@ describe('MixedContentSourceAdapter', () => {
     );
 
     it('Should return expected SourceComponent when given a root metadata xml path', () => {
+      const result = adapter.getComponent(component.xml);
+
+      expect(result).to.deep.equal(component);
+    });
+
+    it('Should return expected SourceComponent when given a source path', () => {
+      const result = adapter.getComponent(component.content);
+
+      expect(result).to.deep.equal(component);
+    });
+  });
+
+  describe('Experience Property Type File Content', () => {
+    const component = experiencePropertyTypeContentSingleFile.COMPONENT;
+    const adapter = new MixedContentSourceAdapter(
+      registry.types.experiencepropertytypebundle,
+      registryAccess,
+      undefined,
+      component.tree
+    );
+
+    it('Should return expected SourceComponent when given a schema.json path', () => {
       const result = adapter.getComponent(component.xml);
 
       expect(result).to.deep.equal(component);


### PR DESCRIPTION
### What does this PR do?

This change is to fix the error during the delete operation for experiencepropertytype metadata bundle. As the bundle is all JSON files and there is no XML file in the bundle there will be an error when the delete operation fails in the backend and this is the fix for the same.

### What issues does this PR fix or reference?

This change is to fix the error during the delete operation for experiencepropertytype metadata bundle. As the bundle is all JSON files and there is no XML file in the bundle there will be an error when the delete operation fails in the backend and this is the fix for the same.

#<Insert GitHub Issue> @W-12642608@

### Functionality Before
 Error when the delete operation fails in the backend.

### Functionality After
There will be no error when the delete operation fails in the backend.
