### PR TITLE
fix: update directory name for oauth policies and mobile policies

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1410,7 +1410,7 @@
       "id": "extlclntappoauthconfigurablepolicies",
       "name": "ExtlClntAppOauthConfigurablePolicies",
       "suffix": "ecaOauthPlcy",
-      "directoryName": "oauthPolicies",
+      "directoryName": "extlClntAppOauthPolicies",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -1418,7 +1418,7 @@
       "id": "extlclntappmobileconfigurablepolicies",
       "name": "ExtlClntAppMobileConfigurablePolicies",
       "suffix": "ecaMobPlcy",
-      "directoryName": "mobilePolicies",
+      "directoryName": "extlClntAppMobilePolicies",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?
Update directory name for oauth policies and mobile policies

### What issues does this PR fix or reference?
[W-13098569](https://gus.lightning.force.com/a07EE00001QAU2gYAH)

### Functionality Before

ExtlClntAppOauthConfigurablePolicies had directory name oauthPolicies. 
ExtlClntAppMobileConfigurablePolicies had directory name mobilePolicies. 

### Functionality After

ExtlClntAppOauthConfigurablePolicies now has directory name extlClntAppOauthPolicies. 
ExtlClntAppMobileConfigurablePolicies now has directory name extlClntAppMobilePolicies. 