### PR TITLE
fix: update the update2 script for TS strict compile

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,11 @@
     "baseUrl": ".",
     "paths": { "@salesforce/kit": ["node_modules/@salesforce/kit"] }
   },
-  "include": ["./src/**/*.ts", "./src/registry/metadataRegistry.json", "./src/registry/stdValueSetRegistry.json"],
+  "include": [
+    "./src/**/*.ts",
+    "./scripts/update-registry/*.ts",
+    "./src/registry/metadataRegistry.json",
+    "./src/registry/stdValueSetRegistry.json"
+  ],
   "exclude": ["node_modules", "lib", "examples"]
 }


### PR DESCRIPTION
### What does this PR do?
Updates the update2.ts script for TS strict compilation and adds the scripts/update-registry folder to tsconfig.json so it's compiled during `yarn compile`

### What issues does this PR fix or reference?

@W-13137391@

### Functionality Before

You get TS compile errors when running `yarn update-registry`

### Functionality After

Script runs as expected; no compile errors.
