### PR TITLE
fix: ensure retrieval and deployment of views with screen aware variants

### DIFF
--- a/src/resolve/adapters/digitalExperienceSourceAdapter.ts
+++ b/src/resolve/adapters/digitalExperienceSourceAdapter.ts
@@ -58,7 +58,17 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
     if (this.isBundleType()) {
       return;
     }
-    return dirname(path);
+    let pathToContent = dirname(path);
+    const parts = pathToContent.split(sep);
+    // Handle mobile or tablet variants.Eg- digitalExperiences/site/lwr11/sfdc_cms__view/home/mobile/mobile
+    // Go back one level in that case
+    if (parts.length > 1 && (parts[parts.length - 1] === 'mobile' || parts[parts.length - 1] === 'tablet')) {
+      parts.pop();
+      pathToContent = parts.join(sep);
+    }
+    // eslint-disable-next-line no-console
+    // console.log(pathToContent+' pathToContent'+'\n');
+    return pathToContent;
   }
 
   protected populate(trigger: string, component?: SourceComponent): SourceComponent {


### PR DESCRIPTION
### What does this PR do?
Updates method for trimming a path up until the root of a component's content to handle screen aware variants 
### What issues does this PR fix or reference?
Ensures Re-retrieve and deploy of a view with screen aware variants is working via sfdx commands
Gus Work Item- W-12171473
### Functionality Before
DEB adapters in SFDX project are not handling mobile and tablet variant files in the content folders but only the _meta.json and content.json file

### Functionality After
DEB adapters will handle the screen variant case and give correct results when method trimPathToContent() is called

