### PR TITLE
ci: metadata support updates as a scheduled job

### DIFF
--- a/.github/workflows/failureNotifications.yml
+++ b/.github/workflows/failureNotifications.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - version, tag and github release
       - publish
+      - supported metadata update
     types:
       - completed
 

--- a/.github/workflows/supportedMetadataUpdate.yml
+++ b/.github/workflows/supportedMetadataUpdate.yml
@@ -1,0 +1,22 @@
+name: supported metadata update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 3 22 * * *
+
+jobs:
+  registry-check:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+      - run: yarn install  --network-timeout 600000
+      - run: yarn build
+      - run: yarn update-supported-metadata.ts

--- a/.github/workflows/supportedMetadataUpdate.yml
+++ b/.github/workflows/supportedMetadataUpdate.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           node-version: lts/*
           cache: yarn
-      - run: yarn install  --network-timeout 600000
+      - run: yarn install --network-timeout 600000
       - run: yarn build
-      - run: yarn update-supported-metadata.ts
+      - run: yarn update-supported-metadata
+      - run: |
+          if [[ -n $(git status --short) ]]; then
+            git METADATA_SUPPORT.md
+            git commit -am "chore: auto-update metadata coverage in METADATA_SUPPORT.md" --no-verify
+            git push --no-verify
+          else
+            echo "Already up to date"
+          fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 echo "husky pre-push again"
-# builds the metadata support markdown file
-yarn build && yarn test && yarn update-supported-metadata
+yarn build && yarn test

--- a/contributing/metadata.md
+++ b/contributing/metadata.md
@@ -3,12 +3,11 @@
 You can view the existing metadata coverage by release using [METADATA_SUPPORT.md](../METADATA_SUPPORT.md)
 
 - It can be updated by running
+- The script runs daily via github actions. You only need to run it if you want to see the results of your registry changes.
 
 ```shell
 yarn update-supported-metadata
 ```
-
-- The above script is run automatically on `git push` updating the [METADATA_SUPPORT.md](../METADATA_SUPPORT.md) file and committing the changes.
 
 Got questions?
 

--- a/scripts/update-registry/update-supported-metadata.ts
+++ b/scripts/update-registry/update-supported-metadata.ts
@@ -126,13 +126,4 @@ ${additionalCLISupport.map((t) => `- ${t}`).join('\n')}
 
   await fs.promises.writeFile('METADATA_SUPPORT.md', contents);
   console.log('Wrote METADATA_SUPPORT.md');
-
-  shell.exec(`git add METADATA_SUPPORT.md`);
-  if (
-    shell.exec(`git commit -am "chore: auto-update metadata coverage in METADATA_SUPPORT.md" --no-verify`).code !== 0
-  ) {
-    shell.echo(
-      'Error: Git commit failed - usually nothing to commit which means there are no new metadata type support added in this version of SDR'
-    );
-  }
 })().catch(console.error);

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/eda.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 208.37945000000764
+    "duration": 207.40213900001254
   },
   {
     "name": "sourceToMdapi",
-    "duration": 5163.694585999998
+    "duration": 5482.2273609999975
   },
   {
     "name": "sourceToZip",
-    "duration": 4249.0233250000165
+    "duration": 3902.8499249999877
   },
   {
     "name": "mdapiToSource",
-    "duration": 3356.330946000002
+    "duration": 3655.7161440000054
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClasses.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 408.6128360000148
+    "duration": 409.48235500001465
   },
   {
     "name": "sourceToMdapi",
-    "duration": 7221.068067000015
+    "duration": 8209.057540999987
   },
   {
     "name": "sourceToZip",
-    "duration": 5880.985977000004
+    "duration": 5968.185670000006
   },
   {
     "name": "mdapiToSource",
-    "duration": 4112.393477000005
+    "duration": 4013.8856420000084
   }
 ]

--- a/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
+++ b/test/nuts/perfResults/x64-linux-2xIntel-Xeon-Platinum-8370C-CPU-2-80GHz/lotsOfClassesOneDir.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "componentSetCreate",
-    "duration": 707.7821399999957
+    "duration": 719.4703750000044
   },
   {
     "name": "sourceToMdapi",
-    "duration": 9948.782891999988
+    "duration": 9654.836611999985
   },
   {
     "name": "sourceToZip",
-    "duration": 9234.353405000002
+    "duration": 10031.155679000018
   },
   {
     "name": "mdapiToSource",
-    "duration": 7288.00951600002
+    "duration": 7090.570546999981
   }
 ]


### PR DESCRIPTION
updating of  https://github.com/forcedotcom/source-deploy-retrieve/blob/main/METADATA_SUPPORT.md will happen from a daily gha job instead of a commit hook.

[skip-validate-pr]