### PR TITLE
fix: prevent [object Object] and provide component details

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^3.36.0",
+    "@salesforce/core": "^3.36.1",
     "@salesforce/kit": "^1.9.2",
     "@salesforce/ts-types": "^1.7.2",
     "archiver": "^5.3.1",

--- a/test/client/diagnosticUtil.test.ts
+++ b/test/client/diagnosticUtil.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'path';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
+import { SfError } from '@salesforce/core';
 import { DiagnosticUtil } from '../../src/client/diagnosticUtil';
 import { DeployMessage, registry, SourceComponent } from '../../src';
 
@@ -51,6 +52,19 @@ describe('DiagnosticUtil', () => {
         error: 'This might be a problem later!',
         problemType: 'Warning',
       });
+    });
+
+    it('should throw friendly error for message with missing problem', () => {
+      const message = createDeployMessage({
+        problemType: 'Warning',
+      });
+      try {
+        util.parseDeployDiagnostic(component, message);
+      } catch (e) {
+        assert(e instanceof SfError);
+        expect(e.message).to.include('Unable to parse deploy diagnostic with empty problem');
+        expect(e.message).to.include(JSON.stringify(message));
+      }
     });
 
     it('should create diagnostic for problem with file line and column info', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,10 +890,31 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^3.34.6", "@salesforce/core@^3.36.0":
+"@salesforce/core@^3.34.6":
   version "3.36.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.36.0.tgz#cbff147d888eee0b921e368c1fdc1a1a3c2eacab"
   integrity sha512-LOeSJgozf5B1S8C98/K3afewRsathfEm+HrXxaFXJjITFfIhxqcIDB5xC1cw0VikfRUlq7dQocmVsvezcK0Ghw==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.9.2"
+    "@salesforce/schemas" "^1.5.1"
+    "@salesforce/ts-types" "^1.7.2"
+    "@types/semver" "^7.3.13"
+    ajv "^8.12.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.21"
+    jsonwebtoken "9.0.0"
+    ts-retry-promise "^0.7.0"
+
+"@salesforce/core@^3.36.1":
+  version "3.36.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.36.1.tgz#053a5e1079b9749b62e461e6ac3e630b5689694a"
+  integrity sha512-kcjyr9bj35nnL8Bqv8U39xeho3CrZYXJiS/X5X1eEHVNZLd9zckrmKrh1V7z8ElCFpsJrewT989SJsdvi9kE8w==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.9.2"


### PR DESCRIPTION
### What does this PR do?
This is a follow-on from strict mode update where we get better error messages.  Call JSON.stringy instead of toString() to get better output.

Also adds the the component name information and consolidates some error message generation.

### What issues does this PR fix or reference?

@W-13222350@ https://github.com/forcedotcom/cli/issues/2140