### PR TITLE
fix: better error messages around static resource converstion failures

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -77,6 +77,11 @@ export class MetadataConverter {
       if (!(err instanceof Error) && !isString(err)) {
         throw err;
       }
+      // if the error is already somewhat descriptive, use that
+      // the allows better error messages to be passed through instead of "failed convert"
+      if (err instanceof SfError && (err.name !== 'SfError' || err.actions)) {
+        throw err;
+      }
       const error = isString(err) ? new Error(err) : err;
       throw new SfError(messages.getMessage('error_failed_convert', [error.message]), 'ConversionError', [], error);
     }

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -439,7 +439,7 @@ describe('MetadataConverter', () => {
         });
         fail(`should have thrown a ${expectedError.name} error`);
       } catch (e) {
-        assert(e instanceof Error);
+        assert(e instanceof SfError);
         expect(e.name).to.equal('ConversionError');
         expect(e.message).to.equal(expectedError.message);
       }


### PR DESCRIPTION
> requires https://github.com/salesforcecli/plugin-source/pull/801 (ps-nuts change)

### What does this PR do?
the SDR strict changes had already "fixed" the bug so that it gives an error, but there was room for improvement.

Also added some logic so that "good errors" thrown from deep in the convert process don't get genericized (losing their name and actions) by metadataConverter.



### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1384


### Functionality Before
```
Error (1): Component conversion failed: FILE_ENDED
```

### Functionality After

<img width="1185" alt="Screenshot 2023-04-05 at 4 29 04 PM" src="https://user-images.githubusercontent.com/4261788/230215747-0a59f03f-79f0-4cd6-b456-61dac07bbe5a.png">
