### PR TITLE
fix: more types support wildcard and names

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -81,6 +81,7 @@
             "ignoreParentName": true,
             "uniqueIdElement": "fullName",
             "directoryName": "labels",
+            "supportsWildcardAndName": true,
             "suffix": "labels"
           }
         },
@@ -199,6 +200,7 @@
       "directoryName": "pages",
       "inFolder": false,
       "strictDirectoryName": false,
+      "supportsWildcardAndName": true,
       "strategies": {
         "adapter": "matchingContentFile"
       }
@@ -297,6 +299,7 @@
       "suffix": "globalValueSet",
       "directoryName": "globalValueSets",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "globalpicklist": {
@@ -440,6 +443,7 @@
       "suffix": "reportType",
       "directoryName": "reportTypes",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "report": {
@@ -488,6 +492,7 @@
       "suffix": "layout",
       "directoryName": "layouts",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "document": {
@@ -517,6 +522,7 @@
       "suffix": "letter",
       "directoryName": "letterhead",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "emailtemplate": {
@@ -537,6 +543,7 @@
       "suffix": "quickAction",
       "directoryName": "quickActions",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "form": {
@@ -576,6 +583,7 @@
       "suffix": "tab",
       "directoryName": "tabs",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "customapplicationcomponent": {
@@ -591,6 +599,7 @@
       "suffix": "app",
       "directoryName": "applications",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "portal": {
@@ -644,6 +653,7 @@
       "suffix": "flow",
       "directoryName": "flows",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "flowdefinition": {
@@ -652,6 +662,7 @@
       "suffix": "flowDefinition",
       "directoryName": "flowDefinitions",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "flowtest": {
@@ -690,6 +701,7 @@
       "directoryName": "workflows",
       "inFolder": false,
       "strictDirectoryName": false,
+      "supportsWildcardAndName": true,
       "children": {
         "types": {
           "workflowfieldupdate": {
@@ -886,6 +898,7 @@
       "directoryName": "objectTranslations",
       "inFolder": false,
       "strictDirectoryName": true,
+      "supportsWildcardAndName": true,
       "children": {
         "types": {
           "customfieldtranslation": {
@@ -924,6 +937,7 @@
       "suffix": "globalValueSetTranslation",
       "directoryName": "globalValueSetTranslations",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "standardvaluesettranslation": {
@@ -941,6 +955,7 @@
       "directoryName": "classes",
       "inFolder": false,
       "strictDirectoryName": false,
+      "supportsWildcardAndName": true,
       "strategies": {
         "adapter": "matchingContentFile"
       }
@@ -994,6 +1009,7 @@
       "suffix": "md",
       "directoryName": "customMetadata",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "profilepasswordpolicy": {
@@ -1026,6 +1042,7 @@
       "suffix": "remoteSite",
       "directoryName": "remoteSiteSettings",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "csptrustedsite": {
@@ -1262,6 +1279,7 @@
       "directoryName": "sharingRules",
       "inFolder": false,
       "strictDirectoryName": false,
+      "supportsWildcardAndName": true,
       "children": {
         "types": {
           "sharingownerrule": {
@@ -1723,6 +1741,7 @@
       "suffix": "pathAssistant",
       "directoryName": "pathAssistants",
       "inFolder": false,
+      "supportsWildcardAndName": true,
       "strictDirectoryName": false
     },
     "leadconvertsettings": {

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -841,13 +841,13 @@ describe('ComponentSet', () => {
     });
 
     it('should overwrite a singular name with wildcard when supportsWildcardAndName=false', async () => {
-      const type = registry.types.apexclass;
+      const type = registry.types.role;
       const set = new ComponentSet();
       set.add(new SourceComponent({ name: 'myType', type }));
       set.add(new SourceComponent({ name: '*', type }));
       set.add(new SourceComponent({ name: 'myType2', type }));
       set.add(new SourceComponent({ name: 'myType', type }));
-      expect((await set.getObject()).Package.types).to.deep.equal([{ members: ['*'], name: 'ApexClass' }]);
+      expect((await set.getObject()).Package.types).to.deep.equal([{ members: ['*'], name: 'Role' }]);
     });
 
     it('should exclude child components that are not addressable as defined in the registry', async () => {


### PR DESCRIPTION
### What does this PR do?
Adds support to a bunch of types for specifying a wildcard with explicitly named metadata in a manifest.

### What issues does this PR fix or reference?
#1825
@W-12164846@

### Functionality Before
Retrieves only unpackaged metadata

### Functionality After
Retrieves both unpackaged and managed package metadata
