### PR TITLE
@W-13311344 Adding ScoreCategory to metadata registry

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -462,7 +462,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |SchedulingObjective|✅||
 |SchedulingRule|✅||
 |SchemaSettings|✅||
-|ScoreCategory|❌|Not supported, but support could be added|
+|ScoreCategory|✅||
 |SearchSettings|✅||
 |SecuritySettings|✅||
 |ServiceAISetupDefinition|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1706,6 +1706,13 @@
       "directoryName": "skilltypes",
       "inFolder": false
     },
+    "scorecategory": {
+      "id": "scorecategory",
+      "name": "ScoreCategory",
+      "suffix": "scorecategory",
+      "directoryName": "scoreCategories",
+      "inFolder": false
+    },
     "livechatdeployment": {
       "id": "livechatdeployment",
       "name": "LiveChatDeployment",
@@ -3647,6 +3654,7 @@
     "policy": "appointmentassignmentpolicy",
     "skill": "skill",
     "skilltype": "skilltype",
+    "scorecategory": "scorecategory",
     "liveChatDeployment": "livechatdeployment",
     "liveChatButton": "livechatbutton",
     "liveChatAgentConfig": "livechatagentconfig",


### PR DESCRIPTION
### What does this PR do?
Adds new MetadataType 'ScoreCategory' to the registry.

### What issues does this PR fix or reference?
@W-13311344

### Functionality Before
ScoreCategory metadata type is not accessible through SFDX cli


### Functionality After
ScoreCategory metadata type is accessible through SFDX cli

