### PR TITLE
Prerelease/set project dir on cs

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -2,12 +2,18 @@ name: version, tag and github release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - prerelease/*
+    tags-ignore:
+      - '*'
 
 jobs:
   release:
     uses: salesforcecli/github-workflows/.github/workflows/githubRelease.yml@main
     secrets: inherit
+    with:
+      prerelease: ${{ github.ref_name != 'main' }}
   docs:
     uses: salesforcecli/github-workflows/.github/workflows/publishTypedoc.yml@main
     secrets: inherit

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,7 +1,9 @@
+name: publish
+
 # when a github release happens, publish an npm package,
 on:
   release:
-    types: [released]
+    types: [published]
   # support manual release
   workflow_dispatch:
     inputs:
@@ -10,9 +12,21 @@ on:
         type: string
         required: true
 jobs:
+  getDistTag:
+    outputs:
+      tag: ${{ steps.distTag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag  }}
+      - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
+        id: distTag
   npm:
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    needs: [getDistTag]
     with:
       ctc: false
+      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -553,8 +553,8 @@ v58 introduces the following new types.  Here's their current level of support
 
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
-|AIScoringModelDefVersion|❌|Not supported, but support could be added|
-|AIScoringModelDefinition|❌|Not supported, but support could be added|
+|AIScoringModelDefVersion|❌|Not supported, but support could be added (but not for tracking)|
+|AIScoringModelDefinition|❌|Not supported, but support could be added (but not for tracking)|
 |Ai4mSettings|✅||
 |AssessmentConfiguration|❌|Not supported, but support could be added|
 |ClaimMgmtFoundationEnabledSettings|✅||
@@ -565,11 +565,13 @@ v58 introduces the following new types.  Here's their current level of support
 |FundraisingConfig|❌|Not supported, but support could be added|
 |LicensingSettings|✅||
 |OmniChannelPricingSettings|✅||
+|PlatformEventSettings|✅||
 |ProcessFlowMigration|❌|Not supported, but support could be added|
 |ProductAttrDisplayConfig|❌|Not supported, but support could be added|
 |ProductSpecificationRecType|❌|Not supported, but support could be added|
 |ProductSpecificationType|❌|Not supported, but support could be added|
 |RecAlrtDataSrcExpSetDef|❌|Not supported, but support could be added|
+|RecordAlertTemplate|❌|Not supported, but support could be added|
 |SkillType|❌|Not supported, but support could be added|
 |Web3Settings|✅||
 |WebStoreBundle|❌|Not supported, but support could be added|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "7.13.1",
+  "version": "7.14.0-beta",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "7.14.0-beta",
+  "version": "7.14.0-beta.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "unzipper": "0.10.11"
   },
   "devDependencies": {
-    "@salesforce/cli-plugins-testkit": "^3.2.25",
+    "@salesforce/cli-plugins-testkit": "^3.3.1",
     "@salesforce/dev-config": "^3.0.1",
     "@salesforce/dev-scripts": "^4.1.3",
     "@salesforce/prettier-config": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "7.14.0-beta.0",
+  "version": "7.14.0-beta.1",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "7.14.0-beta.2",
+  "version": "7.14.0-beta.3",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -64,6 +64,11 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    * This is used as the value for the `version` field in the manifest.
    */
   public sourceApiVersion: string;
+  /**
+   * Used to explicitly set the project directory for the component set.
+   * When not present, sfdx-core's SfProject will use the current working directory.
+   */
+  public projectDirectory?: string;
   public fullName?: string;
   public forceIgnoredPaths?: Set<string>;
   private logger: Logger;

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -120,7 +120,7 @@ export class MetadataConverter {
       const conversionPipeline = pipeline(
         Readable.from(components),
         !targetFormatIsSource && (process.env.SF_APPLY_REPLACEMENTS_ON_CONVERT === 'true' || output.type === 'zip')
-          ? (await getReplacementMarkingStream()) ?? new PassThrough({ objectMode: true })
+          ? (await getReplacementMarkingStream(cs.projectDirectory)) ?? new PassThrough({ objectMode: true })
           : new PassThrough({ objectMode: true }),
         new ComponentConverter(targetFormat, this.registry, mergeSet, defaultDirectory),
         writer

--- a/src/convert/replacements.ts
+++ b/src/convert/replacements.ts
@@ -81,9 +81,11 @@ export const replacementIterations = async (input: string, replacements: MarkedR
 /**
  * Reads the project, gets replacements, removes any that aren't applicable due to environment conditionals, and returns an instance of the ReplacementMarkingStream
  */
-export const getReplacementMarkingStream = async (): Promise<ReplacementMarkingStream | undefined> => {
+export const getReplacementMarkingStream = async (
+  projectDir?: string
+): Promise<ReplacementMarkingStream | undefined> => {
   // remove any that don't agree with current env
-  const filteredReplacements = envFilter(await readReplacementsFromProject());
+  const filteredReplacements = envFilter(await readReplacementsFromProject(projectDir));
   if (filteredReplacements.length) {
     return new ReplacementMarkingStream(filteredReplacements);
   }
@@ -207,8 +209,8 @@ const getEnvValue = (env: string): string => {
 /**
  * Read the `replacement` property from sfdx-project.json
  */
-const readReplacementsFromProject = async (): Promise<ReplacementConfig[]> => {
-  const proj = await SfProject.resolve();
+const readReplacementsFromProject = async (projectDir?: string): Promise<ReplacementConfig[]> => {
+  const proj = await SfProject.resolve(projectDir);
   const projJson = (await proj.resolveProjectConfig()) as { replacements?: ReplacementConfig[] };
   return projJson.replacements;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,12 +864,12 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^3.2.25":
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.2.25.tgz#c0799b36bd3563950a057b0925a9879f4f80751f"
-  integrity sha512-bnzQnY/T7A2Wq894wmEvv9btxDhBSX8Iyq8XDUSgcMdjeWFuZS1JQHgazlSaDkfA/3J5tSbEyPY/vEAi0HRd4g==
+"@salesforce/cli-plugins-testkit@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.3.1.tgz#43f5818fb89c99c606535235624320881e050fae"
+  integrity sha512-cE13PNGBqqk9H01RLGZxDKgXRrHE4p1YsEConet7IsYYgZMXmhH1OUfj9HGmTTe55SZdmF1wt+Cu8AdZwFRBSw==
   dependencies:
-    "@salesforce/core" "^3.33.6"
+    "@salesforce/core" "^3.34.4"
     "@salesforce/kit" "^1.9.2"
     "@salesforce/ts-types" "^1.7.3"
     "@types/shelljs" "^0.8.11"
@@ -879,7 +879,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^3.33.6", "@salesforce/core@^3.34.4":
+"@salesforce/core@^3.34.4":
   version "3.34.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.34.4.tgz#6fa11c32f14d20130a0c92c5d306f368671ec104"
   integrity sha512-WasR/6IXKcNj3MgZIcVaT7W5Ic/blxOgpQIzob/7JEsnLVr3pPPb+9/axRvxEGdJr/gOnL1vR0NbBX+Mz6TtkQ==


### PR DESCRIPTION
### What does this PR do?
devOps center is struggling with cwd being called from Replacements feature which reads the project file via SfProject.
This creates an optional `projectDirectory` prop on ComponentSet which can be used to set the value for SfProject to use instead of cwd.  

[@W-12754654@](https://gus.lightning.force.com/a07EE00001NxDrtYAF)