### PR TITLE
fix: ensure retrieval and deployment of views with screen aware variants

### DIFF
--- a/src/resolve/adapters/digitalExperienceSourceAdapter.ts
+++ b/src/resolve/adapters/digitalExperienceSourceAdapter.ts
@@ -34,6 +34,13 @@ import { BundleSourceAdapter } from './bundleSourceAdapter';
  * |   |   |  ├── _meta.json
  * |   |   |  ├── content.json
  * |   |   |  ├── ar.json
+ * |   |   ├── view3/
+ * |   |   |  ├── _meta.json
+ * |   |   |  ├── content.json
+ * |   |   |  ├── mobile/
+ * |   |   |  |   ├──mobile.json
+ * |   |   |  ├── tablet/
+ * |   |   |  |   ├──tablet.json
  * |   ├── foos.digitalExperience-meta.xml
  * content/
  * ├── bars/
@@ -58,7 +65,20 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
     if (this.isBundleType()) {
       return;
     }
-    return dirname(path);
+    const pathToContent = dirname(path);
+    const parts = pathToContent.split(sep);
+    /* Handle mobile or tablet variants.Eg- digitalExperiences/site/lwr11/sfdc_cms__view/home/mobile/mobile.json
+     Go back to one level in that case
+     Bundle hierarchy baseType/spaceApiName/contentType/contentApiName/variantFolders/file */
+    const digitalExperiencesIndex = parts.indexOf('digitalExperiences');
+    if (digitalExperiencesIndex > -1) {
+      const depth = parts.length - digitalExperiencesIndex - 1;
+      if (depth === digitalExperienceBundleWithVariantsDepth) {
+        parts.pop();
+        return parts.join(sep);
+      }
+    }
+    return pathToContent;
   }
 
   protected populate(trigger: string, component?: SourceComponent): SourceComponent {
@@ -131,3 +151,6 @@ export class DigitalExperienceSourceAdapter extends BundleSourceAdapter {
  * @returns name of type/apiName format
  */
 const calculateNameFromPath = (contentPath: string): string => `${parentName(contentPath)}/${baseName(contentPath)}`;
+
+// Bundle hierarchy baseType/spaceApiName/contentType/contentApiName/variantFolders/file
+const digitalExperienceBundleWithVariantsDepth = 5;

--- a/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
+++ b/test/resolve/adapters/digitalExperienceSourceAdapter.test.ts
@@ -20,9 +20,14 @@ describe('DigitalExperienceSourceAdapter', () => {
 
   const HOME_VIEW_NAME = 'sfdc_cms__view/home';
   const HOME_VIEW_PATH = join(BUNDLE_PATH, 'sfdc_cms__view', 'home');
+  const HOME_VIEW_MOBILE_PATH = join(HOME_VIEW_PATH, 'mobile');
+  const HOME_VIEW_TABLET_PATH = join(HOME_VIEW_PATH, 'tablet');
+
   const HOME_VIEW_CONTENT_FILE = join(HOME_VIEW_PATH, 'content.json');
   const HOME_VIEW_META_FILE = join(HOME_VIEW_PATH, DE_METAFILE);
   const HOME_VIEW_FRENCH_VARIANT_FILE = join(HOME_VIEW_PATH, 'fr.json');
+  const HOME_VIEW_MOBILE_VARIANT_FILE = join(HOME_VIEW_MOBILE_PATH, 'mobile.json');
+  const HOME_VIEW_TABLET_VARIANT_FILE = join(HOME_VIEW_TABLET_PATH, 'tablet.json');
 
   const registryAccess = new RegistryAccess();
   const forceIgnore = new ForceIgnore();
@@ -31,6 +36,8 @@ describe('DigitalExperienceSourceAdapter', () => {
     HOME_VIEW_CONTENT_FILE,
     HOME_VIEW_META_FILE,
     HOME_VIEW_FRENCH_VARIANT_FILE,
+    HOME_VIEW_MOBILE_VARIANT_FILE,
+    HOME_VIEW_TABLET_VARIANT_FILE,
   ]);
 
   const bundleAdapter = new DigitalExperienceSourceAdapter(
@@ -67,6 +74,11 @@ describe('DigitalExperienceSourceAdapter', () => {
       expect(bundleAdapter.getComponent(HOME_VIEW_FRENCH_VARIANT_FILE)).to.deep.equal(component);
     });
 
+    it('should return a SourceComponent for mobile and tablet variant json', () => {
+      expect(bundleAdapter.getComponent(HOME_VIEW_MOBILE_VARIANT_FILE)).to.deep.equal(component);
+      expect(bundleAdapter.getComponent(HOME_VIEW_TABLET_VARIANT_FILE)).to.deep.equal(component);
+    });
+
     it('should return a SourceComponent when a bundle path is provided', () => {
       expect(bundleAdapter.getComponent(HOME_VIEW_PATH)).to.deep.equal(component);
       expect(bundleAdapter.getComponent(BUNDLE_PATH)).to.deep.equal(component);
@@ -99,6 +111,11 @@ describe('DigitalExperienceSourceAdapter', () => {
       expect(digitalExperienceAdapter.getComponent(HOME_VIEW_CONTENT_FILE)).to.deep.equal(component);
       expect(digitalExperienceAdapter.getComponent(HOME_VIEW_META_FILE)).to.deep.equal(component);
       expect(digitalExperienceAdapter.getComponent(HOME_VIEW_FRENCH_VARIANT_FILE)).to.deep.equal(component);
+    });
+
+    it('should return a SourceComponent for mobile and tablet variant json', () => {
+      expect(digitalExperienceAdapter.getComponent(HOME_VIEW_MOBILE_VARIANT_FILE)).to.deep.equal(component);
+      expect(digitalExperienceAdapter.getComponent(HOME_VIEW_TABLET_VARIANT_FILE)).to.deep.equal(component);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Updates method for trimming a path up until the root of a component's content to handle screen aware variants

### What issues does this PR fix or reference?

Ensures Retrieval and deployment of a view with screen aware variants is working via sfdx commands
@W-12171473@

### Functionality Before

DEB adapters in SFDX project are not handling mobile and tablet variant files in the content folders but only the _meta.json and content.json file. Hence, we are getting errors when we have mobile or tablet variants in the bundle.

### Functionality After
DEB adapters will be to handle the screen variant case as method trimPathToContent() is updated to give correct directory hierarchy for screen variants .Eg- digitalExperiences/site/lwr11/sfdc_cms__view/home/mobile/mobile.json
