### PR TITLE
Sh/archiver to jszip swap

### DIFF
--- a/.sfdevrc.json
+++ b/.sfdevrc.json
@@ -1,0 +1,33 @@
+{
+  "wireit": {
+    "compile": {
+      "command": "tsc -p . --pretty --incremental",
+      "files": [
+        "src/**/*.ts",
+        "**/tsconfig.json",
+        "messages/**",
+        "src/registry/metadataRegistry.json",
+        "src/registry/stdValueSetRegistry.json"
+      ],
+      "output": ["lib/**", "*.tsbuildinfo"],
+      "clean": "if-file-deleted"
+    },
+    "test:only": {
+      "command": "nyc mocha \"test/**/*.test.ts\"",
+      "env": {
+        "FORCE_COLOR": "2"
+      },
+      "files": [
+        "test/**/*.ts",
+        "src/**/*.ts",
+        "**/tsconfig.json",
+        ".mocha*",
+        "!*.nut.ts",
+        ".nycrc",
+        "src/registry/metadataRegistry.json",
+        "src/registry/stdValueSetRegistry.json"
+      ],
+      "output": []
+    }
+  }
+}

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -4,7 +4,7 @@ This list compares metadata types found in Salesforce v58 with the [metadata reg
 
 This repository is used by both the Salesforce CLIs and Salesforce's VSCode Extensions.
 
-Currently, there are 515/550 supported metadata types.
+Currently, there are 516/550 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 

--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -70,6 +70,11 @@ Metadata xml file %s is forceignored but is required for %s.
 
 SourceComponent %s (metadata type = %s) is missing its content file.
 
+# noContentFound.actions
+
+- Ensure the content file exists in the expected location.
+- If the content file is in your .forceignore file, ensure the meta-xml file is also ignored to completely exclude it.
+
 # error_parsing_xml
 
 SourceComponent %s (metadata type = %s) does not have an associated metadata xml to parse

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-jsdoc": "^39.9.1",
     "eslint-plugin-sf-plugin": "^1.15.1",
     "husky": "^7.0.4",
-    "jsforce": "^2.0.0-beta.21",
+    "jsforce": "^2.0.0-beta.23",
     "mocha": "^9.2.2",
     "mocha-junit-reporter": "^1.23.3",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "got": "^11.8.6",
     "graceful-fs": "^4.2.11",
     "ignore": "^5.2.4",
+    "jszip": "^3.10.1",
     "mime": "2.6.0",
     "minimatch": "^5.1.6",
     "proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@salesforce/dev-scripts": "^4.3.0",
     "@salesforce/prettier-config": "^0.0.2",
     "@salesforce/ts-sinon": "^1.4.6",
-    "@types/archiver": "^5.3.1",
     "@types/deep-equal-in-any-order": "^1.0.1",
     "@types/fast-levenshtein": "^0.0.2",
     "@types/graceful-fs": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,9 @@
       "files": [
         "src/**/*.ts",
         "**/tsconfig.json",
-        "messages/**"
+        "messages/**",
+        "src/registry/metadataRegistry.json",
+        "src/registry/stdValueSetRegistry.json"
       ],
       "output": [
         "lib/**",
@@ -185,7 +187,9 @@
         "**/tsconfig.json",
         ".mocha*",
         "!*.nut.ts",
-        ".nycrc"
+        ".nycrc",
+        "src/registry/metadataRegistry.json",
+        "src/registry/stdValueSetRegistry.json"
       ],
       "output": []
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@salesforce/core": "^3.36.0",
     "@salesforce/kit": "^1.9.2",
     "@salesforce/ts-types": "^1.7.2",
-    "archiver": "^5.3.1",
     "fast-levenshtein": "^3.0.0",
     "fast-xml-parser": "^4.2.2",
     "got": "^11.8.6",

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -445,11 +445,10 @@ export class MetadataApiDeploy extends MetadataTransfer<
       const zip = JSZip();
 
       const zipDirRecursive = (dir: string): void => {
-        const list = fs.readdirSync(dir);
-        for (const file of list) {
-          const fullPath = pathResolve(dir, file);
-          const stat = fs.statSync(fullPath);
-          if (stat.isDirectory()) {
+        const dirents = fs.readdirSync(dir, { withFileTypes: true });
+        for (const dirent of dirents) {
+          const fullPath = pathResolve(dir, dirent.name);
+          if (dirent.isDirectory()) {
             zipDirRecursive(fullPath);
           } else {
             // Add relative file paths to a root of "zip" for MDAPI.

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -443,8 +443,6 @@ export class MetadataApiDeploy extends MetadataTransfer<
       }
 
       const zip = JSZip();
-      // metadata API doesn't want things at root, so add everything to a directory named, "zip"
-      zip.folder('zip');
 
       const zipDirRecursive = (dir: string): void => {
         const list = fs.readdirSync(dir);
@@ -454,7 +452,9 @@ export class MetadataApiDeploy extends MetadataTransfer<
           if (stat.isDirectory()) {
             zipDirRecursive(fullPath);
           } else {
-            zip.file(relative(mdapiPath, fullPath), fs.createReadStream(fullPath));
+            // Add relative file paths to a root of "zip" for MDAPI.
+            const relPath = join('zip', relative(mdapiPath, fullPath));
+            zip.file(relPath, fs.createReadStream(fullPath));
           }
         }
       };

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -273,7 +273,7 @@ export class MetadataApiDeploy extends MetadataTransfer<
     }
 
     const conn = await this.getConnection();
-    const response = (await conn.deployRecentValidation({
+    const response = (await conn.metadata.deployRecentValidation({
       id: this.id,
       rest,
     })) as unknown as AsyncResult | string;

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -443,6 +443,8 @@ export class MetadataApiDeploy extends MetadataTransfer<
       }
 
       const zip = JSZip();
+      // metadata API doesn't want things at root, so add everything to a directory named, "zip"
+      zip.folder('zip');
 
       const zipDirRecursive = (dir: string): void => {
         const list = fs.readdirSync(dir);
@@ -452,9 +454,7 @@ export class MetadataApiDeploy extends MetadataTransfer<
           if (stat.isDirectory()) {
             zipDirRecursive(fullPath);
           } else {
-            // Add relative file paths to a root of "zip" for MDAPI.
-            const relPath = join('zip', relative(mdapiPath, fullPath));
-            zip.file(relPath, fs.createReadStream(fullPath));
+            zip.file(relative(mdapiPath, fullPath), fs.createReadStream(fullPath));
           }
         }
       };

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, extname, join, posix, relative, resolve, sep } from 'path';
+import { basename, dirname, extname, join, posix, relative, resolve as pathResolve, sep } from 'path';
 import { format } from 'util';
 import { isString } from '@salesforce/ts-types';
 import * as JSZip from 'jszip';
@@ -444,10 +444,10 @@ export class MetadataApiDeploy extends MetadataTransfer<
 
       const zip = JSZip();
 
-      const zipDirRecursive = (dir: string) => {
+      const zipDirRecursive = (dir: string): void => {
         const list = fs.readdirSync(dir);
         for (const file of list) {
-          const fullPath = resolve(dir, file);
+          const fullPath = pathResolve(dir, file);
           const stat = fs.statSync(fullPath);
           if (stat.isDirectory()) {
             zipDirRecursive(fullPath);
@@ -458,11 +458,11 @@ export class MetadataApiDeploy extends MetadataTransfer<
           }
         }
       };
-      console.log('Zipping directory for metadata deploy:', mdapiPath);
+      this.logger.debug('Zipping directory for metadata deploy:', mdapiPath);
       zipDirRecursive(mdapiPath);
 
       return zip.generateAsync({
-        type: "nodebuffer",
+        type: 'nodebuffer',
         compression: 'DEFLATE',
         compressionOptions: { level: 9 },
       });

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -455,7 +455,7 @@ export class MetadataApiDeploy extends MetadataTransfer<
             // Add relative file paths to a root of "zip" for MDAPI.
             const relPath = join('zip', relative(mdapiPath, fullPath));
             // Ensure only posix paths are added to zip files
-            const relPosixPath = relPath.replace(sep, '/');
+            const relPosixPath = relPath.replace(/\\/g, '/');
             zip.file(relPosixPath, fs.createReadStream(fullPath));
           }
         }

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -454,7 +454,9 @@ export class MetadataApiDeploy extends MetadataTransfer<
           } else {
             // Add relative file paths to a root of "zip" for MDAPI.
             const relPath = join('zip', relative(mdapiPath, fullPath));
-            zip.file(relPath, fs.createReadStream(fullPath));
+            // Ensure only posix paths are added to zip files
+            const relPosixPath = relPath.replace(sep, '/');
+            zip.file(relPosixPath, fs.createReadStream(fullPath));
           }
         }
       };

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -55,7 +55,6 @@ export class MetadataConverter {
         mergeSet,
         tasks = [],
       } = await getConvertIngredients(output, cs, targetFormatIsSource);
-      console.log('convert to path:', packagePath);
 
       const conversionPipeline = pipeline(
         Readable.from(components),

--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -55,6 +55,7 @@ export class MetadataConverter {
         mergeSet,
         tasks = [],
       } = await getConvertIngredients(output, cs, targetFormatIsSource);
+      console.log('convert to path:', packagePath);
 
       const conversionPipeline = pipeline(
         Readable.from(components),

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, isAbsolute, join, sep } from 'path';
+import { basename, dirname, isAbsolute, join } from 'path';
 import { pipeline as cbPipeline, Readable, Stream, Transform, Writable } from 'stream';
 import { promisify } from 'util';
 import { Messages, SfError } from '@salesforce/core';
@@ -234,7 +234,7 @@ export class ZipWriter extends ComponentWriter {
 
   public addToZip(contents: string | Readable | Buffer, path: SourcePath): void {
     // Ensure only posix paths are added to zip files
-    const posixPath = path.replace(sep, '/');
+    const posixPath = path.replace(/\\/g, '/');
     this.zip.file(posixPath, contents);
   }
 }

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, isAbsolute, join } from 'path';
+import { basename, dirname, isAbsolute, join, sep } from 'path';
 import { pipeline as cbPipeline, Readable, Stream, Transform, Writable } from 'stream';
 import { promisify } from 'util';
 import { Messages, SfError } from '@salesforce/core';
@@ -223,7 +223,7 @@ export class ZipWriter extends ComponentWriter {
       this.zipBuffer = await this.zip.generateAsync({
         type: 'nodebuffer',
         compression: 'DEFLATE',
-        compressionOptions: { level: 9 }, // Need level 9 for backwards compat
+        compressionOptions: { level: 3 },
       });
       this.logger.debug('Generated zip complete');
     } catch (e) {
@@ -233,7 +233,9 @@ export class ZipWriter extends ComponentWriter {
   }
 
   public addToZip(contents: string | Readable | Buffer, path: SourcePath): void {
-    this.zip.file(path, contents);
+    // Ensure only posix paths are added to zip files
+    const posixPath = path.replace(sep, '/');
+    this.zip.file(posixPath, contents);
   }
 }
 

--- a/src/convert/transformers/baseMetadataTransformer.ts
+++ b/src/convert/transformers/baseMetadataTransformer.ts
@@ -8,15 +8,18 @@ import { MetadataTransformer, WriteInfo } from '../types';
 import { ConvertContext } from '../convertContext';
 import { SourceComponent } from '../../resolve';
 import { RegistryAccess } from '../../registry';
+import { Logger } from '@salesforce/core';
 
 export abstract class BaseMetadataTransformer implements MetadataTransformer {
   public readonly context: ConvertContext;
   public defaultDirectory?: string;
   protected registry: RegistryAccess;
+  protected logger: Logger;
 
   public constructor(registry = new RegistryAccess(), context = new ConvertContext()) {
     this.registry = registry;
     this.context = context;
+    this.logger = Logger.childFromRoot(this.constructor.name);
   }
 
   public abstract toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]>;

--- a/src/convert/transformers/baseMetadataTransformer.ts
+++ b/src/convert/transformers/baseMetadataTransformer.ts
@@ -4,11 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { Logger } from '@salesforce/core';
 import { MetadataTransformer, WriteInfo } from '../types';
 import { ConvertContext } from '../convertContext';
 import { SourceComponent } from '../../resolve';
 import { RegistryAccess } from '../../registry';
-import { Logger } from '@salesforce/core';
 
 export abstract class BaseMetadataTransformer implements MetadataTransformer {
   public readonly context: ConvertContext;

--- a/src/convert/transformers/baseMetadataTransformer.ts
+++ b/src/convert/transformers/baseMetadataTransformer.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Logger } from '@salesforce/core';
 import { MetadataTransformer, WriteInfo } from '../types';
 import { ConvertContext } from '../convertContext';
 import { SourceComponent } from '../../resolve';
@@ -14,12 +13,10 @@ export abstract class BaseMetadataTransformer implements MetadataTransformer {
   public readonly context: ConvertContext;
   public defaultDirectory?: string;
   protected registry: RegistryAccess;
-  protected logger: Logger;
 
   public constructor(registry = new RegistryAccess(), context = new ConvertContext()) {
     this.registry = registry;
     this.context = context;
-    this.logger = Logger.childFromRoot(this.constructor.name);
   }
 
   public abstract toMetadataFormat(component: SourceComponent): Promise<WriteInfo[]>;

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, isAbsolute, join, relative, sep } from 'path';
+import { basename, dirname, isAbsolute, join, relative } from 'path';
 import { Readable } from 'stream';
 import * as JSZip from 'jszip';
 import { getExtension } from 'mime';
@@ -60,7 +60,7 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
       for (const path of component.walkContent()) {
         const replacementStream = getReplacementStreamForReadable(component, path);
         const relPath = relative(content, path);
-        const relPosixPath = relPath.replace(sep, '/');
+        const relPosixPath = relPath.replace(/\\/g, '/');
         zip.file(relPosixPath, replacementStream);
       }
 

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, dirname, isAbsolute, join, relative } from 'path';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'path';
 import { Readable } from 'stream';
 import * as JSZip from 'jszip';
 import { getExtension } from 'mime';
@@ -59,7 +59,9 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
       // have to walk the component content. Replacements only happen if set on the component.
       for (const path of component.walkContent()) {
         const replacementStream = getReplacementStreamForReadable(component, path);
-        zip.file(relative(content, path), replacementStream);
+        const relPath = relative(content, path);
+        const relPosixPath = relPath.replace(sep, '/');
+        zip.file(relPosixPath, replacementStream);
       }
 
       return new Readable().wrap(

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -12,6 +12,7 @@ import { CentralDirectory, Open } from 'unzipper';
 import { JsonMap } from '@salesforce/ts-types';
 import { createWriteStream } from 'graceful-fs';
 import { Logger, Messages, SfError } from '@salesforce/core';
+import { isEmpty } from '@salesforce/kit';
 import { baseName } from '../../utils';
 import { WriteInfo } from '..';
 import { SourceComponent } from '../../resolve';
@@ -62,6 +63,12 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
         const relPath = relative(content, path);
         const relPosixPath = relPath.replace(/\\/g, '/');
         zip.file(relPosixPath, replacementStream);
+      }
+
+      // If the generated zip is empty it means either no content files exist or they are
+      // all force-ignored.  Throw an error in this case.
+      if (isEmpty(zip.files)) {
+        throw messages.createError('noContentFound', [component.fullName, component.type.name]);
       }
 
       return new Readable().wrap(

--- a/src/resolve/adapters/mixedContentSourceAdapter.ts
+++ b/src/resolve/adapters/mixedContentSourceAdapter.ts
@@ -58,6 +58,8 @@ export class MixedContentSourceAdapter extends BaseSourceAdapter {
         : trimmedPath;
 
     // Content path might be undefined for staticResource where all files are ignored and only the xml is included.
+    // Note that if contentPath is a directory that is not ignored, but all the files within it are
+    // ignored (or it's an empty dir) contentPath will be truthy and the error will not be thrown.
     if (!contentPath || !this.tree.exists(contentPath)) {
       throw new SfError(
         messages.getMessage('error_expected_source_files', [trigger, this.type.name]),

--- a/test/convert/metadataConverter.test.ts
+++ b/test/convert/metadataConverter.test.ts
@@ -300,29 +300,6 @@ describe('MetadataConverter', () => {
       expect(ensureDirectoryStub.firstCall.args[0]).to.equal(dirname(zipPath));
     });
 
-    it('should create conversion pipeline with fs write configuration', async () => {
-      await converter.convert(components, 'metadata', {
-        type: 'zip',
-        outputDirectory,
-        packageName,
-      });
-
-      // secondCall is used because ZipWriter uses pipeline upon construction
-      const pipelineArgs = pipelineStub.secondCall.args;
-      validatePipelineArgs(pipelineArgs);
-      expect(pipelineArgs[3] instanceof streams.ZipWriter).to.be.true;
-      expect(pipelineArgs[3].rootDestination).to.equal(`${packageOutput}.zip`);
-    });
-
-    it('should create conversion pipeline with in-memory configuration', async () => {
-      await converter.convert(components, 'metadata', { type: 'zip' });
-
-      const pipelineArgs = pipelineStub.secondCall.args;
-      validatePipelineArgs(pipelineArgs);
-      expect(pipelineArgs[3] instanceof streams.ZipWriter).to.be.true;
-      expect(pipelineArgs[3].rootDestination).to.be.undefined;
-    });
-
     it('should return zipBuffer result for in-memory configuration', async () => {
       const testBuffer = Buffer.from('oh hi mark');
       $$.SANDBOX.stub(streams.ZipWriter.prototype, 'buffer').value(testBuffer);

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -454,7 +454,7 @@ describe('Streams', () => {
         await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
-        expect(jsZipFileStub.firstCall.args[0]).to.equal('classes/myComponent.cls-meta.xml');
+        expect(jsZipFileStub.firstCall.args[0]).to.equal(join('classes', 'myComponent.cls-meta.xml'));
         expect(jsZipFileStub.firstCall.args[1]).to.deep.equal(Buffer.from('hi'));
       });
 
@@ -466,7 +466,7 @@ describe('Streams', () => {
         await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
-        expect(jsZipFileStub.firstCall.args[0]).to.equal('classes/myComponent.cls-meta.xml');
+        expect(jsZipFileStub.firstCall.args[0]).to.equal(join('classes', 'myComponent.cls-meta.xml'));
         expect(jsZipFileStub.firstCall.args[1]).to.deep.equal(Buffer.from('hi'));
       });
 

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -454,7 +454,8 @@ describe('Streams', () => {
         await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
-        expect(jsZipFileStub.firstCall.args[0]).to.equal(join('classes', 'myComponent.cls-meta.xml'));
+        // NOTE: Zips must only contain files with posix paths
+        expect(jsZipFileStub.firstCall.args[0]).to.equal('classes/myComponent.cls-meta.xml');
         expect(jsZipFileStub.firstCall.args[1]).to.deep.equal(Buffer.from('hi'));
       });
 
@@ -466,7 +467,7 @@ describe('Streams', () => {
         await writer._write(chunk, '', (err: Error | undefined) => {
           expect(err).to.be.undefined;
         });
-        expect(jsZipFileStub.firstCall.args[0]).to.equal(join('classes', 'myComponent.cls-meta.xml'));
+        expect(jsZipFileStub.firstCall.args[0]).to.equal('classes/myComponent.cls-meta.xml');
         expect(jsZipFileStub.firstCall.args[1]).to.deep.equal(Buffer.from('hi'));
       });
 
@@ -475,7 +476,7 @@ describe('Streams', () => {
         const expectedArgs = {
           type: 'nodebuffer',
           compression: 'DEFLATE',
-          compressionOptions: { level: 9 },
+          compressionOptions: { level: 3 },
         };
 
         await writer._final((err: Error | undefined) => {

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'graceful-fs';
 import { Logger, SfError, Messages } from '@salesforce/core';
 import { expect, assert } from 'chai';
 import { createSandbox, SinonStub } from 'sinon';
+import JSZip = require('jszip');
 import * as streams from '../../src/convert/streams';
 import * as fsUtil from '../../src/utils/fileSystemHandler';
 import { ComponentSet, MetadataResolver, RegistryAccess, SourceComponent, WriteInfo, WriterFormat } from '../../src';
@@ -19,7 +20,6 @@ import { COMPONENTS } from '../mock/type-constants/reportConstant';
 import { XML_DECL, XML_NS_KEY, XML_NS_URL } from '../../src/common';
 import { COMPONENT, CONTENT_NAMES, TYPE_DIRECTORY, XML_NAMES } from '../mock/type-constants/apexClassConstant';
 import { BaseMetadataTransformer } from '../../src/convert/transformers/baseMetadataTransformer';
-import JSZip = require('jszip');
 
 const env = createSandbox();
 const registryAccess = new RegistryAccess();

--- a/test/convert/transformers/metadataTransformerFactory.test.ts
+++ b/test/convert/transformers/metadataTransformerFactory.test.ts
@@ -24,13 +24,10 @@ const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sd
 const registryAccess = new RegistryAccess();
 
 describe('MetadataTransformerFactory', () => {
-  it.only('should return DefaultMetadataTransformer', () => {
+  it('should return DefaultMetadataTransformer', () => {
     const component = matchingContentFile.COMPONENT;
     const factory = new MetadataTransformerFactory(registryAccess);
-    const transformer = factory.getTransformer(component);
-    // console.dir(transformer.context, { depth: 8 });
-    // console.dir(new DefaultMetadataTransformer(), { depth: 8 });
-    expect(transformer).to.deep.equal(new DefaultMetadataTransformer(registryAccess, new ConvertContext()));
+    expect(factory.getTransformer(component)).to.deep.equal(new DefaultMetadataTransformer());
   });
 
   it('should return DecomposedMetadataTransformer', () => {

--- a/test/convert/transformers/metadataTransformerFactory.test.ts
+++ b/test/convert/transformers/metadataTransformerFactory.test.ts
@@ -24,10 +24,13 @@ const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sd
 const registryAccess = new RegistryAccess();
 
 describe('MetadataTransformerFactory', () => {
-  it('should return DefaultMetadataTransformer', () => {
+  it.only('should return DefaultMetadataTransformer', () => {
     const component = matchingContentFile.COMPONENT;
     const factory = new MetadataTransformerFactory(registryAccess);
-    expect(factory.getTransformer(component)).to.deep.equal(new DefaultMetadataTransformer());
+    const transformer = factory.getTransformer(component);
+    // console.dir(transformer.context, { depth: 8 });
+    // console.dir(new DefaultMetadataTransformer(), { depth: 8 });
+    expect(transformer).to.deep.equal(new DefaultMetadataTransformer(registryAccess, new ConvertContext()));
   });
 
   it('should return DecomposedMetadataTransformer', () => {

--- a/test/convert/transformers/staticResourceMetadataTransformer.test.ts
+++ b/test/convert/transformers/staticResourceMetadataTransformer.test.ts
@@ -88,6 +88,9 @@ describe('StaticResourceMetadataTransformer', () => {
         // eslint-disable-next-line no-await-in-loop
         const result = await transformer.toMetadataFormat(component);
         expect(jszipFileStub.calledThrice).to.be.true;
+        expect(jszipFileStub.firstCall.args[0]).to.not.contain('\\', 'zip must only contain posix paths');
+        expect(jszipFileStub.secondCall.args[0]).to.not.contain('\\', 'zip must only contain posix paths');
+        expect(jszipFileStub.thirdCall.args[0]).to.not.contain('\\', 'zip must only contain posix paths');
         expect(jszipStreamStub.calledOnce).to.be.true;
         expect(jszipStreamStub.firstCall.args[0]).to.deep.equal({
           compression: 'DEFLATE',

--- a/test/mock/client/index.ts
+++ b/test/mock/client/index.ts
@@ -4,22 +4,16 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { pipeline, Writable } from 'stream';
-import { promisify } from 'util';
-import { create as createArchive } from 'archiver';
+import * as JSZip from 'jszip';
 
 export async function createMockZip(entries: string[]): Promise<Buffer> {
-  const archive = createArchive('zip');
+  const zip = JSZip();
   for (const entry of entries) {
-    archive.append('', { name: entry });
+    zip.file(entry, '');
   }
-  await archive.finalize();
-  const bufferWritable = new Writable();
-  const buffers: Buffer[] = [];
-  bufferWritable._write = (chunk: Buffer, encoding: string, cb: () => void): void => {
-    buffers.push(chunk);
-    cb();
-  };
-  await promisify(pipeline)(archive, bufferWritable);
-  return Buffer.concat(buffers);
+  return zip.generateAsync({
+    type: 'nodebuffer',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 9 },
+  });
 }

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -80,10 +80,10 @@ export async function stubMetadataDeploy(
 
   deployStub.withArgs(zipBuffer, options.apiOptions ?? defaultOptions).resolves(MOCK_ASYNC_RESULT);
 
-  const deployRecentlyValidatedIdStub = sandbox.stub(connection, 'deployRecentValidation');
+  const deployRecentlyValidatedIdStub = sandbox.stub(connection.metadata, 'deployRecentValidation');
   deployRecentlyValidatedIdStub
     .withArgs({ id: MOCK_ASYNC_RESULT.id, rest: true })
-    .resolves(MOCK_RECENTLY_VALIDATED_ID_REST)
+    .resolves(MOCK_RECENTLY_VALIDATED_ID_REST.id)
     .withArgs({ id: MOCK_ASYNC_RESULT.id, rest: false })
     // @ts-ignore overriding return type to match API
     .resolves(MOCK_RECENTLY_VALIDATED_ID_SOAP);

--- a/test/mock/type-constants/staticresourceConstant.ts
+++ b/test/mock/type-constants/staticresourceConstant.ts
@@ -11,6 +11,7 @@ import { registry, SourceComponent } from '../../../src';
 const type = registry.types.staticresource;
 
 export const MIXED_CONTENT_DIRECTORY_DIR = join('path', 'to', 'staticresources');
+export const MIXED_CONTENT_DIRECTORY_CONTENT_DIR = join(MIXED_CONTENT_DIRECTORY_DIR, 'aStaticResource');
 export const MIXED_CONTENT_DIRECTORY_CONTENT_PATH = join(MIXED_CONTENT_DIRECTORY_DIR, 'aStaticResource.json');
 export const MIXED_CONTENT_DIRECTORY_XML_NAMES = ['aStaticResource.resource-meta.xml'];
 export const MIXED_CONTENT_DIRECTORY_XML_PATHS = MIXED_CONTENT_DIRECTORY_XML_NAMES.map((n) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3979,6 +3979,11 @@ ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4604,6 +4609,16 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 just-diff-apply@^5.2.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/just-diff-apply/-/just-diff-apply-5.5.0.tgz#771c2ca9fa69f3d2b54e7c3f5c1dfcbcc47f9f0f"
@@ -4670,6 +4685,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -5833,6 +5855,11 @@ pad-component@0.0.1:
   resolved "https://registry.yarnpkg.com/pad-component/-/pad-component-0.0.1.tgz#ad1f22ce1bf0fdc0d6ddd908af17f351a404b8ac"
   integrity sha512-8EKVBxCRSvLnsX1p2LlSFSH3c2/wuhY9/BXXWu8boL78FbVKqn2L5SpURt1x5iw6Gq8PTqJ7MdPoe5nCtX3I+g==
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -6509,7 +6536,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-setimmediate@~1.0.4:
+setimmediate@^1.0.5, setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,13 +1106,6 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@types/archiver@^5.3.1":
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-5.3.2.tgz#a9f0bcb0f0b991400e7766d35f6e19d163bdadcc"
-  integrity sha512-IctHreBuWE5dvBDz/0WeKtyVKVRs4h75IblxOACL92wU66v+HGAfEYAOyXkOFphvRJMhuXdI9huDXpX0FC6lCw==
-  dependencies:
-    "@types/readdir-glob" "*"
-
 "@types/cacheable-request@^6.0.1":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"
@@ -1241,13 +1234,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/proxy-from-env/-/proxy-from-env-1.0.1.tgz#b5f3e99230ca4518af196c18267055fc51f892b7"
   integrity sha512-luG++TFHyS61eKcfkR1CVV6a1GMNXDjtqEQIIfaSHax75xp0HU3SlezjOi1yqubJwrG8e9DeW59n6wTblIDwFg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/readdir-glob@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/readdir-glob/-/readdir-glob-1.1.1.tgz#27ac2db283e6aa3d110b14ff9da44fcd1a5c38b1"
-  integrity sha512-ImM6TmoF8bgOwvehGviEj3tRdRBbQujr1N+0ypaln/GWjaerOB26jb93vsRHmdMtvVQZQebOlqt2HROark87mQ==
   dependencies:
     "@types/node" "*"
 
@@ -4527,32 +4513,6 @@ jsforce@^2.0.0-beta.21:
   version "2.0.0-beta.22"
   resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.22.tgz#cccb72b3f89b451e3e24e52661c008d334e07909"
   integrity sha512-aSmztQYS64z/Pr7QmJwpq67Qzajt8nVrZDf8dbU+TEWhOXIHlJ8q8Dx6p0zaV89WksxUDmSt6dA11KcZEBFXPw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.12.5"
-    "@types/node" "^12.19.9"
-    abort-controller "^3.0.0"
-    base64url "^3.0.1"
-    commander "^4.0.1"
-    core-js "^3.6.4"
-    csv-parse "^4.8.2"
-    csv-stringify "^5.3.4"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    fs-extra "^8.1.0"
-    https-proxy-agent "^5.0.0"
-    inquirer "^7.0.0"
-    multistream "^3.1.0"
-    node-fetch "^2.6.1"
-    open "^7.0.0"
-    regenerator-runtime "^0.13.3"
-    strip-ansi "^6.0.0"
-    xml2js "^0.5.0"
-
-jsforce@^2.0.0-beta.23:
-  version "2.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.23.tgz#5eeb1a2635498ee77f0726ababe089cc12113551"
-  integrity sha512-lfeLHbCJ40ela1JPu4VqgK1GtIzR0NQOMZ/Rxesv9Ty3PyxK18o01AQ4E+JqGAWDDQhwyUp2A/9V+uOqU3w7Rw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,7 +1537,7 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
-archiver@^5.2.0, archiver@^5.3.0, archiver@^5.3.1:
+archiver@^5.2.0, archiver@^5.3.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.1.tgz#21e92811d6f09ecfce649fbefefe8c79e57cbbb6"
   integrity sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,6 +4526,32 @@ jsforce@^2.0.0-beta.21:
     strip-ansi "^6.0.0"
     xml2js "^0.5.0"
 
+jsforce@^2.0.0-beta.23:
+  version "2.0.0-beta.23"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.23.tgz#5eeb1a2635498ee77f0726ababe089cc12113551"
+  integrity sha512-lfeLHbCJ40ela1JPu4VqgK1GtIzR0NQOMZ/Rxesv9Ty3PyxK18o01AQ4E+JqGAWDDQhwyUp2A/9V+uOqU3w7Rw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@babel/runtime-corejs3" "^7.12.5"
+    "@types/node" "^12.19.9"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    commander "^4.0.1"
+    core-js "^3.6.4"
+    csv-parse "^4.8.2"
+    csv-stringify "^5.3.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    inquirer "^7.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    open "^7.0.0"
+    regenerator-runtime "^0.13.3"
+    strip-ansi "^6.0.0"
+    xml2js "^0.5.0"
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"


### PR DESCRIPTION
### What does this PR do?
Replaces the archiver library with jszip.

### What issues does this PR fix or reference?
@W-13196750@

QA Notes:
Be sure to test using both NodeJS v18.16.0 and v18.15.0, but primarily 18.16.0.
1. conversion of static resources
2. deploys, both source and metadata format with static resources
3. retrieves
4. package version create with static resources
