### PR TITLE
Sm/strict mode 2 finalizers as maps

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v57 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 511/536 supported metadata types.
+Currently, there are 510/535 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
@@ -91,7 +91,6 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |CallCenter|✅||
 |CallCenterRoutingMap|✅||
 |CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
-|CallCtrAgentFavTrfrDest|✅||
 |CampaignInfluenceModel|✅||
 |CampaignSettings|✅||
 |CanvasMetadata|✅||
@@ -566,8 +565,13 @@ v58 introduces the following new types.  Here's their current level of support
 |FundraisingConfig|❌|Not supported, but support could be added|
 |LicensingSettings|✅||
 |OmniChannelPricingSettings|✅||
+|PlatformEventSettings|✅||
 |ProcessFlowMigration|❌|Not supported, but support could be added|
+|ProductAttrDisplayConfig|❌|Not supported, but support could be added|
+|ProductSpecificationRecType|❌|Not supported, but support could be added|
 |ProductSpecificationType|❌|Not supported, but support could be added|
+|RecAlrtDataSrcExpSetDef|❌|Not supported, but support could be added|
+|RecordAlertTemplate|❌|Not supported, but support could be added|
 |SkillType|❌|Not supported, but support could be added|
 |Web3Settings|✅||
 |WebStoreBundle|❌|Not supported, but support could be added|
@@ -621,3 +625,4 @@ v58 introduces the following new types.  Here's their current level of support
 - InternalOrganization
 - UiViewDefinition
 - MobileSecurityPolicySet
+- CallCtrAgentFavTrfrDest

--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
-import { getString, JsonArray, JsonMap } from '@salesforce/ts-types';
+import { ensureString, getString, JsonArray, JsonMap } from '@salesforce/ts-types';
 import { SfProject } from '@salesforce/core';
 import { ensureArray } from '@salesforce/kit';
 import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '../common';
@@ -18,96 +18,106 @@ import { WriteInfo, WriterFormat } from './types';
 abstract class ConvertTransactionFinalizer<T> {
   protected abstract transactionState: T;
 
-  public get state(): T {
-    return this.transactionState;
-  }
-
-  public setState(props: (state: T) => void): void {
-    props(this.transactionState);
-  }
-
   public abstract finalize(defaultDirectory?: string): Promise<WriterFormat[]>;
 }
 
-interface RecompositionState {
-  [componentKey: string]: {
-    /**
-     * Parent component that children are rolled up into
-     */
-    component?: SourceComponent;
-    /**
-     * Children to be rolled up into the parent file
-     */
-    children?: ComponentSet;
-  };
-}
+type RecompositionStateValue = {
+  /**
+   * Parent component that children are rolled up into
+   */
+  component?: SourceComponent;
+  /**
+   * Children to be rolled up into the parent file
+   */
+  children?: ComponentSet;
+};
+type RecompositionState = Map<string, RecompositionStateValue>;
 
 /**
  * Merges child components that share the same parent in the conversion pipeline
  * into a single file.
  */
 class RecompositionFinalizer extends ConvertTransactionFinalizer<RecompositionState> {
-  protected transactionState: RecompositionState = {};
+  public transactionState: RecompositionState = new Map<string, RecompositionStateValue>();
 
   // A cache of SourceComponent xml file paths to parsed contents so that identical child xml
   // files are not read and parsed multiple times.
   private parsedXmlCache = new Map<string, JsonMap>();
 
   public async finalize(): Promise<WriterFormat[]> {
-    const writerData: WriterFormat[] = [];
-    for (const { component: parent, children } of Object.values(this.state)) {
-      // TODO: can we safely parallelize this?
-      // eslint-disable-next-line no-await-in-loop
-      const recomposedXmlObj = await this.recompose(children, parent);
-      writerData.push({
-        component: parent,
-        writeInfos: [
-          {
-            source: new JsToXml(recomposedXmlObj),
-            output: join(parent.type.directoryName, `${parent.fullName}.${parent.type.suffix}`),
-          },
-        ],
-      });
-    }
+    return Promise.all(
+      Array.from(this.transactionState.values()).map(async (stateValue): Promise<WriterFormat> => {
+        if (!stateValue.component) {
+          throw new Error(
+            `The parent component is missing from the recomposition state entry.  The children are ${stateValue.children
+              ?.toArray()
+              .map((c) => c.fullName)
+              .join(', ')}`
+          );
+        }
 
-    return writerData;
+        const recomposedXmlObj = await this.recompose(stateValue.children, stateValue.component);
+        return {
+          component: stateValue.component,
+          writeInfos: [
+            {
+              source: new JsToXml(recomposedXmlObj),
+              output: join(
+                stateValue.component.type.directoryName,
+                `${stateValue.component.fullName}.${stateValue.component.type.suffix}`
+              ),
+            },
+          ],
+        };
+      })
+    );
   }
 
-  private async recompose(children: ComponentSet, parent: SourceComponent): Promise<JsonMap> {
+  private async recompose(children: ComponentSet = new ComponentSet(), parent: SourceComponent): Promise<JsonMap> {
     // When recomposing children that are non-decomposed, read and cache the parent XML to prevent
     // reading the parent source file (referenced in all child SourceComponents) multiple times.
-    let parentXml: JsonMap;
-    if (parent.type.strategies.transformer === TransformerStrategy.NonDecomposed) {
+    let parentXml: JsonMap | undefined;
+    if (parent.type.strategies?.transformer === TransformerStrategy.NonDecomposed && parent.xml) {
       parentXml = await parent.parseXml();
       this.parsedXmlCache.set(parent.xml, parentXml);
     }
 
     const parentXmlObj =
-      parent.type.strategies.recomposition === RecompositionStrategy.StartEmpty
+      parent.type.strategies?.recomposition === RecompositionStrategy.StartEmpty
         ? {}
         : parentXml ?? (await parent.parseXml());
 
     for (const child of children) {
+      if (!child.parent) {
+        throw new Error(`Child component ${child.fullName} has no parent type`);
+      }
       const { directoryName: groupName } = child.type;
       const { name: parentName } = child.parent.type;
       const childSourceComponent = child as SourceComponent;
 
-      let xmlObj: JsonMap;
+      let xmlObj: JsonMap | undefined;
       if (parentXml) {
         // If the xml file for the child is in the cache, use it. Otherwise
         // read and cache the xml file that contains this child and use it.
-        if (!this.parsedXmlCache.has(childSourceComponent.xml)) {
+        if (childSourceComponent.xml && !this.parsedXmlCache.has(childSourceComponent.xml)) {
           // TODO: can we safely parallelize this?
           // eslint-disable-next-line no-await-in-loop
           this.parsedXmlCache.set(childSourceComponent.xml, await parent.parseXml(childSourceComponent.xml));
         }
-        xmlObj = childSourceComponent.parseFromParentXml(this.parsedXmlCache.get(childSourceComponent.xml));
+        xmlObj = childSourceComponent.parseFromParentXml(
+          this.parsedXmlCache.get(
+            ensureString(childSourceComponent.xml, `Child component ${child.fullName} has no xml file`)
+          )
+        );
       } else {
         // TODO: can we safely parallelize this?
         // eslint-disable-next-line no-await-in-loop
         xmlObj = await childSourceComponent.parseXml();
       }
-      const childContents = xmlObj[child.type.name] || xmlObj;
+      if (!xmlObj) {
+        throw new Error(`Failed to parse xml for child component ${child.fullName}`);
+      }
+      const childContents = xmlObj[child.type.name] ?? xmlObj;
 
       if (!parentXmlObj[parentName]) {
         parentXmlObj[parentName] = { [XML_NS_KEY]: XML_NS_URL };
@@ -134,35 +144,34 @@ class RecompositionFinalizer extends ConvertTransactionFinalizer<RecompositionSt
   }
 }
 
-export interface DecompositionState {
-  [componentKey: string]: {
-    foundMerge?: boolean;
-    writeInfo?: WriteInfo;
-    origin?: MetadataComponent;
-  };
-}
+export type DecompositionStateValue = {
+  foundMerge?: boolean;
+  writeInfo?: WriteInfo;
+  origin?: MetadataComponent;
+  component?: SourceComponent;
+  children?: ComponentSet;
+};
+export type DecompositionState = Map<string, DecompositionStateValue>;
 
+/** DecompositionStateValue has all props as optional.  The makes writeInfo and origin required  */
+const hasFullDecompositionInfo = (
+  value: [string, DecompositionStateValue]
+): value is [string, DecompositionStateValue & { writeInfo: WriteInfo; origin: MetadataComponent }] =>
+  Boolean(value[1].writeInfo) && Boolean(value[1].origin);
 /**
  * Creates write infos for any children that haven't been written yet. Children may
  * delay being written in order to find potential existing children to merge
  * with in the conversion pipeline.
  */
 class DecompositionFinalizer extends ConvertTransactionFinalizer<DecompositionState> {
-  protected transactionState: DecompositionState = {};
+  public transactionState: DecompositionState = new Map<string, DecompositionStateValue>();
 
   // eslint-disable-next-line @typescript-eslint/require-await
   public async finalize(): Promise<WriterFormat[]> {
-    const writerData: WriterFormat[] = [];
-
-    for (const toDecompose of Object.values(this.transactionState)) {
-      if (!toDecompose.foundMerge) {
-        writerData.push({
-          component: toDecompose.origin.parent ?? toDecompose.origin,
-          writeInfos: [toDecompose.writeInfo],
-        });
-      }
-    }
-    return writerData;
+    return Array.from(this.transactionState.entries())
+      .filter(hasFullDecompositionInfo)
+      .filter(([, value]) => !value.foundMerge)
+      .map(([, value]) => ({ component: value.origin?.parent ?? value.origin, writeInfos: [value.writeInfo] }));
   }
 }
 
@@ -171,7 +180,7 @@ interface NonDecompositionState {
    * Incoming child xml (ex CustomLabel) keyed by uniqueId (label name).
    */
   childrenByUniqueElement: Map<string, JsonMap>;
-  exampleComponent: SourceComponent;
+  exampleComponent?: SourceComponent;
 }
 
 /**
@@ -181,7 +190,7 @@ interface NonDecompositionState {
  * Inserts unclaimed child components into the parent that belongs to the default package
  */
 class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecompositionState> {
-  protected transactionState: NonDecompositionState = {
+  public transactionState: NonDecompositionState = {
     childrenByUniqueElement: new Map(),
     exampleComponent: undefined,
   };
@@ -191,7 +200,7 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
 
   // filename => sourceComponent
   protected parentComponentMap = new Map<string, SourceComponent>();
-  protected tree: TreeContainer;
+  protected tree: TreeContainer | undefined;
 
   public async finalize(defaultDirectory: string, tree = new NodeFSTreeContainer()): Promise<WriterFormat[]> {
     const writerData: WriterFormat[] = [];
@@ -206,6 +215,9 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
 
     // nondecomposed metadata types can exist in multiple locations under the same name
     // so we have to find all components that could potentially match inbound components
+    if (!this.transactionState.exampleComponent) {
+      throw new Error('No example component exists in the transaction state for nondecomposed metadata');
+    }
     const allNonDecomposed = pkgPaths.includes(defaultDirectory)
       ? this.getAllComponentsOfType(pkgPaths, this.transactionState.exampleComponent.type.name)
       : // defaultDirectory isn't a package, assume it's the target output dir for conversion so don't scan folder
@@ -213,7 +225,9 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
 
     // prepare 3 maps to simplify component merging
     await this.initMergeMap(allNonDecomposed);
-    this.parentComponentMap = new Map(allNonDecomposed.map((c) => [c.xml, c]));
+    this.parentComponentMap = new Map(
+      allNonDecomposed.map((c) => [ensureString(c.xml, `no xml file path for ${c.fullName}`), c])
+    );
     const childNameToParentFilePath = this.initChildMapping();
 
     // we'll merge any new labels into the default location
@@ -222,10 +236,10 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
 
     // put the incoming components into the mergeMap.  Keep track of any files we need to write
     const filesToWrite = new Set<string>();
-    this.state.childrenByUniqueElement.forEach((child, childUniqueElement) => {
+    this.transactionState.childrenByUniqueElement.forEach((child, childUniqueElement) => {
       const parentKey = childNameToParentFilePath.get(childUniqueElement) ?? defaultKey;
       const parentItemMap = this.mergeMap.get(parentKey);
-      parentItemMap.set(childUniqueElement, child);
+      parentItemMap?.set(childUniqueElement, child);
       filesToWrite.add(parentKey);
     });
 
@@ -233,6 +247,9 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
     this.mergeMap.forEach((children, parentKey) => {
       if (filesToWrite.has(parentKey)) {
         const parentSourceComponent = this.parentComponentMap.get(parentKey);
+        if (!parentSourceComponent) {
+          throw new Error(`No source component found for ${parentKey}`);
+        }
         const recomposedXmlObj = recompose(children, parentSourceComponent);
         writerData.push({
           component: parentSourceComponent,
@@ -300,14 +317,26 @@ class NonDecompositionFinalizer extends ConvertTransactionFinalizer<NonDecomposi
       const results = await Promise.all(
         component.getChildren().map(async (child): Promise<[string, JsonMap]> => {
           const childXml = await child.parseXml();
-          return [getString(childXml, child.type.uniqueIdElement), childXml];
+          return [
+            getString(
+              childXml,
+              ensureString(child.type.uniqueIdElement),
+              `No uniqueIdElement exists in the registry for ${child.type.name}`
+            ),
+            childXml,
+          ];
         })
       );
       return new Map(results);
     };
 
     const result = await Promise.all(
-      allComponentsOfType.map(async (c): Promise<[string, Map<string, JsonMap>]> => [c.xml, await getMappedChildren(c)])
+      allComponentsOfType.map(
+        async (c): Promise<[string, Map<string, JsonMap>]> => [
+          ensureString(c.xml, `Missing xml file for ${c.type.name}`),
+          await getMappedChildren(c),
+        ]
+      )
     );
 
     this.mergeMap = new Map(result);

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -52,8 +52,8 @@ export class MetadataConverter {
 
       let writer: StandardWriter | ZipWriter;
       let mergeSet: ComponentSet;
-      let packagePath: SourcePath;
-      let defaultDirectory: SourcePath;
+      let packagePath: SourcePath | undefined;
+      let defaultDirectory: SourcePath | undefined;
 
       switch (output.type) {
         case 'directory':

--- a/src/convert/transformers/nonDecomposedMetadataTransformer.ts
+++ b/src/convert/transformers/nonDecomposedMetadataTransformer.ts
@@ -35,9 +35,7 @@ export class NonDecomposedMetadataTransformer extends DecomposedMetadataTransfor
     const [childTypeId] = Object.keys(component.type.children.types);
     const { uniqueIdElement } = component.type.children.types[childTypeId];
 
-    this.context.nonDecomposition.setState((state) => {
-      state.exampleComponent ??= component;
-    });
+    this.context.nonDecomposition.transactionState.exampleComponent ??= component;
 
     incomingChildrenXml.map((child) => {
       if (!uniqueIdElement) {
@@ -51,9 +49,7 @@ export class NonDecomposedMetadataTransformer extends DecomposedMetadataTransfor
           `The uniqueIdElement ${uniqueIdElement} was not found the child (reading ${component.fullName} ${component.xml})`
         );
       }
-      this.context.nonDecomposition.setState((state) => {
-        state.childrenByUniqueElement.set(childName, child);
-      });
+      this.context.nonDecomposition.transactionState.childrenByUniqueElement.set(childName, child);
     });
 
     return [];

--- a/test/convert/transformers/nonDecomposedMetadataTransformer.test.ts
+++ b/test/convert/transformers/nonDecomposedMetadataTransformer.test.ts
@@ -26,15 +26,12 @@ describe('NonDecomposedMetadataTransformer', () => {
 
       expect(await transformer.toMetadataFormat(child1)).to.deep.equal([]);
       expect(await transformer.toMetadataFormat(child2)).to.deep.equal([]);
-      const expected = JSON.parse(
-        JSON.stringify({
-          [component.fullName]: {
-            component,
-            children: new ComponentSet([child1, child2]),
-          },
-        })
-      );
-      expect(JSON.parse(JSON.stringify(context.recomposition.state))).to.deep.equal(expected);
+
+      expect(context.recomposition.transactionState.size).to.equal(1);
+      expect(context.recomposition.transactionState.get(component.fullName)).to.deep.equal({
+        component,
+        children: new ComponentSet([child1, child2]),
+      });
     });
   });
 
@@ -45,10 +42,10 @@ describe('NonDecomposedMetadataTransformer', () => {
 
       const result = await transformer.toSourceFormat(component);
       expect(result).to.deep.equal([]);
-      expect(context.decomposition.state).to.deep.equal({});
-      expect(context.recomposition.state).to.deep.equal({});
+      expect(context.decomposition.transactionState).to.deep.equal(new Map());
+      expect(context.recomposition.transactionState).to.deep.equal(new Map());
 
-      expect(context.nonDecomposition.state).to.deep.equal({
+      expect(context.nonDecomposition.transactionState).to.deep.equal({
         childrenByUniqueElement: new Map([
           [nonDecomposed.CHILD_1_NAME, nonDecomposed.CHILD_1_XML],
           [nonDecomposed.CHILD_2_NAME, nonDecomposed.CHILD_2_XML],
@@ -73,7 +70,7 @@ describe('NonDecomposedMetadataTransformer', () => {
 
       const result = await transformer.toSourceFormat(componentToConvert, component);
       expect(result).to.deep.equal([]);
-      expect(context.nonDecomposition.state).to.deep.equal({
+      expect(context.nonDecomposition.transactionState).to.deep.equal({
         childrenByUniqueElement: new Map([
           [nonDecomposed.CHILD_1_NAME, nonDecomposed.CHILD_1_XML],
           [nonDecomposed.CHILD_2_NAME, nonDecomposed.CHILD_2_XML],

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 220.73954499998945
+    "duration": 221.34168599999975
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8764.579136
+    "duration": 5850.5624820000085
   },
   {
     "name": "sourceToZip",
-    "duration": 4817.994116999995
+    "duration": 4167.160709000018
   },
   {
     "name": "mdapiToSource",
-    "duration": 3999.1985480000003
+    "duration": 3945.668333999987
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 440.0365330000059
+    "duration": 425.6713430000236
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8547.088470999995
+    "duration": 8908.706042999984
   },
   {
     "name": "sourceToZip",
-    "duration": 7158.503278999997
+    "duration": 6679.152606000018
   },
   {
     "name": "mdapiToSource",
-    "duration": 4846.582094999991
+    "duration": 4796.360680999991
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 765.1924759999965
+    "duration": 754.8279489999986
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12505.445792999992
+    "duration": 12162.005130999954
   },
   {
     "name": "sourceToZip",
-    "duration": 10468.818727000005
+    "duration": 10550.278282999992
   },
   {
     "name": "mdapiToSource",
-    "duration": 8742.701778000017
+    "duration": 8382.379116999975
   }
 ]


### PR DESCRIPTION
> https://github.com/forcedotcom/source-deploy-retrieve/pull/879

ConvertContext Decomposition/Recomposition Finalizers were written as keyedObject.  This changes them to a js map.
Also makes them a public property so the consumer can get/set from the map (removes the getter and setState functions).
And, of course, lots of types cleanup around those areas.

QA notes:
test this with a decomposed (ex: CustomObject) and nonDecomposed (customLabels) beyond what the nut suite is doing.

[@W-12671663@](https://gus.lightning.force.com/a07EE00001MxCd3YAF)