### PR TITLE
fix: use always forward slash for DEB and DE fullName

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -565,11 +565,13 @@ v58 introduces the following new types.  Here's their current level of support
 |FundraisingConfig|❌|Not supported, but support could be added|
 |LicensingSettings|✅||
 |OmniChannelPricingSettings|✅||
+|PlatformEventSettings|✅||
 |ProcessFlowMigration|❌|Not supported, but support could be added|
 |ProductAttrDisplayConfig|❌|Not supported, but support could be added|
 |ProductSpecificationRecType|❌|Not supported, but support could be added|
 |ProductSpecificationType|❌|Not supported, but support could be added|
 |RecAlrtDataSrcExpSetDef|❌|Not supported, but support could be added|
+|RecordAlertTemplate|❌|Not supported, but support could be added|
 |SkillType|❌|Not supported, but support could be added|
 |Web3Settings|✅||
 |WebStoreBundle|❌|Not supported, but support could be added|

--- a/src/resolve/adapters/digitalExperienceSourceAdapter.ts
+++ b/src/resolve/adapters/digitalExperienceSourceAdapter.ts
@@ -103,7 +103,7 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
 
   private getBundleName(contentPath: string): string {
     const bundlePath = this.getBundleMetadataXmlPath(contentPath);
-    return `${parentName(dirname(bundlePath))}${sep}${parentName(bundlePath)}`;
+    return `${parentName(dirname(bundlePath))}/${parentName(bundlePath)}`;
   }
 
   private getBundleMetadataXmlPath(path: string): string {
@@ -129,5 +129,4 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
  * @param contentPath This hook is called only after trimPathToContent() is called. so this will always be a folder structure
  * @returns name of type/apiName format
  */
-const calculateNameFromPath = (contentPath: string): string =>
-  `${parentName(contentPath)}${sep}${baseName(contentPath)}`;
+const calculateNameFromPath = (contentPath: string): string => `${parentName(contentPath)}/${baseName(contentPath)}`;

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -1257,8 +1257,9 @@ describe('ComponentSet', () => {
         type: digitalExperienceBundle.DEB_TYPE.id,
       };
 
-      const debMetaFilePath = join('path', 'to', 'digitalExperiences', 'site', 'foo', 'foo.digitalExperience-meta.xml');
-      expect(set.getComponentFilenamesByNameAndType(deb)).to.have.members([debMetaFilePath]);
+      expect(set.getComponentFilenamesByNameAndType(deb)).to.have.members([
+        digitalExperienceBundle.BUNDLE_META_FILE_PATH,
+      ]);
     });
 
     it('should correctly return DE (DigitalExperience) component file paths', () => {
@@ -1272,12 +1273,10 @@ describe('ComponentSet', () => {
         type: digitalExperienceBundle.DE_TYPE.id,
       };
 
-      const deViewHomePath = join('path', 'to', 'digitalExperiences', 'site', 'foo', 'sfdc_cms__view', 'home');
-
       expect(set.getComponentFilenamesByNameAndType(de)).to.have.members([
-        join(deViewHomePath, 'content.json'),
-        join(deViewHomePath, 'fr.json'),
-        join(deViewHomePath, '_meta.json'),
+        join(digitalExperienceBundle.HOME_VIEW_PATH, 'content.json'),
+        join(digitalExperienceBundle.HOME_VIEW_PATH, 'fr.json'),
+        join(digitalExperienceBundle.HOME_VIEW_PATH, '_meta.json'),
       ]);
     });
   });

--- a/test/mock/type-constants/digitalExperienceBundleConstants.ts
+++ b/test/mock/type-constants/digitalExperienceBundleConstants.ts
@@ -14,9 +14,9 @@ export const DEB_TYPE = registry.types.digitalexperiencebundle;
 // metaFileName = metaFileSuffix for DigitalExperience.
 export const DE_METAFILE = DE_TYPE.metaFileSuffix;
 
-export const BUNDLE_NAME = join('site', 'foo');
+export const BUNDLE_NAME = 'site/foo';
 export const BUNDLE_FULL_NAME = BUNDLE_NAME;
-export const HOME_VIEW_NAME = join('sfdc_cms__view', 'home');
+export const HOME_VIEW_NAME = 'sfdc_cms__view/home';
 export const HOME_VIEW_FULL_NAME = `${BUNDLE_FULL_NAME}.${HOME_VIEW_NAME}`;
 
 export const BUNDLE_META_FILE = `foo.${DEB_TYPE.suffix}${META_XML_SUFFIX}`;
@@ -25,9 +25,9 @@ export const HOME_VIEW_CONTENT_FILE = 'content.json';
 export const HOME_VIEW_FRENCH_VARIANT_FILE = 'fr.json';
 
 export const BASE_PATH = join('path', 'to', DEB_TYPE.directoryName);
-export const BUNDLE_PATH = join(BASE_PATH, BUNDLE_NAME);
+export const BUNDLE_PATH = join(BASE_PATH, 'site', 'foo');
 export const BUNDLE_META_FILE_PATH = join(BUNDLE_PATH, BUNDLE_META_FILE);
-export const HOME_VIEW_PATH = join(BUNDLE_PATH, HOME_VIEW_NAME);
+export const HOME_VIEW_PATH = join(BUNDLE_PATH, 'sfdc_cms__view', 'home');
 export const HOME_VIEW_CONTENT_FILE_PATH = join(HOME_VIEW_PATH, HOME_VIEW_CONTENT_FILE);
 export const HOME_VIEW_FRENCH_VARIANT_FILE_PATH = join(HOME_VIEW_PATH, HOME_VIEW_FRENCH_VARIANT_FILE);
 

--- a/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
+++ b/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
@@ -14,12 +14,12 @@ import { DE_METAFILE } from '../../mock/type-constants/digitalExperienceBundleCo
 describe('DigitalExperienceSourceAdapter', () => {
   const BASE_PATH = join('path', 'to', registry.types.digitalexperiencebundle.directoryName);
 
-  const BUNDLE_NAME = join('site', 'foo');
-  const BUNDLE_PATH = join(BASE_PATH, BUNDLE_NAME);
+  const BUNDLE_NAME = 'site/foo';
+  const BUNDLE_PATH = join(BASE_PATH, 'site', 'foo');
   const BUNDLE_META_FILE = join(BUNDLE_PATH, `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`);
 
-  const HOME_VIEW_NAME = join('sfdc_cms__view', 'home');
-  const HOME_VIEW_PATH = join(BUNDLE_PATH, HOME_VIEW_NAME);
+  const HOME_VIEW_NAME = 'sfdc_cms__view/home';
+  const HOME_VIEW_PATH = join(BUNDLE_PATH, 'sfdc_cms__view', 'home');
   const HOME_VIEW_CONTENT_FILE = join(HOME_VIEW_PATH, 'content.json');
   const HOME_VIEW_META_FILE = join(HOME_VIEW_PATH, DE_METAFILE);
   const HOME_VIEW_FRENCH_VARIANT_FILE = join(HOME_VIEW_PATH, 'fr.json');

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -211,7 +211,7 @@ describe('MetadataResolver', () => {
         const mdResolver = new MetadataResolver(undefined, treeContainer);
         const parentComponent = new SourceComponent(
           {
-            name: join('site', 'foo'),
+            name: 'site/foo',
             type: registry.types.digitalexperiencebundle,
             xml: parent_meta_file,
           },
@@ -219,7 +219,7 @@ describe('MetadataResolver', () => {
         );
         const expectedComponent = new SourceComponent(
           {
-            name: join('sfdc_cms__view', 'home'),
+            name: 'sfdc_cms__view/home',
             type: registry.types.digitalexperiencebundle.children.types.digitalexperience,
             content: dirname(path),
             parent: parentComponent,

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -187,7 +187,7 @@ const testData = {
     expectedFilePaths: [getFilePath('digitalExperiences/site/foo/foo.digitalExperience-meta.xml')],
     expectedComponents: [
       {
-        name: path.join('site', 'foo'), // as defined in digitalExperienceSourceAdapter.calculateNameFromPath()
+        name: 'site/foo', // as defined in digitalExperienceSourceAdapter.getBundleName()
         type: registryAccess.getTypeByName('DigitalExperienceBundle'),
         xml: getFilePath('digitalExperiences/site/foo/foo.digitalExperience-meta.xml'),
       },
@@ -199,7 +199,7 @@ const testData = {
     expectedFilePaths: [getFilePath('digitalExperiences/site/foo/sfdc_cms__view/home/_meta.json')],
     expectedComponents: [
       {
-        name: path.join('sfdc_cms__view', 'home'), // as defined in digitalExperienceSourceAdapter.calculateNameFromPath()
+        name: 'sfdc_cms__view/home', // as defined in digitalExperienceSourceAdapter.calculateNameFromPath()
         type: registryAccess.getTypeByName('DigitalExperience'),
       },
     ],


### PR DESCRIPTION
### What does this PR do?

fullName for DEB and DE components should always use the forward slash (/) as a separator regardless of the OS.

DEB - DigitalExperienceBundle
DE - DigitalExperience

### What issues does this PR fix or reference?

@[W-12749906](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NtCyGYAV/view)@

### Functionality Before

fullName is changing based on the OS. 

e.g., 

DEB fullName in Windows: site\Capricorn_Coffee_A1 (using backward slash)
DEB fullName in Linux: site/Capricorn_Coffee_A1 (using forward slash)

### Functionality After

fullName doesn't change based on the OS. Always use the forward slash (/) as a separator.

e.g., DEB fullName: site/Capricorn_Coffee_A1 
