### PR TITLE
@W-13311344 Adding ScoreCategory to metadata registry

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -462,7 +462,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |SchedulingObjective|✅||
 |SchedulingRule|✅||
 |SchemaSettings|✅||
-|ScoreCategory|❌|Not supported, but support could be added|
+|ScoreCategory|✅||
 |SearchSettings|✅||
 |SecuritySettings|✅||
 |ServiceAISetupDefinition|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2749,6 +2749,13 @@
       "directoryName": "SchedulingRules",
       "strictDirectoryName": false
     },
+    "ScoreCategory": {
+      "id": "ScoreCategory",
+      "name": "ScoreCategory",
+      "suffix": "ScoreCategory",
+      "directoryName": "scoreCategories",
+      "inFolder": false
+    },
     "userauthcertificate": {
       "id": "userauthcertificate",
       "name": "UserAuthCertificate",
@@ -3757,6 +3764,7 @@
     "ConversationVendorInformation": "conversationvendorinfo",
     "ConversationVendorFieldDefinition": "conversationvendorfielddef",
     "schedulingRule": "schedulingrule",
+    "ScoreCategory": "ScoreCategory",
     "userAuthCertificate": "userauthcertificate",
     "forecastingTypeSource": "forecastingtypesource",
     "forecastingType": "forecastingtype",


### PR DESCRIPTION
### What does this PR do?

Adds new MetadataType 'ScoreCategory' to the registry.

### What issues does this PR fix or reference?

@W-13311344

### Functionality Before

ScoreCategory metadata type is not accessible through SFDX cli

### Functionality After

ScoreCategory metadata type is accessible through SFDX cli
