### PR TITLE
chore: exclude new types with incorrect scratch settings

### DIFF
--- a/src/registry/nonSupportedTypes.ts
+++ b/src/registry/nonSupportedTypes.ts
@@ -72,6 +72,12 @@ export const metadataTypes = [
   // spun up with CUSTOMERDATAPLATFORM, not in describe
   'ExternalDataTranField',
   'ExternalDataTranObject',
+
+  // spun up with HIGHSCALEORDERS, not in describe
+  'RegisteredExternalService',
+
+  // B2CLOYALTYMANAGEMENTPLUS, not in describe
+  'ServiceProcess',
 ];
 
 export const hasUnsupportedFeatures = (type: CoverageObjectType): boolean => {


### PR DESCRIPTION
### What does this PR do?
tried to add 2 types to the registry.  Using their scratch-def from the MetadataCoverageReport, they do not appear in the describe.

So I added them to the nonSupportedTypes instead

### What issues does this PR fix or reference?
https://github.com/forcedotcom/source-deploy-retrieve/actions/runs/4591081684

[skip-pr-validate]