### PR TITLE
Sm/strict null 5 tests

### DIFF
--- a/scripts/update-registry/update-supported-metadata.ts
+++ b/scripts/update-registry/update-supported-metadata.ts
@@ -1,4 +1,4 @@
-import { CoverageObject } from '../../src/registry/types';
+import { CoverageObject, CoverageObjectType } from '../../src/registry/types';
 import { getCurrentApiVersion, getCoverage } from '../../src/registry/coverage';
 import { registry as untypedRegistry } from '../../src';
 import { MetadataRegistry } from '../../src';
@@ -18,21 +18,21 @@ import * as fs from 'fs';
   ]);
 
   const inRegistry = (key: string) => registryTypes.some((regType) => regType.name === key);
-  const filterNoMetadata = ([key, type]) => !type.channels.metadataApi.exposed;
-  const filterFullCliSupport = ([key, type]) =>
+  const filterNoMetadata = ([key, type]: [string, CoverageObjectType]) => !type.channels.metadataApi.exposed;
+  const filterFullCliSupport = ([key, type]: [string, CoverageObjectType]) =>
     key.endsWith('Settings') ||
     (type.channels.metadataApi.exposed && type.channels.sourceTracking.exposed && inRegistry(key));
-  const filterCliNoTracking = ([key, type]) =>
+  const filterCliNoTracking = ([key, type]: [string, CoverageObjectType]) =>
     !key.endsWith('Settings') &&
     type.channels.metadataApi.exposed &&
     !type.channels.sourceTracking.exposed &&
     inRegistry(key);
-  const filterCliNoSupport = ([key, type]) =>
+  const filterCliNoSupport = ([key, type]: [string, CoverageObjectType]) =>
     !key.endsWith('Settings') &&
     type.channels.metadataApi.exposed &&
     type.channels.sourceTracking.exposed &&
     !inRegistry(key);
-  const filterCliNoSupportMetadataApiOnly = ([key, type]) =>
+  const filterCliNoSupportMetadataApiOnly = ([key, type]: [string, CoverageObjectType]) =>
     !key.endsWith('Settings') &&
     type.channels.metadataApi.exposed &&
     !type.channels.sourceTracking.exposed &&

--- a/src/resolve/adapters/baseSourceAdapter.ts
+++ b/src/resolve/adapters/baseSourceAdapter.ts
@@ -6,6 +6,7 @@
  */
 import { basename, dirname, sep } from 'path';
 import { Messages, SfError } from '@salesforce/core';
+import { ensureString } from '@salesforce/ts-types';
 import { MetadataXml, SourceAdapter } from '../types';
 import { parseMetadataXml, parseNestedFullName } from '../../utils';
 import { ForceIgnore } from '../forceIgnore';
@@ -160,13 +161,16 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
   }
 
   // Given a MetadataXml, build a fullName from the path and type.
-  private calculateName(rootMetadata: MetadataXml): string | undefined {
+  private calculateName(rootMetadata: MetadataXml): string {
     const { directoryName, inFolder, folderType, folderContentType } = this.type;
 
     // inFolder types (report, dashboard, emailTemplate, document) and their folder
     // container types (reportFolder, dashboardFolder, emailFolder, documentFolder)
     if (inFolder || folderContentType) {
-      return parseNestedFullName(rootMetadata.path, directoryName);
+      return ensureString(
+        parseNestedFullName(rootMetadata.path, directoryName),
+        `Unable to calculate fullName from component at path: ${rootMetadata.path} (${this.type.name})`
+      );
     }
 
     // not using folders?  then name is fullname

--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -279,7 +279,7 @@ export class VirtualTreeContainer extends TreeContainer {
   public exists(fsPath: string): boolean {
     const files = this.tree.get(dirname(fsPath));
     const isFile = files?.has(fsPath);
-    return isFile || this.tree.has(fsPath);
+    return this.tree.has(fsPath) || Boolean(isFile);
   }
 
   public readDirectory(fsPath: string): string[] {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -91,7 +91,7 @@ export function parseMetadataXml(fsPath: string): Optional<MetadataXml> {
  * @param directoryName - name of directory to use as a parsing index
  * @returns the FullName
  */
-export function parseNestedFullName(fsPath: string, directoryName: string): Optional<string> {
+export function parseNestedFullName(fsPath: string, directoryName: string): string | undefined {
   const pathSplits = fsPath.split(sep);
   // Exit if the directoryName is not included in the file path.
   if (!pathSplits.includes(directoryName)) {

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -209,6 +209,7 @@ describe('MetadataApiDeploy', () => {
         await operation.checkStatus();
         assert.fail('should have thrown an error');
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.name).to.equal(expectedError.name);
         expect(e.message).to.equal(expectedError.message);
       }
@@ -242,6 +243,7 @@ describe('MetadataApiDeploy', () => {
         await operation.deployRecentValidation(false);
         assert.fail('should have thrown an error');
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.name).to.equal(expectedError.name);
         expect(e.message).to.equal(expectedError.message);
       }
@@ -267,6 +269,7 @@ describe('MetadataApiDeploy', () => {
         await operation.cancel();
         assert.fail('should have thrown an error');
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.name).to.equal(expectedError.name);
         expect(e.message).to.equal(expectedError.message);
       }
@@ -292,6 +295,7 @@ describe('MetadataApiDeploy', () => {
           ]);
           const deployedSet = new ComponentSet([component]);
           const { fullName, type, xml } = component;
+          assert(xml);
           const apiStatus: Partial<MetadataApiDeployStatus> = {
             details: {
               componentSuccesses: {

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -7,7 +7,7 @@
 import { fail } from 'assert';
 import { join } from 'path';
 import { Messages } from '@salesforce/core';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import chai = require('chai');
 import deepEqualInAnyOrder = require('deep-equal-in-any-order');
 import * as unzipper from 'unzipper';
@@ -68,6 +68,7 @@ describe('MetadataApiRetrieve', () => {
           await operation.start();
           fail('should have thrown an error');
         } catch (e) {
+          assert(e instanceof Error);
           expect(e.name).to.equal(expectedError.name);
           expect(e.message).to.equal(expectedError.message);
         }
@@ -85,6 +86,7 @@ describe('MetadataApiRetrieve', () => {
           await operation.start();
           fail('should have thrown an error');
         } catch (e) {
+          assert(e instanceof Error);
           expect(e.name).to.equal(expectedError.name);
           expect(e.message).to.equal(expectedError.message);
         }
@@ -379,6 +381,8 @@ describe('MetadataApiRetrieve', () => {
 
       it('should construct a result object with no components when components are forceIgnored', async () => {
         const toRetrieve = new ComponentSet([COMPONENT]);
+        assert(COMPONENT.xml);
+        assert(COMPONENT.content);
         toRetrieve.forceIgnoredPaths = new Set([COMPONENT.xml, COMPONENT.content]);
         const { operation } = await stubMetadataRetrieve($$, testOrg, {
           toRetrieve,
@@ -429,6 +433,8 @@ describe('MetadataApiRetrieve', () => {
           name: 'MissingJobIdError',
           message: messages.getMessage('error_no_job_id', ['retrieve']),
         };
+        assert(e instanceof Error);
+
         expect(e.name).to.equal(expectedError.name);
         expect(e.message).to.equal(expectedError.message);
       }

--- a/test/client/metadataTransfer.test.ts
+++ b/test/client/metadataTransfer.test.ts
@@ -7,7 +7,7 @@
 import { fail } from 'assert';
 import { SinonStub } from 'sinon';
 import { AuthInfo, Connection, PollingClient, Messages } from '@salesforce/core';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { Duration, sleep } from '@salesforce/kit';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
 import { ComponentSet } from '../../src';
@@ -100,6 +100,7 @@ describe('MetadataTransfer', () => {
       }
     }
     const username = connection.getUsername();
+    assert(username);
     const authInfo = await AuthInfo.create({ username });
     $$.SANDBOX.stub(AuthInfo, 'create').withArgs({ username }).resolves(authInfo);
     $$.SANDBOX.stub(Connection, 'create').withArgs({ authInfo }).resolves(connection);
@@ -122,6 +123,7 @@ describe('MetadataTransfer', () => {
     }
     const apiVersion = '50.0';
     const username = connection.getUsername();
+    assert(username);
 
     const authInfo = await AuthInfo.create({ username });
     $$.SANDBOX.stub(AuthInfo, 'create').withArgs({ username }).resolves(authInfo);
@@ -149,6 +151,7 @@ describe('MetadataTransfer', () => {
     const apiVersion = '51.0';
     const maxApiVersion = '50.0';
     const username = connection.getUsername();
+    assert(username);
 
     const authInfo = await AuthInfo.create({ username });
     $$.SANDBOX.stub(AuthInfo, 'create').withArgs({ username }).resolves(authInfo);
@@ -294,6 +297,7 @@ describe('MetadataTransfer', () => {
         fail('should have thrown an error');
       } catch (err) {
         expect(callCount).to.be.greaterThan(15);
+        assert(err instanceof Error);
         expect(err.name, 'Polling function should have timed out').to.equal('MetadataTransferError');
         expect(err.message).to.equal('Metadata API request failed: The client has timed out.');
       }
@@ -307,10 +311,10 @@ describe('MetadataTransfer', () => {
         message: messages.getMessage('md_request_fail', [originalError.message]),
       };
       checkStatus.throws(originalError);
-      let error: Error;
+      let error: Error | undefined;
       operation.onError((e) => (error = e));
       await operation.pollStatus();
-
+      assert(error instanceof Error);
       expect(error.name).to.deep.equal(expectedError.name);
       expect(error.message).to.deep.equal(expectedError.message);
     });
@@ -374,6 +378,7 @@ describe('MetadataTransfer', () => {
         await operation.pollStatus();
         fail('should have thrown an error');
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.name).to.deep.equal(expectedError.name);
         expect(e.message).to.deep.equal(expectedError.message);
       }

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -7,7 +7,7 @@
 import { fail } from 'assert';
 import { join } from 'path';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { SinonStub } from 'sinon';
 import { AuthInfo, ConfigAggregator, Connection, Lifecycle, Messages } from '@salesforce/core';
 import {
@@ -82,7 +82,7 @@ describe('ComponentSet', () => {
         });
     };
 
-    const getManifestContent = (version) => ({
+    const getManifestContent = (version: string) => ({
       types: [
         { members: ['replaceStuff'], name: 'ApexClass' },
         { members: ['TestObj__c.FieldA__c'], name: 'CustomField' },
@@ -822,7 +822,8 @@ describe('ComponentSet', () => {
     });
 
     it('should exclude components that are not addressable as defined in the registry', async () => {
-      const type = registry.types.customobjecttranslation.children.types.customfieldtranslation;
+      const type = registry.types.customobjecttranslation.children?.types.customfieldtranslation;
+      assert(type);
       const set = new ComponentSet();
       set.add(new SourceComponent({ name: type.name, type }));
       expect((await set.getObject()).Package.types).to.deep.equal([]);
@@ -851,7 +852,8 @@ describe('ComponentSet', () => {
     });
 
     it('should exclude child components that are not addressable as defined in the registry', async () => {
-      const childType = registry.types.customobjecttranslation.children.types.customfieldtranslation;
+      const childType = registry.types.customobjecttranslation.children?.types.customfieldtranslation;
+      assert(childType);
       const type = registry.types.customobjecttranslation;
       const set = new ComponentSet();
       const testComp = new SourceComponent({ name: type.name, type });
@@ -887,6 +889,7 @@ describe('ComponentSet', () => {
     });
     it('should return manifest string when initialized from manifest file', async () => {
       const manifest = manifestFiles.ONE_OF_EACH;
+      assert(manifest.data);
       const set = await ComponentSet.fromManifest({
         manifestPath: manifest.name,
         registry: registryAccess,
@@ -905,7 +908,7 @@ describe('ComponentSet', () => {
         registry: registryAccess,
         tree: manifestFiles.TREE,
       });
-      expect((await set.getPackageXml(4)).toString()).to.equal(manifestFiles.BASIC.data.toString());
+      expect((await set.getPackageXml(4)).toString()).to.equal(manifestFiles.BASIC.data?.toString());
     });
 
     it('should return destructive changes manifest string when initialized from source', async () => {
@@ -915,7 +918,7 @@ describe('ComponentSet', () => {
         tree: manifestFiles.TREE,
         fsDeletePaths: ['.'],
       });
-      expect(await set.getPackageXml(4, DestructiveChangesType.POST)).to.equal(manifestFiles.BASIC.data.toString());
+      expect(await set.getPackageXml(4, DestructiveChangesType.POST)).to.equal(manifestFiles.BASIC.data?.toString());
     });
   });
 
@@ -1004,6 +1007,7 @@ describe('ComponentSet', () => {
         await set.deploy({ usernameOrConnection: 'test@foobar.com' });
         fail('should have thrown an error');
       } catch (e) {
+        assert(e instanceof Error);
         Messages.importMessagesDirectory(__dirname);
         const messages = Messages.load('@salesforce/source-deploy-retrieve', 'sdr', ['error_no_source_to_deploy']);
 
@@ -1139,7 +1143,7 @@ describe('ComponentSet', () => {
       set.add(component, DestructiveChangesType.POST);
 
       expect(!!set.getTypesOfDestructiveChanges().length).to.be.true;
-      expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
+      expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
       expect(set.has(component)).to.be.true;
     });
 
@@ -1156,12 +1160,12 @@ describe('ComponentSet', () => {
 
       expect(!!set.getTypesOfDestructiveChanges().length).to.be.true;
       expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.POST);
-      expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
+      expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
 
       set.add(component);
       set.setDestructiveChangesType(DestructiveChangesType.PRE);
       expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.PRE);
-      expect(set.getSourceComponents().first().isMarkedForDelete()).to.be.true;
+      expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
       expect(set.has(component)).to.be.true;
       expect(set.getSourceComponents().toArray().length).to.equal(1);
     });
@@ -1266,7 +1270,7 @@ describe('ComponentSet', () => {
         [digitalExperienceBundle.DE_CONTENT_COMPONENT, digitalExperienceBundle.DE_FR_VARIENT_COMPONENT],
         registryAccess
       );
-
+      assert(typeof digitalExperienceBundle.DE_TYPE?.id === 'string');
       const de: MetadataMember = {
         fullName: digitalExperienceBundle.HOME_VIEW_FULL_NAME,
         type: digitalExperienceBundle.DE_TYPE.id,

--- a/test/collections/componentSetBuilder.test.ts
+++ b/test/collections/componentSetBuilder.test.ts
@@ -172,7 +172,7 @@ describe('ComponentSetBuilder', () => {
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
       const filter = new ComponentSet();
       filter.add({ type: 'ApexClass', fullName: '*' });
-      expect(fromSourceArgs).to.have.property('include');
+      assert(fromSourceArgs.include instanceof ComponentSet, 'include should be a ComponentSet');
       expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
       expect(compSet.size).to.equal(2);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -197,7 +197,7 @@ describe('ComponentSetBuilder', () => {
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
       const filter = new ComponentSet();
       filter.add({ type: 'ApexClass', fullName: 'MyApexClass' });
-      expect(fromSourceArgs).to.have.property('include');
+      assert(fromSourceArgs.include instanceof ComponentSet, 'include should be a ComponentSet');
       expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
       expect(compSet.size).to.equal(2);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -241,7 +241,7 @@ describe('ComponentSetBuilder', () => {
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
       const filter = new ComponentSet();
       filter.add({ type: 'ApexClass', fullName: 'MyClass' });
-      expect(fromSourceArgs).to.have.property('include');
+      assert(fromSourceArgs.include instanceof ComponentSet, 'include should be a ComponentSet');
       expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
       expect(compSet.size).to.equal(1);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -267,7 +267,7 @@ describe('ComponentSetBuilder', () => {
       const filter = new ComponentSet();
       filter.add({ type: 'ApexClass', fullName: 'MyClass' });
       filter.add({ type: 'CustomObject', fullName: '*' });
-      expect(fromSourceArgs).to.have.property('include');
+      assert(fromSourceArgs.include instanceof ComponentSet, 'include should be a ComponentSet');
       expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
       expect(compSet.size).to.equal(3);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -296,7 +296,7 @@ describe('ComponentSetBuilder', () => {
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1, packageDir2]);
       const filter = new ComponentSet();
       filter.add({ type: 'ApexClass', fullName: '*' });
-      expect(fromSourceArgs).to.have.property('include');
+      assert(fromSourceArgs.include instanceof ComponentSet, 'include should be a ComponentSet');
       expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
       expect(compSet.size).to.equal(3);
       expect(compSet.has(apexClassComponent)).to.equal(true);

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -97,6 +97,7 @@ describe('MetadataConverter', () => {
       });
       assert.fail('an error should have been thrown');
     } catch (e) {
+      assert(e instanceof Error);
       expect(e.message).to.equal(expectedError.message);
       expect(e.name).to.equal(expectedError.name);
     }
@@ -441,6 +442,7 @@ describe('MetadataConverter', () => {
         });
         fail(`should have thrown a ${expectedError.name} error`);
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.name).to.equal('ConversionError');
         expect(e.message).to.equal(expectedError.message);
       }
@@ -461,7 +463,7 @@ describe('MetadataConverter', () => {
 
     it('should create conversion pipeline with addressable components', async () => {
       components.push({
-        type: registry.types.customobjecttranslation.children.types.customfieldtranslation,
+        type: registry.types.customobjecttranslation.children?.types.customfieldtranslation,
         name: 'myFieldTranslation',
       } as SourceComponent);
 
@@ -481,6 +483,7 @@ describe('MetadataConverter', () => {
     });
 
     it('should ensure merge set contains parents of child components instead of the children themselves', async () => {
+      assert(DECOMPOSED_CHILD_COMPONENT_1.parent?.xml);
       await converter.convert(components, 'source', {
         type: 'merge',
         defaultDirectory,

--- a/test/convert/replacements.test.ts
+++ b/test/convert/replacements.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import Sinon = require('sinon');
 import { Lifecycle } from '@salesforce/core';
 import { getReplacements, matchesFile, replacementIterations, stringToRegex } from '../../src/convert/replacements';
@@ -57,6 +57,7 @@ describe('marking replacements on a component', () => {
     expect(await getReplacements(cmp, [])).to.be.undefined;
   });
   it('marks a string replacement from env', async () => {
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [
       { filename: cmp.xml, stringToReplace: 'foo', replaceWithEnv: 'FOO_REPLACEMENT' },
     ]);
@@ -72,6 +73,7 @@ describe('marking replacements on a component', () => {
     });
   });
   it('marks string replacements from file', async () => {
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [{ filename: cmp.xml, stringToReplace: 'foo', replaceWithFile: 'bar' }]);
     expect(result).to.deep.equal({
       [cmp.xml]: [
@@ -86,6 +88,7 @@ describe('marking replacements on a component', () => {
   });
 
   it('marks regex replacements on a matching file', async () => {
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [
       { filename: cmp.xml, regexToReplace: '.*foo.*', replaceWithEnv: 'FOO_REPLACEMENT' },
     ]);
@@ -101,6 +104,7 @@ describe('marking replacements on a component', () => {
     });
   });
   it('marks 2 replacements on one file', async () => {
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [
       { filename: cmp.xml, stringToReplace: 'foo', replaceWithEnv: 'FOO_REPLACEMENT' },
       { filename: cmp.xml, stringToReplace: 'baz', replaceWithEnv: 'FOO_REPLACEMENT' },
@@ -123,6 +127,8 @@ describe('marking replacements on a component', () => {
     });
   });
   it('marks two files with 1 replacement each for greedy glob', async () => {
+    assert(cmp.content);
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [
       { glob: '**/*', stringToReplace: 'foo', replaceWithEnv: 'FOO_REPLACEMENT' },
     ]);
@@ -146,6 +152,8 @@ describe('marking replacements on a component', () => {
     });
   });
   it('marks replacement on multiple files from multiple configs', async () => {
+    assert(cmp.content);
+    assert(cmp.xml);
     const result = await getReplacements(cmp, [
       { filename: cmp.xml, stringToReplace: 'foo', replaceWithEnv: 'FOO_REPLACEMENT' },
       { filename: cmp.content, stringToReplace: 'foo', replaceWithEnv: 'FOO_REPLACEMENT' },

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -36,7 +36,7 @@ class TestTransformer extends BaseMetadataTransformer {
   // partial implementation only for tests
   // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
   public async toSourceFormat(component: SourceComponent, mergeWith?: SourceComponent): Promise<WriteInfo[]> {
-    const output = mergeWith ? mergeWith.content || mergeWith.xml : '/type/file.s';
+    const output = mergeWith ? mergeWith.content ?? mergeWith.xml : '/type/file.s';
     assert(output);
     return [{ output, source: new Readable() }];
   }

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -10,7 +10,7 @@ import { Readable, Writable } from 'stream';
 import * as fs from 'graceful-fs';
 import * as archiver from 'archiver';
 import { Logger, SfError, Messages } from '@salesforce/core';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
 import * as streams from '../../src/convert/streams';
 import * as fsUtil from '../../src/utils/fileSystemHandler';
@@ -37,6 +37,7 @@ class TestTransformer extends BaseMetadataTransformer {
   // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
   public async toSourceFormat(component: SourceComponent, mergeWith?: SourceComponent): Promise<WriteInfo[]> {
     const output = mergeWith ? mergeWith.content || mergeWith.xml : '/type/file.s';
+    assert(output);
     return [{ output, source: new Readable() }];
   }
 }
@@ -66,8 +67,9 @@ describe('Streams', () => {
       );
       // convert overrides node's Transform _transform method
       // eslint-disable-next-line no-underscore-dangle
-      converter._transform(component, '', (err: Error) => {
+      converter._transform(component, '', (err: Error | undefined) => {
         try {
+          assert(err instanceof Error);
           expect(err.message).to.equal(expectedError.message);
           expect(err.name).to.equal(expectedError.name);
           done();
@@ -81,7 +83,7 @@ describe('Streams', () => {
       const converter = new streams.ComponentConverter('metadata', registryAccess);
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      converter._transform(component, '', async (err: Error, data: WriterFormat) => {
+      converter._transform(component, '', async (err: Error | undefined, data: WriterFormat) => {
         try {
           expect(err).to.be.undefined;
           expect(data).to.deep.equal({
@@ -99,7 +101,7 @@ describe('Streams', () => {
       const converter = new streams.ComponentConverter('source', registryAccess);
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      converter._transform(component, '', async (err: Error, data: WriterFormat) => {
+      converter._transform(component, '', async (err: Error | undefined, data: WriterFormat) => {
         try {
           expect(err).to.be.undefined;
           expect(data).to.deep.equal({
@@ -126,7 +128,7 @@ describe('Streams', () => {
       const converter = new streams.ComponentConverter('source', registryAccess, mergeSet);
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      converter._transform(newComponent, '', async (err: Error, data: WriterFormat) => {
+      converter._transform(newComponent, '', async (err: Error | undefined, data: WriterFormat) => {
         try {
           expect(err).to.be.undefined;
           expect(data).to.deep.equal({
@@ -155,7 +157,7 @@ describe('Streams', () => {
       const converter = new streams.ComponentConverter('source', registryAccess, mergeSet);
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      converter._transform(newComponent, '', async (err: Error, data: WriterFormat) => {
+      converter._transform(newComponent, '', async (err: Error | undefined, data: WriterFormat) => {
         try {
           expect(err).to.be.undefined;
           expect(data).to.deep.equal({
@@ -181,7 +183,7 @@ describe('Streams', () => {
       const converter = new streams.ComponentConverter('source', registryAccess);
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises, @typescript-eslint/require-await
-      converter._transform(myComp, '', async (err: Error, data: WriterFormat) => {
+      converter._transform(myComp, '', async (err: Error | undefined, data: WriterFormat) => {
         try {
           expect(err).to.be.undefined;
           expect(data).to.deep.equal({
@@ -230,7 +232,7 @@ describe('Streams', () => {
         const expectedError = new Error('whoops');
         env.stub(converter.context, 'executeFinalizers').throws(expectedError);
 
-        await converter._flush((err: Error) => expect(err).to.deep.equal(expectedError));
+        await converter._flush((err: Error | undefined) => expect(err).to.deep.equal(expectedError));
       });
     });
   });
@@ -244,6 +246,9 @@ describe('Streams', () => {
       readableMock.push('hi');
       readableMock.push(null);
     };
+    assert(COMPONENT.xml);
+    assert(COMPONENT.content);
+
     const component = SourceComponent.createVirtualComponent(COMPONENT, [
       {
         dirPath: TYPE_DIRECTORY,
@@ -258,6 +263,8 @@ describe('Streams', () => {
         children: [basename(COMPONENT.xml), basename(COMPONENT.content)],
       },
     ]);
+    assert(component.xml);
+    assert(component.content);
     const chunk: WriterFormat = {
       component,
       writeInfos: [
@@ -300,7 +307,8 @@ describe('Streams', () => {
         const whoops = new Error('whoops!');
         pipelineStub.rejects(whoops);
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
+          assert(err instanceof Error);
           expect(err.message).to.equal(whoops.message);
           expect(err.name).to.equal(whoops.name);
         });
@@ -310,8 +318,10 @@ describe('Streams', () => {
         pipelineStub.resolves();
         const root = join(rootDestination, COMPONENT.type.directoryName);
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
+          assert(COMPONENT.xml);
+          assert(COMPONENT.content);
           expect(ensureFile.firstCall.args[0]).to.equal(join(root, basename(COMPONENT.xml)));
           expect(ensureFile.secondCall.args[0]).to.equal(join(root, basename(COMPONENT.content)));
           expect(pipelineStub.firstCall.args).to.deep.equal([chunk.writeInfos[0].source, fsWritableMock]);
@@ -320,7 +330,8 @@ describe('Streams', () => {
 
       it('should use full paths of WriteInfo output if they are absolute during copy', async () => {
         pipelineStub.resolves();
-
+        assert(component.xml);
+        assert(component.content);
         const formatWithAbsoluteOutput: WriterFormat = {
           component,
           writeInfos: [
@@ -335,7 +346,7 @@ describe('Streams', () => {
           ],
         };
 
-        await writer._write(formatWithAbsoluteOutput, '', (err: Error) => {
+        await writer._write(formatWithAbsoluteOutput, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
           expect(ensureFile.firstCall.args).to.deep.equal([formatWithAbsoluteOutput.writeInfos[0].output]);
           expect(ensureFile.secondCall.args).to.deep.equal([formatWithAbsoluteOutput.writeInfos[1].output]);
@@ -349,7 +360,7 @@ describe('Streams', () => {
       it('should resolve copied source components during write', async () => {
         pipelineStub.resolves();
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
           const destination = join(rootDestination, component.type.directoryName);
           const expected = resolver.getComponentsFromPath(destination);
@@ -365,7 +376,7 @@ describe('Streams', () => {
           writeInfos: [],
         };
 
-        await writer._write(emptyChunk, '', (err: Error) => {
+        await writer._write(emptyChunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
           expect(ensureFile.notCalled).to.be.true;
           expect(pipelineStub.notCalled).to.be.true;
@@ -376,7 +387,8 @@ describe('Streams', () => {
       it('should skip duplicate components in WriteInfos', async () => {
         pipelineStub.resolves();
         const loggerStub = env.stub(Logger.prototype, 'debug');
-
+        assert(COMPONENT.xml);
+        assert(COMPONENT.content);
         const dupedComponent = SourceComponent.createVirtualComponent(COMPONENT, [
           {
             dirPath: TYPE_DIRECTORY,
@@ -398,6 +410,7 @@ describe('Streams', () => {
           children: registryAccess.getTypeByName('customobject').children,
         };
 
+        assert(component.xml);
         const compWriteInfo: WriteInfo = {
           output: dupedComponent.getPackageRelativePath(component.xml, 'metadata'),
           source: readableMock,
@@ -409,7 +422,7 @@ describe('Streams', () => {
 
         // The chunk has 2 identical components. The dupe should be
         // ignored so that it only writes once to compensate for W-9614275
-        await writer._write(chunkWithDupe, '', (err: Error) => {
+        await writer._write(chunkWithDupe, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
           expect(ensureFile.calledOnce).to.be.true;
           expect(pipelineStub.calledOnce).to.be.true;
@@ -441,7 +454,7 @@ describe('Streams', () => {
         const appendStub = env.stub(archive, 'append');
         env.stub(streams, 'stream2buffer').resolves(Buffer.from('hi'));
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
         expect(appendStub.firstCall.args[0].toString()).to.equal('hi');
@@ -452,7 +465,7 @@ describe('Streams', () => {
         const appendStub = env.stub(archive, 'append');
         env.stub(streams, 'stream2buffer').resolves(Buffer.from('hi'));
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
         expect(appendStub.firstCall.args[0].toString()).to.equal('hi');
@@ -461,14 +474,14 @@ describe('Streams', () => {
       it('should finalize zip when stream is finished', async () => {
         const finalizeStub = env.stub(archive, 'finalize').resolves();
 
-        await writer._final((err: Error) => {
+        await writer._final((err: Error | undefined) => {
           expect(err).to.be.undefined;
           expect(finalizeStub.calledOnce).to.be.true;
         });
       });
 
       it('should write zip to buffer if no fs destination given', async () => {
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
         await writer._final(() => {
@@ -481,7 +494,8 @@ describe('Streams', () => {
         env.stub(archive, 'append').throws(whoops);
         env.stub(streams, 'stream2buffer').resolves(Buffer.from('hi'));
 
-        await writer._write(chunk, '', (err: Error) => {
+        await writer._write(chunk, '', (err: Error | undefined) => {
+          assert(err instanceof Error);
           expect(err.message).to.equal(whoops.message);
           expect(err.name).to.equal(whoops.name);
         });
@@ -491,7 +505,8 @@ describe('Streams', () => {
         const whoops = new Error('whoops!');
         env.stub(archive, 'finalize').throws(whoops);
 
-        await writer._final((err: Error) => {
+        await writer._final((err: Error | undefined) => {
+          assert(err instanceof Error);
           expect(err.message).to.equal(whoops.message);
           expect(err.name).to.equal(whoops.name);
         });

--- a/test/convert/transformers/defaultMetadataTransformer.test.ts
+++ b/test/convert/transformers/defaultMetadataTransformer.test.ts
@@ -6,7 +6,7 @@
  */
 import { basename, join } from 'path';
 import { createSandbox } from 'sinon';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { bundle, document, matchingContentFile, nestedTypes, xmlInFolder } from '../../mock';
 import { DefaultMetadataTransformer } from '../../../src/convert/transformers/defaultMetadataTransformer';
 import { registry, RegistryAccess, SourceComponent, VirtualTreeContainer, WriteInfo } from '../../../src';
@@ -29,6 +29,7 @@ describe('DefaultMetadataTransformer', () => {
   describe('toMetadataFormat', () => {
     it('should create a WriteInfo for each file in the component', async () => {
       const component = bundle.COMPONENT;
+      assert(typeof component.xml === 'string');
       const { directoryName } = component.type;
       const relativeBundle = join(directoryName, basename(bundle.CONTENT_PATH));
       const expectedInfos: WriteInfo[] = [];
@@ -48,6 +49,8 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should strip the -meta.xml suffix for components with no content', async () => {
       const component = SourceComponent.createVirtualComponent(xmlInFolder.COMPONENTS[0], []);
+      assert(typeof component.xml === 'string');
+
       const { directoryName } = component.type;
       const fileName = `${component.fullName}.${component.type.suffix}`;
       const expectedInfos: WriteInfo[] = [
@@ -62,6 +65,8 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should remove the -meta.xml suffix for components with no content and in folders', async () => {
       const component = SourceComponent.createVirtualComponent(xmlInFolder.COMPONENTS[0], []);
+      assert(typeof component.xml === 'string');
+
       const fullNameParts = component.fullName.split('/');
       const { directoryName } = component.type;
       const expectedInfos: WriteInfo[] = [
@@ -87,6 +92,8 @@ describe('DefaultMetadataTransformer', () => {
           `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`
         ),
       });
+      assert(typeof component.xml === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           source: component.tree.stream(component.xml),
@@ -98,6 +105,8 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should remove file extension and preserve -meta.xml for folder components', async () => {
       const component = FOLDER_COMPONENT;
+      assert(typeof component.xml === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           output: join(component.type.directoryName, `${component.fullName}${META_XML_SUFFIX}`),
@@ -110,6 +119,9 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should replace document suffix with original suffix', async () => {
       const component = SourceComponent.createVirtualComponent(document.COMPONENT_MD, document.COMPONENT_VIRTUAL_FS);
+      assert(typeof component.xml === 'string');
+      assert(typeof component.content === 'string');
+
       const outputPath = join(component.type.directoryName, component.fullName);
       const expectedInfos: WriteInfo[] = [
         {
@@ -128,6 +140,8 @@ describe('DefaultMetadataTransformer', () => {
     it('should handle nested components (parent)', async () => {
       // ex: territory2Models/someModel/
       const component = nestedTypes.NESTED_PARENT_COMPONENT;
+      assert(typeof component.xml === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           output: join(
@@ -145,6 +159,9 @@ describe('DefaultMetadataTransformer', () => {
     it('should handle nested components (children)', async () => {
       // ex: territory2Models/someModel/rules/someRule.Territory2Rule-meta.xml
       const component = nestedTypes.NESTED_CHILD_COMPONENT;
+      assert(typeof component.xml === 'string');
+      assert(component.parentType);
+
       const expectedInfos: WriteInfo[] = [
         {
           output: join(
@@ -164,6 +181,8 @@ describe('DefaultMetadataTransformer', () => {
   describe('toSourceFormat', () => {
     it('should create a WriteInfo for each file in the component', async () => {
       const component = bundle.COMPONENT;
+      assert(typeof component.xml === 'string');
+
       const { directoryName } = component.type;
       const relativeBundle = join(DEFAULT_PACKAGE_ROOT_SFDX, directoryName, basename(bundle.CONTENT_PATH));
       const expectedInfos: WriteInfo[] = [];
@@ -183,6 +202,8 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should add in the -meta.xml suffix for components with no content', async () => {
       const component = SourceComponent.createVirtualComponent(xmlInFolder.COMPONENTS_MD_FORMAT[0], []);
+      assert(typeof component.xml === 'string');
+
       const { directoryName } = component.type;
       const fileName = `${component.fullName}.${component.type.suffix}${META_XML_SUFFIX}`;
       const expectedInfos: WriteInfo[] = [
@@ -197,6 +218,8 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should handle components in folders with no content', async () => {
       const component = SourceComponent.createVirtualComponent(xmlInFolder.COMPONENTS_MD_FORMAT[0], []);
+      assert(typeof component.xml === 'string');
+
       const fullNameParts = component.fullName.split('/');
       const { directoryName } = component.type;
       const expectedInfos: WriteInfo[] = [
@@ -226,6 +249,8 @@ describe('DefaultMetadataTransformer', () => {
           `foo.${registry.types.digitalexperiencebundle.suffix}${META_XML_SUFFIX}`
         ),
       });
+      assert(typeof component.xml === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           source: component.tree.stream(component.xml),
@@ -243,6 +268,9 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should handle folder components', async () => {
       const component = FOLDER_COMPONENT_MD_FORMAT;
+      assert(typeof component.type.folderContentType === 'string');
+      assert(typeof component.xml === 'string');
+
       const registryAccess = new RegistryAccess();
       const { directoryName } = registryAccess.getTypeByName(component.type.folderContentType);
       const expectedInfos: WriteInfo[] = [
@@ -260,6 +288,7 @@ describe('DefaultMetadataTransformer', () => {
     });
 
     it('should merge output with merge component when content is a directory', async () => {
+      assert(typeof bundle.COMPONENT.name === 'string');
       const root = join('path', 'to', 'another', bundle.COMPONENT.type.directoryName, bundle.COMPONENT.name);
       const component = SourceComponent.createVirtualComponent(
         {
@@ -276,6 +305,8 @@ describe('DefaultMetadataTransformer', () => {
         ]
       );
       const mergeWith = bundle.COMPONENT;
+      assert(typeof mergeWith.content === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           output: join(mergeWith.content, 'b.c'),
@@ -311,6 +342,9 @@ describe('DefaultMetadataTransformer', () => {
         ]
       );
       const mergeWith = matchingContentFile.COMPONENT;
+      assert(typeof mergeWith.content === 'string');
+      assert(typeof mergeWith.xml === 'string');
+
       const expectedInfos: WriteInfo[] = [
         {
           output: mergeWith.content,
@@ -327,6 +361,7 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should use merge component xml path', async () => {
       const mergeWith = xmlInFolder.COMPONENTS[0];
+      assert(typeof mergeWith.xml === 'string');
       const component = SourceComponent.createVirtualComponent(
         {
           name: mergeWith.name,
@@ -335,7 +370,7 @@ describe('DefaultMetadataTransformer', () => {
         },
         []
       );
-
+      assert(typeof component.xml === 'string');
       expect(await transformer.toSourceFormat(component, mergeWith)).to.deep.contain({
         output: mergeWith.xml,
         source: component.tree.stream(component.xml),
@@ -351,6 +386,7 @@ describe('DefaultMetadataTransformer', () => {
         },
         []
       );
+      assert(typeof component.xml === 'string');
 
       expect(await transformer.toSourceFormat(component, mergeWith)).to.deep.contain({
         output: component.getPackageRelativePath(component.xml, 'source'),
@@ -360,14 +396,17 @@ describe('DefaultMetadataTransformer', () => {
 
     it('should replace original suffix with type suffix', async () => {
       const component = SourceComponent.createVirtualComponent(document.COMPONENT, document.COMPONENT_VIRTUAL_FS);
+      assert(typeof component.xml === 'string');
+      assert(typeof component.content === 'string');
+
       const outputPath = join(DEFAULT_PACKAGE_ROOT_SFDX, component.type.directoryName, component.fullName);
       const expectedInfos: WriteInfo[] = [
         {
-          output: outputPath + '.' + extName(component.content),
+          output: `${outputPath}.${extName(component.content)}`,
           source: component.tree.stream(component.content),
         },
         {
-          output: outputPath + '.' + component.type.suffix + META_XML_SUFFIX,
+          output: `${outputPath}.${component.type.suffix}${META_XML_SUFFIX}`,
           source: component.tree.stream(component.xml),
         },
       ];

--- a/test/convert/transformers/metadataTransformerFactory.test.ts
+++ b/test/convert/transformers/metadataTransformerFactory.test.ts
@@ -74,7 +74,7 @@ describe('MetadataTransformerFactory', () => {
     assert.throws(
       () => factory.getTransformer(component),
       SfError,
-      messages.getMessage('error_missing_transformer', [type.name, type.strategies.transformer])
+      messages.getMessage('error_missing_transformer', [type.name, type.strategies?.transformer])
     );
   });
 });

--- a/test/mock/manifestConstants.ts
+++ b/test/mock/manifestConstants.ts
@@ -88,7 +88,7 @@ export const ONE_PARTIAL_WILDCARD: VirtualFile = {
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
         <members>site/foo.*</members>
-        <name>${registry.types.digitalexperiencebundle.children.types.digitalexperience.name}</name>
+        <name>${registry.types.digitalexperiencebundle.children?.types.digitalexperience.name}</name>
     </types>
     <version>${testApiVersionAsString}</version>
 </Package>\n`),

--- a/test/mock/type-constants/customObjectConstant.ts
+++ b/test/mock/type-constants/customObjectConstant.ts
@@ -5,12 +5,16 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
+import { assert } from 'chai';
 import { baseName } from '../../../src/utils';
 import { registry, SourceComponent, VirtualDirectory } from '../../../src';
 import { XML_NS_URL } from '../../../src/common';
 
 // Constants for a decomposed type
 const type = registry.types.customobject;
+// 2 asserts to guard againt future changes to the registry (TS needs these to trust it, since registry is mushy JSON, not a static type)
+assert(type.children?.types.validationrule);
+assert(type.children.types.customfield);
 
 export const DECOMPOSEDS_PATH = join('path', 'to', 'objects');
 export const DECOMPOSED_PATH = join(DECOMPOSEDS_PATH, 'customObject__c');
@@ -65,6 +69,7 @@ export const DECOMPOSED_COMPONENT = SourceComponent.createVirtualComponent(
   },
   DECOMPOSED_VIRTUAL_FS
 );
+
 export const DECOMPOSED_CHILD_COMPONENT_1 = SourceComponent.createVirtualComponent(
   {
     name: baseName(DECOMPOSED_CHILD_XML_NAME_1),

--- a/test/mock/type-constants/digitalExperienceBundleConstants.ts
+++ b/test/mock/type-constants/digitalExperienceBundleConstants.ts
@@ -5,14 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
+import { assert } from 'chai';
 import { registry, SourceComponent } from '../../../src';
 import { META_XML_SUFFIX } from '../../../src/common';
 
-export const DE_TYPE = registry.types.digitalexperiencebundle.children.types.digitalexperience;
+export const DE_TYPE = registry.types.digitalexperiencebundle.children?.types.digitalexperience;
+assert(DE_TYPE);
 export const DEB_TYPE = registry.types.digitalexperiencebundle;
 
 // metaFileName = metaFileSuffix for DigitalExperience.
 export const DE_METAFILE = DE_TYPE.metaFileSuffix;
+assert(typeof DE_METAFILE === 'string');
 
 export const BUNDLE_NAME = join('site', 'foo');
 export const BUNDLE_FULL_NAME = BUNDLE_NAME;

--- a/test/nuts/local/replacements/replacements.nut.ts
+++ b/test/nuts/local/replacements/replacements.nut.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { Open } from 'unzipper';
 import { TestSession } from '@salesforce/cli-plugins-testkit';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { ComponentSetBuilder, MetadataConverter } from '../../../../src';
 
 describe('e2e replacements test', () => {
@@ -48,7 +48,7 @@ describe('e2e replacements test', () => {
       const { zipBuffer } = await converter.convert(cs, 'metadata', {
         type: 'zip',
       });
-      expect(zipBuffer).to.not.be.undefined;
+      assert(zipBuffer, 'zipBuffer should be defined');
       await (await Open.buffer(zipBuffer)).extract({ path: path.join(session.project.dir, 'unzipped') });
     });
 

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 220.73954499998945
+    "duration": 220.5309910000069
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8764.579136
+    "duration": 4492.38378199999
   },
   {
     "name": "sourceToZip",
-    "duration": 4817.994116999995
+    "duration": 4092.074657000019
   },
   {
     "name": "mdapiToSource",
-    "duration": 3999.1985480000003
+    "duration": 3848.1475029999856
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 440.0365330000059
+    "duration": 445.5382540000137
   },
   {
     "name": "sourceToMdapi",
-    "duration": 8547.088470999995
+    "duration": 8276.800906000019
   },
   {
     "name": "sourceToZip",
-    "duration": 7158.503278999997
+    "duration": 6884.491367999988
   },
   {
     "name": "mdapiToSource",
-    "duration": 4846.582094999991
+    "duration": 4920.062658999988
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8272CL-CPU-2-60GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 765.1924759999965
+    "duration": 778.979272000026
   },
   {
     "name": "sourceToMdapi",
-    "duration": 12505.445792999992
+    "duration": 12468.194125999988
   },
   {
     "name": "sourceToZip",
-    "duration": 10468.818727000005
+    "duration": 15476.20274899999
   },
   {
     "name": "mdapiToSource",
-    "duration": 8742.701778000017
+    "duration": 8798.90843499999
   }
 ]

--- a/test/registry/registryAccess.test.ts
+++ b/test/registry/registryAccess.test.ts
@@ -29,7 +29,7 @@ describe('RegistryAccess', () => {
 
     it('should fetch child type definition', () => {
       expect(registryAccess.getTypeByName('customfield')).to.deep.equal(
-        registry.types.customobject.children.types.customfield
+        registry.types.customobject.children?.types.customfield
       );
     });
 
@@ -45,6 +45,7 @@ describe('RegistryAccess', () => {
   describe('getTypeBySuffix', () => {
     it('should get known type by suffix', () => {
       const type = registry.types.apexclass;
+      assert(type.suffix, 'Type should have a suffix defined for this test to work.');
       expect(registryAccess.getTypeBySuffix(type.suffix)).to.deep.equal(type);
     });
 
@@ -94,6 +95,8 @@ describe('RegistryAccess', () => {
 
   describe('getParentType', () => {
     it('should return a valid parent for a child metadata type', () => {
+      assert(registry.types.digitalexperiencebundle.children?.types.digitalexperience.id);
+      assert(registry.types.customobject.children?.types.customfield.id);
       expect(
         registryAccess.getParentType(registry.types.digitalexperiencebundle.children.types.digitalexperience.id)
       ).to.be.equal(registry.types.digitalexperiencebundle);

--- a/test/resolve/adapters/baseSourceAdapter.test.ts
+++ b/test/resolve/adapters/baseSourceAdapter.test.ts
@@ -26,6 +26,7 @@ class TestAdapter extends BaseSourceAdapter {
   }
 
   protected getRootMetadataXmlPath(): string {
+    assert(this.component.xml);
     return this.component.xml;
   }
   protected populate(): SourceComponent {
@@ -36,6 +37,7 @@ class TestAdapter extends BaseSourceAdapter {
 describe('BaseSourceAdapter', () => {
   it('should reformat the fullName for folder types', () => {
     const component = xmlInFolder.COMPONENTS[0];
+    assert(component.xml);
     const adapter = new TestAdapter(component);
 
     const result = adapter.getComponent(component.xml);
@@ -46,6 +48,7 @@ describe('BaseSourceAdapter', () => {
   it('should defer parsing metadata xml to child adapter if path is not a metadata xml', () => {
     const component = mixedContentSingleFile.COMPONENT;
     const adapter = new TestAdapter(component);
+    assert(component.content);
 
     const result = adapter.getComponent(component.content);
 
@@ -55,7 +58,7 @@ describe('BaseSourceAdapter', () => {
   it('should defer parsing metadata xml to child adapter if path is not a root metadata xml', () => {
     const component = decomposed.DECOMPOSED_CHILD_COMPONENT_1;
     const adapter = new TestAdapter(component);
-
+    assert(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
     const result = adapter.getComponent(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
 
     expect(result).to.deep.equal(component);
@@ -81,6 +84,7 @@ describe('BaseSourceAdapter', () => {
 
   it('should resolve a folder component in metadata format', () => {
     const component = xmlInFolder.FOLDER_COMPONENT_MD_FORMAT;
+    assert(component.xml);
     const adapter = new DefaultSourceAdapter(component.type, undefined);
 
     expect(adapter.getComponent(component.xml)).to.deep.equal(component);
@@ -93,6 +97,8 @@ describe('BaseSourceAdapter', () => {
       xml: join(xmlInFolder.TYPE_DIRECTORY, 'subfolder', `${xmlInFolder.COMPONENT_FOLDER_NAME}${META_XML_SUFFIX}`),
       parentType: registry.types.documentfolder,
     });
+    assert(component.xml);
+
     const adapter = new DefaultSourceAdapter(component.type);
 
     expect(adapter.getComponent(component.xml)).to.deep.equal(component);
@@ -108,24 +114,35 @@ describe('BaseSourceAdapter', () => {
 
   describe('handling nested types (Territory2Model)', () => {
     // mocha was throwing errors about private property _tree not matching
-    const sourceComponentKeys = ['type', 'name', 'xml', 'parent', 'parentType', 'content'];
+    const sourceComponentKeys: Array<keyof SourceComponent> = [
+      'type',
+      'name',
+      'xml',
+      'parent',
+      'parentType',
+      'content',
+    ];
 
     it('should resolve the parent name and type', () => {
       const component = nestedTypes.NESTED_PARENT_COMPONENT;
+      assert(component.xml);
+
       const adapter = new DefaultSourceAdapter(component.type);
       const componentFromAdapter = adapter.getComponent(component.xml);
-      sourceComponentKeys.map((prop: keyof SourceComponent) =>
-        expect(componentFromAdapter[prop]).to.deep.equal(component[prop])
-      );
+      assert(componentFromAdapter);
+
+      sourceComponentKeys.map((prop) => expect(componentFromAdapter[prop]).to.deep.equal(component[prop]));
     });
 
     it('should resolve the child name and type AND parentType', () => {
       const component = nestedTypes.NESTED_CHILD_COMPONENT;
+      assert(component.xml);
       const adapter = new DefaultSourceAdapter(component.type);
       const componentFromAdapter = adapter.getComponent(component.xml);
-      sourceComponentKeys.map((prop: keyof SourceComponent) =>
-        expect(componentFromAdapter[prop]).to.deep.equal(component[prop])
-      );
+      assert(componentFromAdapter);
+      sourceComponentKeys.map((prop) => {
+        expect(componentFromAdapter[prop]).to.deep.equal(component[prop]);
+      });
     });
   });
 });

--- a/test/resolve/adapters/baseSourceAdapter.test.ts
+++ b/test/resolve/adapters/baseSourceAdapter.test.ts
@@ -8,7 +8,14 @@ import { join } from 'path';
 import { Messages, SfError } from '@salesforce/core';
 
 import { assert, expect } from 'chai';
-import { decomposed, matchingContentFile, mixedContentSingleFile, nestedTypes, xmlInFolder } from '../../mock';
+import {
+  decomposed,
+  matchingContentFile,
+  mixedContentSingleFile,
+  nestedTypes,
+  xmlInFolder,
+  document,
+} from '../../mock';
 import { BaseSourceAdapter, DefaultSourceAdapter } from '../../../src/resolve/adapters';
 import { META_XML_SUFFIX } from '../../../src/common';
 import { RegistryTestUtil } from '../registryTestUtil';
@@ -90,11 +97,11 @@ describe('BaseSourceAdapter', () => {
     expect(adapter.getComponent(component.xml)).to.deep.equal(component);
   });
 
-  it('should resolve a nested folder component in metadata format', () => {
+  it('should resolve a nested folder component in metadata format (document)', () => {
     const component = new SourceComponent({
-      name: undefined,
+      name: `subfolder/${document.COMPONENT_FOLDER_NAME}`,
       type: registry.types.document,
-      xml: join(xmlInFolder.TYPE_DIRECTORY, 'subfolder', `${xmlInFolder.COMPONENT_FOLDER_NAME}${META_XML_SUFFIX}`),
+      xml: join(document.DOCUMENTS_DIRECTORY, 'subfolder', `${document.COMPONENT_FOLDER_NAME}${META_XML_SUFFIX}`),
       parentType: registry.types.documentfolder,
     });
     assert(component.xml);

--- a/test/resolve/adapters/decomposedSourceAdapter.test.ts
+++ b/test/resolve/adapters/decomposedSourceAdapter.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { DecomposedSourceAdapter, DefaultSourceAdapter } from '../../../src/resolve/adapters';
 import { decomposed, decomposedtoplevel, xmlInFolder } from '../../mock';
 import { registry, RegistryAccess, SourceComponent, VirtualTreeContainer } from '../../../src';
@@ -64,8 +64,7 @@ describe('DecomposedSourceAdapter', () => {
       { name: decomposed.DECOMPOSED_COMPONENT.name, type, content: decomposed.DECOMPOSED_PATH },
       tree
     );
-
-    expect(adapter.getComponent(decomposed.DECOMPOSED_CHILD_XML_PATH_2).parent).to.deep.equal(expectedParent);
+    expect(adapter.getComponent(decomposed.DECOMPOSED_CHILD_XML_PATH_2)?.parent).to.deep.equal(expectedParent);
   });
 
   it('should return expected SourceComponent when given a topLevel parent component', () => {
@@ -78,13 +77,14 @@ describe('DecomposedSourceAdapter', () => {
 
   it('should defer parsing metadata xml to child adapter if path is not a root metadata xml', () => {
     const component = decomposed.DECOMPOSED_CHILD_COMPONENT_1;
+    assert(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
     const result = adapter.getComponent(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
 
     expect(result).to.deep.equal(component);
   });
 
   it('should NOT throw an error if a parent metadata xml file is forceignored', () => {
-    let testUtil;
+    let testUtil: RegistryTestUtil | undefined;
     try {
       const path = join('path', 'to', type.directoryName, `My_Test.${type.suffix}${META_XML_SUFFIX}`);
 
@@ -101,12 +101,13 @@ describe('DecomposedSourceAdapter', () => {
     } catch (e) {
       expect(e).to.be.undefined;
     } finally {
-      testUtil.restore();
+      testUtil?.restore();
     }
   });
 
   it('should resolve a folder component in metadata format', () => {
     const component = xmlInFolder.FOLDER_COMPONENT_MD_FORMAT;
+    assert(component.xml);
     const adapter = new DefaultSourceAdapter(component.type, registryAccess);
 
     expect(adapter.getComponent(component.xml)).to.deep.equal(component);

--- a/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
+++ b/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { RegistryAccess, registry, VirtualTreeContainer, ForceIgnore, SourceComponent } from '../../../src';
 import { DigitalExperienceSourceAdapter } from '../../../src/resolve/adapters/digitalExperienceSourceAdapter';
 import { META_XML_SUFFIX } from '../../../src/common';
@@ -21,6 +21,7 @@ describe('DigitalExperienceSourceAdapter', () => {
   const HOME_VIEW_NAME = join('sfdc_cms__view', 'home');
   const HOME_VIEW_PATH = join(BUNDLE_PATH, HOME_VIEW_NAME);
   const HOME_VIEW_CONTENT_FILE = join(HOME_VIEW_PATH, 'content.json');
+  assert(typeof DE_METAFILE === 'string');
   const HOME_VIEW_META_FILE = join(HOME_VIEW_PATH, DE_METAFILE);
   const HOME_VIEW_FRENCH_VARIANT_FILE = join(HOME_VIEW_PATH, 'fr.json');
 
@@ -40,6 +41,7 @@ describe('DigitalExperienceSourceAdapter', () => {
     tree
   );
 
+  assert(registry.types.digitalexperiencebundle.children?.types.digitalexperience);
   const digitalExperienceAdapter = new DigitalExperienceSourceAdapter(
     registry.types.digitalexperiencebundle.children.types.digitalexperience,
     registryAccess,
@@ -74,6 +76,7 @@ describe('DigitalExperienceSourceAdapter', () => {
   });
 
   describe('DigitalExperienceSourceAdapter for DE', () => {
+    assert(registry.types.digitalexperiencebundle.children?.types.digitalexperience);
     const component = new SourceComponent(
       {
         name: HOME_VIEW_NAME,

--- a/test/resolve/adapters/mixedContentSourceAdapter.test.ts
+++ b/test/resolve/adapters/mixedContentSourceAdapter.test.ts
@@ -9,6 +9,7 @@ import { assert, expect } from 'chai';
 import * as fs from 'graceful-fs';
 import { Messages, SfError } from '@salesforce/core';
 import { createSandbox } from 'sinon';
+import { ensureString } from '@salesforce/ts-types';
 import { MixedContentSourceAdapter } from '../../../src/resolve/adapters';
 import { ForceIgnore, registry, RegistryAccess, SourceComponent, VirtualTreeContainer } from '../../../src';
 import {
@@ -33,7 +34,7 @@ describe('MixedContentSourceAdapter', () => {
     ]);
     const adapter = new MixedContentSourceAdapter(type, registryAccess, undefined, tree);
     assert.throws(
-      () => adapter.getComponent(mixedContentSingleFile.COMPONENT.content),
+      () => adapter.getComponent(ensureString(mixedContentSingleFile.COMPONENT.content)),
       SfError,
       messages.getMessage('error_expected_source_files', [mixedContentSingleFile.CONTENT_PATHS[0], type.name])
     );
@@ -49,7 +50,7 @@ describe('MixedContentSourceAdapter', () => {
     const adapter = new MixedContentSourceAdapter(type, registryAccess, new ForceIgnore(forceIgnorePath), tree);
     env.restore();
     assert.throws(
-      () => adapter.getComponent(mixedContentSingleFile.COMPONENT.content),
+      () => adapter.getComponent(ensureString(mixedContentSingleFile.COMPONENT.content)),
       SfError,
       messages.getMessage('error_expected_source_files', [mixedContentSingleFile.CONTENT_PATHS[0], type.name])
     );
@@ -65,14 +66,14 @@ describe('MixedContentSourceAdapter', () => {
     );
 
     it('Should return expected SourceComponent when given a root metadata xml path', () => {
+      assert(component.xml);
       const result = adapter.getComponent(component.xml);
-
       expect(result).to.deep.equal(component);
     });
 
     it('Should return expected SourceComponent when given a source path', () => {
+      assert(component.content);
       const result = adapter.getComponent(component.content);
-
       expect(result).to.deep.equal(component);
     });
   });

--- a/test/resolve/adapters/sourceAdapterFactory.test.ts
+++ b/test/resolve/adapters/sourceAdapterFactory.test.ts
@@ -27,8 +27,8 @@ const messages = Messages.load('@salesforce/source-deploy-retrieve', 'sdr', ['er
  */
 describe('SourceAdapterFactory', () => {
   const tree = new VirtualTreeContainer([]);
-  const factory = new SourceAdapterFactory(undefined, tree);
   const registryAccess = new RegistryAccess();
+  const factory = new SourceAdapterFactory(registryAccess, tree);
 
   it('Should return DefaultSourceAdapter for type with no assigned AdapterId', () => {
     const type = registry.types.reportfolder;
@@ -56,6 +56,8 @@ describe('SourceAdapterFactory', () => {
   });
 
   it('Should return DigitalExperienceSourceAdapter for digitalExperience AdapterId', () => {
+    assert(registry.types.digitalexperiencebundle.children?.types.digitalexperience);
+
     const type = registry.types.digitalexperiencebundle;
     const adapter = factory.getAdapter(type);
     expect(adapter).to.deep.equal(new DigitalExperienceSourceAdapter(type, registryAccess, undefined, tree));
@@ -89,7 +91,7 @@ describe('SourceAdapterFactory', () => {
     assert.throws(
       () => factory.getAdapter(type),
       SfError,
-      messages.getMessage('error_missing_adapter', [type.strategies.adapter, type.name])
+      messages.getMessage('error_missing_adapter', [type.strategies?.adapter, type.name])
     );
   });
 });

--- a/test/resolve/connectionResolver.test.ts
+++ b/test/resolve/connectionResolver.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
 import { Connection, Logger } from '@salesforce/core';
 import { ConnectionResolver } from '../../src/resolve';
@@ -71,6 +71,7 @@ describe('ConnectionResolver', () => {
 
       const resolver = new ConnectionResolver(connection);
       const result = await resolver.resolve();
+      assert(registry.types.customobject.children?.types.customfield);
       const expected: MetadataComponent[] = [
         {
           fullName: 'Account',

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -8,6 +8,7 @@
 import { basename, dirname, join } from 'path';
 import { assert, expect } from 'chai';
 import { Messages, SfError } from '@salesforce/core';
+import { ensureString } from '@salesforce/ts-types';
 import {
   ComponentSet,
   MetadataResolver,
@@ -206,6 +207,7 @@ describe('MetadataResolver', () => {
       it('Should determine type for DigitalExperience metadata file (_meta.json file)', () => {
         const parent = join('unpackaged', 'digitalExperiences', 'site', 'foo');
         const parent_meta_file = join(parent, 'foo.digitalExperience-meta.xml');
+        assert(DE_METAFILE);
         const path = join(parent, 'sfdc_cms__view', 'home', DE_METAFILE);
         const treeContainer = VirtualTreeContainer.fromFilePaths([path, parent_meta_file]);
         const mdResolver = new MetadataResolver(undefined, treeContainer);
@@ -217,6 +219,7 @@ describe('MetadataResolver', () => {
           },
           treeContainer
         );
+        assert(registry.types.digitalexperiencebundle.children?.types.digitalexperience);
         const expectedComponent = new SourceComponent(
           {
             name: join('sfdc_cms__view', 'home'),
@@ -276,7 +279,7 @@ describe('MetadataResolver', () => {
           },
         ]);
         const componentMappings = xmlInFolder.COMPONENTS.map((c: SourceComponent) => ({
-          path: c.xml,
+          path: ensureString(c.xml),
           component: c,
         }));
         testUtil.stubAdapters([
@@ -782,7 +785,7 @@ describe('MetadataResolver', () => {
         const resolver = testUtil.createMetadataResolver(decomposedtoplevel.DECOMPOSED_VIRTUAL_FS);
         const children = decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT.getChildren();
         const componentMappings = children.map((c: SourceComponent) => ({
-          path: c.xml,
+          path: ensureString(c.xml),
           component: c,
         }));
         componentMappings.push({

--- a/test/resolve/registryTestUtil.ts
+++ b/test/resolve/registryTestUtil.ts
@@ -48,7 +48,7 @@ export class RegistryTestUtil {
       }
       getAdapterStub.withArgs(entry.type).returns({
         getComponent: (path: SourcePath) => componentMap[path],
-        allowMetadataWithContent: () => entry.allowContent,
+        allowMetadataWithContent: () => entry.allowContent ?? false,
       });
     }
   }

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -66,7 +66,7 @@ describe('SourceComponent', () => {
   });
 
   it('should return correct markedForDelete status', () => {
-    const comp = new SourceComponent({ name: 'test', type: undefined });
+    const comp = new SourceComponent({ name: 'test', type: registry.types.apexclass });
     expect(comp.isMarkedForDelete()).to.be.false;
     expect(comp.getDestructiveChangesType()).to.equal(undefined);
 
@@ -90,6 +90,7 @@ describe('SourceComponent', () => {
   it('should return correct relative path for a nested component', () => {
     const registry = new RegistryAccess();
     const inFolderType = registry.getTypeBySuffix('report');
+    assert(inFolderType);
     const folderContentType = registry.getTypeByName('ReportFolder');
     expect(inFolderType.inFolder).to.be.true;
     expect(folderContentType.folderContentType).to.equal('report');
@@ -121,6 +122,8 @@ describe('SourceComponent', () => {
 
   it('should return correct relative path for DigitalExperience', () => {
     const registry = new RegistryAccess();
+    assert(typeof DE_METAFILE === 'string');
+
     const deType = registry.getTypeByName('DigitalExperience');
     const cmp = new SourceComponent({ name: deType.name, type: deType });
 
@@ -169,6 +172,7 @@ describe('SourceComponent', () => {
       try {
         await component.parseXml();
       } catch (e) {
+        assert(e instanceof Error);
         expect(e.message).to.include(`error parsing ${component.xml} due to:`);
         expect(e.message).to.include("message: Closing tag 'CustomLabels' can't have attributes or invalid starting.");
         expect(e.message).to.include('line: 1');
@@ -185,6 +189,8 @@ describe('SourceComponent', () => {
       try {
         component.parseXmlSync();
       } catch (e) {
+        assert(e instanceof Error);
+
         expect(e.message).to.include(`error parsing ${component.xml} due to:`);
         expect(e.message).to.include("message: Closing tag 'CustomLabels' can't have attributes or invalid starting.");
         expect(e.message).to.include('line: 1');
@@ -193,6 +199,7 @@ describe('SourceComponent', () => {
     });
 
     it('should parse the child components xml content to js object', async () => {
+      assert(registry.types.customlabels.children?.types.customlabel);
       const component = new SourceComponent({
         name: 'mylabel',
         type: registry.types.customlabels.children.types.customlabel,
@@ -340,6 +347,7 @@ describe('SourceComponent', () => {
 
   describe('Child Components', () => {
     const type = registry.types.customobject;
+    assert(type.children);
     const expectedChild = SourceComponent.createVirtualComponent(
       {
         name: 'Fields__c',
@@ -438,13 +446,14 @@ describe('SourceComponent', () => {
       );
 
       const result = adapter.getComponent(DECOMPOSED_TOP_LEVEL_CHILD_XML_PATHS[0], true);
-      expect(result.type).to.deep.equal(expectedTopLevel.type);
-      expect(result.xml).to.equal(expectedTopLevel.xml);
+      expect(result?.type).to.deep.equal(expectedTopLevel.type);
+      expect(result?.xml).to.equal(expectedTopLevel.xml);
     });
   });
 
   describe('Nondecomposed Child Components', () => {
     const type = registry.types.customlabels;
+    assert(type.children);
     const expectedChild = SourceComponent.createVirtualComponent(
       {
         name: CHILD_1_NAME,
@@ -481,6 +490,7 @@ describe('SourceComponent', () => {
     // https://github.com/forcedotcom/salesforcedx-vscode/issues/3210
     it('should return empty children for types that do not have uniqueIdElement but xmlPathToChildren returns elements', () => {
       const noUniqueIdElementType: MetadataType = JSON.parse(JSON.stringify(MATCHING_RULES_TYPE));
+      assert(noUniqueIdElementType.children);
       // remove the uniqueElementType for this test
       delete noUniqueIdElementType.children.types.matchingrule.uniqueIdElement;
       const noUniqueIdElementComponent = new SourceComponent(

--- a/test/resolve/treeContainers.test.ts
+++ b/test/resolve/treeContainers.test.ts
@@ -58,6 +58,7 @@ describe('Tree Containers', () => {
       }
 
       public stream(): Readable {
+        // @ts-expect-error it's a mock!
         return;
       }
     }
@@ -146,8 +147,8 @@ describe('Tree Containers', () => {
       };
       pipeline(archive, bufferWritable);
 
-      archive.append(null, { name: 'main/' });
-      archive.append(null, { name: 'main/default/' });
+      archive.append('', { name: 'main/' });
+      archive.append('', { name: 'main/default/' });
       archive.append('test text', { name: 'main/default/test.txt' });
       archive.append('test text 2', { name: 'main/default/test2.txt' });
       archive.append('test text 3', { name: 'main/default/morefiles/test3.txt' });
@@ -248,6 +249,7 @@ describe('Tree Containers', () => {
         const path = join(filesRoot, 'test.txt');
         const zipDir = await unzipper.Open.buffer(zipBuffer);
         const expectedStream = zipDir.files.find((f) => normalize(f.path) === path)?.stream();
+        assert(expectedStream);
         const actual = tree.stream(path);
         expect(actual instanceof Readable).to.be.true;
         expect((actual as unzipper.Entry).path).to.equal(expectedStream.path);
@@ -350,6 +352,7 @@ describe('Tree Containers', () => {
           await tree.readFile(path);
           assert.fail('should have thrown an error');
         } catch (e) {
+          assert(e instanceof Error);
           expect(e.message).to.deep.equal(messages.getMessage('error_path_not_found', [path]));
         }
       });
@@ -372,6 +375,7 @@ describe('Tree Containers', () => {
           tree.readFileSync(path);
           assert.fail('should have thrown an error');
         } catch (e) {
+          assert(e instanceof Error);
           expect(e.message).to.deep.equal(messages.getMessage('error_path_not_found', [path]));
         }
       });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@salesforce/dev-config/tsconfig-test",
+  "extends": "@salesforce/dev-config/tsconfig-test-strict",
   "include": ["./**/*.ts", "../src/registry/metadataRegistry.json", "../src/registry/stdValueSetRegistry.json"],
   "compilerOptions": {
     // Needed in order to import metadataRegistry.json

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -324,7 +324,7 @@ describe('generating virtual tree from component name/type', () => {
       expect(component.type.children).to.equal(undefined);
       const topLevelType = component.type.children
         ? component.type
-        : registryAccess.findType((t) => t.children && Object.keys(t.children.types).includes(component.type.id));
+        : registryAccess.findType((t) => Object.keys(t.children?.types ?? {}).includes(component.type.id));
       expect(topLevelType).to.deep.equal(registryAccess.getTypeByName('CustomObject'));
     });
 

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -222,7 +222,7 @@ describe('generating virtual tree from component name/type', () => {
     const resolver = new MetadataResolver(registryAccess, VirtualTreeContainer.fromFilePaths(filePaths));
 
     const components = resolver.getComponentsFromPath(packageDir);
-    const expectedComponentsSize = typeEntry.expectedComponents?.length || 1;
+    const expectedComponentsSize = typeEntry.expectedComponents?.length ?? 1;
     expect(components).to.have.lengthOf(expectedComponentsSize);
 
     for (let i = 0; i < expectedComponentsSize; i++) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@salesforce/dev-config/tsconfig",
+  "extends": "@salesforce/dev-config/tsconfig-strict",
   "compilerOptions": {
     // Needed in order to import metadataRegistry.json
     "resolveJsonModule": true,


### PR DESCRIPTION
### What does this PR do?
Almost all changes are to test classes.
Throws in a lot of asserts about the registry
- the MetadataRegistry is JSON, and the TS types from it are generic across all mdTypes
- therefore, TS can't know that the mdTypes have children (for example).  
- These assertions are pretty low-value, but they do prevent changes to the registry that would break test setup or mocks
Also a lot of asserts about SourceComponent optional properties like xml/content
- also low value, but there's not a clear link between the Registry entry/strategy and the mock files, so this again prevents accidental test breakage and should make it more clear what's wrong with the tests if you do break them (Oh, your mock has no content but the test expects it!)

### What issues does this PR fix or reference?
[@W-12671663@](https://gus.lightning.force.com/a07EE00001MxCd3YAF)