### PR TITLE
fix: get correct file paths for a DigitalExperience component

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -602,7 +602,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
     }
     const output = new Set<string>();
     componentMap.forEach((component) => {
-      [...component.walkContent(), component.content, component.metaFilePath]
+      [...component.walkContent(), component.content, component.xml]
         .filter(Boolean)
         .map((filename) => output.add(filename));
     });

--- a/src/resolve/adapters/digitalExperienceSourceAdapter.ts
+++ b/src/resolve/adapters/digitalExperienceSourceAdapter.ts
@@ -50,7 +50,7 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
     if (this.isBundleType()) {
       return this.getBundleMetadataXmlPath(trigger);
     }
-    // metaFileName = metaFileSuffix for DigitalExperience.
+    // metafile name = metaFileSuffix for DigitalExperience.
     return join(dirname(trigger), this.type.metaFileSuffix);
   }
 
@@ -82,6 +82,7 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
         name: calculateNameFromPath(source.content),
         type: this.type,
         content: source.content,
+        xml: source.xml,
         parent,
         parentType,
       },

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, join, dirname } from 'path';
+import { basename, join } from 'path';
 import { Messages, SfError } from '@salesforce/core';
 import { parse, validate } from 'fast-xml-parser';
 import { get, getString, JsonMap } from '@salesforce/ts-types';
@@ -77,21 +77,6 @@ export class SourceComponent implements MetadataComponent {
     } else {
       return `${this.parent ? `${this.parent.fullName}.` : ''}${this.name}`;
     }
-  }
-
-  /**
-   * Gets the metafile path of this component. Not all the types have an XML metafile,
-   * e.g., DigitalExperience has a JSON metafile (_meta.json).
-   *
-   * @returns The metafile path
-   */
-  public get metaFilePath(): string {
-    if (this.type.id === 'digitalexperience') {
-      // metaFileName = metaFileSuffix for DigitalExperience.
-      return join(dirname(this.content), this.type.metaFileSuffix);
-    }
-
-    return this.xml;
   }
 
   public get tree(): TreeContainer {

--- a/src/utils/filePathGenerator.ts
+++ b/src/utils/filePathGenerator.ts
@@ -39,7 +39,7 @@ export const filePathsFromMetadataComponent = (
   if (type.strategies?.adapter === 'digitalExperience') {
     // child MD Type, the metafile is a JSON, not an XML
     if (type.id === 'digitalexperience') {
-      // metaFileName = metaFileSuffix for DigitalExperience.
+      // metafile name = metaFileSuffix for DigitalExperience.
       return [
         join(
           packageDirWithTypeDir,

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -1263,10 +1263,7 @@ describe('ComponentSet', () => {
     });
 
     it('should correctly return DE (DigitalExperience) component file paths', () => {
-      const set = new ComponentSet(
-        [digitalExperienceBundle.DE_CONTENT_COMPONENT, digitalExperienceBundle.DE_FR_VARIENT_COMPONENT],
-        registryAccess
-      );
+      const set = new ComponentSet([digitalExperienceBundle.DE_COMPONENT], registryAccess);
 
       const de: MetadataMember = {
         fullName: digitalExperienceBundle.HOME_VIEW_FULL_NAME,
@@ -1274,6 +1271,7 @@ describe('ComponentSet', () => {
       };
 
       expect(set.getComponentFilenamesByNameAndType(de)).to.have.members([
+        digitalExperienceBundle.HOME_VIEW_PATH,
         join(digitalExperienceBundle.HOME_VIEW_PATH, 'content.json'),
         join(digitalExperienceBundle.HOME_VIEW_PATH, 'fr.json'),
         join(digitalExperienceBundle.HOME_VIEW_PATH, '_meta.json'),

--- a/test/mock/type-constants/digitalExperienceBundleConstants.ts
+++ b/test/mock/type-constants/digitalExperienceBundleConstants.ts
@@ -11,7 +11,7 @@ import { META_XML_SUFFIX } from '../../../src/common';
 export const DEB_TYPE = registry.types.digitalexperiencebundle;
 export const DE_TYPE = DEB_TYPE.children.types.digitalexperience;
 
-// metaFileName = metaFileSuffix for DigitalExperience.
+// metafile name = metaFileSuffix for DigitalExperience.
 export const DE_METAFILE = DE_TYPE.metaFileSuffix;
 
 export const BUNDLE_NAME = 'site/foo';
@@ -28,8 +28,7 @@ export const BASE_PATH = join('path', 'to', DEB_TYPE.directoryName);
 export const BUNDLE_PATH = join(BASE_PATH, 'site', 'foo');
 export const BUNDLE_META_FILE_PATH = join(BUNDLE_PATH, BUNDLE_META_FILE);
 export const HOME_VIEW_PATH = join(BUNDLE_PATH, 'sfdc_cms__view', 'home');
-export const HOME_VIEW_CONTENT_FILE_PATH = join(HOME_VIEW_PATH, HOME_VIEW_CONTENT_FILE);
-export const HOME_VIEW_FRENCH_VARIANT_FILE_PATH = join(HOME_VIEW_PATH, HOME_VIEW_FRENCH_VARIANT_FILE);
+export const HOME_VIEW_META_FILE_PATH = join(HOME_VIEW_PATH, DE_METAFILE);
 
 // DigitalExperienceBundle component
 export const DEB_COMPONENT = SourceComponent.createVirtualComponent(
@@ -46,29 +45,13 @@ export const DEB_COMPONENT = SourceComponent.createVirtualComponent(
   ]
 );
 
-// DigitalExperience component for content (content.json)
-export const DE_CONTENT_COMPONENT = SourceComponent.createVirtualComponent(
+// DigitalExperience component
+export const DE_COMPONENT = SourceComponent.createVirtualComponent(
   {
     name: HOME_VIEW_NAME,
     type: DE_TYPE,
-    content: HOME_VIEW_CONTENT_FILE_PATH,
-    parent: DEB_COMPONENT,
-    parentType: DEB_TYPE,
-  },
-  [
-    {
-      dirPath: HOME_VIEW_PATH,
-      children: [HOME_VIEW_CONTENT_FILE, HOME_VIEW_FRENCH_VARIANT_FILE, HOME_VIEW_META_FILE],
-    },
-  ]
-);
-
-// DigitalExperience component for content variant (fr.json)
-export const DE_FR_VARIENT_COMPONENT = SourceComponent.createVirtualComponent(
-  {
-    name: HOME_VIEW_NAME,
-    type: DE_TYPE,
-    content: HOME_VIEW_FRENCH_VARIANT_FILE_PATH,
+    content: HOME_VIEW_PATH,
+    xml: HOME_VIEW_META_FILE_PATH,
     parent: DEB_COMPONENT,
     parentType: DEB_TYPE,
   },

--- a/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
+++ b/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
@@ -79,6 +79,7 @@ describe('DigitalExperienceSourceAdapter', () => {
         name: HOME_VIEW_NAME,
         type: registry.types.digitalexperiencebundle.children.types.digitalexperience,
         content: HOME_VIEW_PATH,
+        xml: HOME_VIEW_META_FILE,
         parent: new SourceComponent(
           {
             name: BUNDLE_NAME,

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -222,6 +222,7 @@ describe('MetadataResolver', () => {
             name: 'sfdc_cms__view/home',
             type: registry.types.digitalexperiencebundle.children.types.digitalexperience,
             content: dirname(path),
+            xml: path,
             parent: parentComponent,
             parentType: registry.types.digitalexperiencebundle,
           },

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -201,6 +201,7 @@ const testData = {
       {
         name: 'sfdc_cms__view/home', // as defined in digitalExperienceSourceAdapter.calculateNameFromPath()
         type: registryAccess.getTypeByName('DigitalExperience'),
+        xml: getFilePath('digitalExperiences/site/foo/sfdc_cms__view/home/_meta.json'),
       },
     ],
   },


### PR DESCRIPTION
### What does this PR do?

Fixes componentSet.getComponentFilenamesByNameAndType to return correct file paths.

### What issues does this PR fix or reference?

@[W-12965438](https://gus.lightning.force.com/a07EE00001OS9AAYA1)@

### Functionality Before

Returned paths:

[
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/content.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/fr.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/_meta.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/_meta.json" **- WRONG**
]

### Functionality After

Returned paths:

[
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/content.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/fr.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home/_meta.json"
"path/to/digitalExperiences/site/foo/sfdc_cms__view/home"
]
