### PR TITLE
fix: update registry for ExpressionSetVersion

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2513,6 +2513,22 @@
         }
       }
     },
+    "expressionsetdefinition": {
+      "id": "expressionsetdefinition",
+      "name": "ExpressionSetDefinition",
+      "suffix": "expressionSetDefinition",
+      "directoryName": "expressionSetDefinition",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "expressionsetdefinitionversion": {
+      "id": "expressionsetdefinitionversion",
+      "name": "ExpressionSetDefinitionVersion",
+      "suffix": "expressionSetVersion",
+      "directoryName": "expressionSetVersion",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "briefcasedefinition": {
       "id": "briefcasedefinition",
       "name": "BriefcaseDefinition",
@@ -3443,22 +3459,6 @@
       "directoryName": "useraccesspolicies",
       "inFolder": false,
       "strictDirectoryName": false
-    },
-    "expressionsetdefinition": {
-      "id": "expressionsetdefinition",
-      "name": "ExpressionSetDefinition",
-      "suffix": "expressionSetDefinition",
-      "directoryName": "expressionSetDefinition",
-      "inFolder": false,
-      "strictDirectoryName": false
-    },
-    "expressionsetdefinitionversion": {
-      "id": "expressionsetdefinitionversion",
-      "name": "ExpressionSetDefinitionVersion",
-      "suffix": "expressionSetVersion",
-      "directoryName": "expressionSetVersion",
-      "inFolder": false,
-      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3488,6 +3488,8 @@
     "decisionTableDatasetLink": "decisiontabledatasetlink",
     "decisionMatrixDefinition": "decisionmatrixdefinition",
     "decisionMatrixDefinitionVersion": "decisionmatrixdefinitionversion",
+    "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetVersion": "expressionsetdefinitionversion",
     "briefcaseDefinition": "briefcasedefinition",
     "batchProcessJobDefinition": "batchprocessjobdefinition",
     "acctMgrTargetSetting": "acctmgrtargetsettings",
@@ -3836,9 +3838,7 @@
     "personAccountOwnerPowerUser": "personaccountownerpoweruser",
     "pipelineInspMetricConfig": "pipelineinspmetricconfig",
     "productSpecificationTypeDefinition": "productspecificationtypedefinition",
-    "useraccesspolicy": "useraccesspolicy",
-    "expressionSetDefinition": "expressionsetdefinition",
-    "expressionSetVersion": "expressionsetdefinitionversion"
+    "useraccesspolicy": "useraccesspolicy"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2513,30 +2513,6 @@
         }
       }
     },
-    "expressionsetdefinition": {
-      "id": "expressionsetdefinition",
-      "name": "ExpressionSetDefinition",
-      "suffix": "expressionSetDefinition",
-      "directoryName": "expressionSetDefinition",
-      "inFolder": false,
-      "strictDirectoryName": false,
-      "children": {
-        "types": {
-          "expressionsetdefinitionversion": {
-            "id": "expressionsetdefinitionversion",
-            "name": "ExpressionSetDefinitionVersion",
-            "directoryName": "versions",
-            "suffix": "expressionSetDefinitionVersion"
-          }
-        },
-        "directories": {
-          "versions": "expressionsetdefinitionversion"
-        },
-        "suffixes": {
-          "expressionSetDefinitionVersion": "expressionsetdefinitionversion"
-        }
-      }
-    },
     "briefcasedefinition": {
       "id": "briefcasedefinition",
       "name": "BriefcaseDefinition",
@@ -3467,6 +3443,22 @@
       "directoryName": "useraccesspolicies",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "expressionsetdefinition": {
+      "id": "expressionsetdefinition",
+      "name": "ExpressionSetDefinition",
+      "suffix": "expressionSetDefinition",
+      "directoryName": "expressionSetDefinition",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "expressionsetdefinitionversion": {
+      "id": "expressionsetdefinitionversion",
+      "name": "ExpressionSetDefinitionVersion",
+      "suffix": "expressionSetVersion",
+      "directoryName": "expressionSetVersion",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3496,8 +3488,6 @@
     "decisionTableDatasetLink": "decisiontabledatasetlink",
     "decisionMatrixDefinition": "decisionmatrixdefinition",
     "decisionMatrixDefinitionVersion": "decisionmatrixdefinitionversion",
-    "expressionSetDefinition": "expressionsetdefinition",
-    "expressionSetDefinitionVersion": "expressionsetdefinitionversion",
     "briefcaseDefinition": "briefcasedefinition",
     "batchProcessJobDefinition": "batchprocessjobdefinition",
     "acctMgrTargetSetting": "acctmgrtargetsettings",
@@ -3846,7 +3836,9 @@
     "personAccountOwnerPowerUser": "personaccountownerpoweruser",
     "pipelineInspMetricConfig": "pipelineinspmetricconfig",
     "productSpecificationTypeDefinition": "productspecificationtypedefinition",
-    "useraccesspolicy": "useraccesspolicy"
+    "useraccesspolicy": "useraccesspolicy",
+    "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetVersion": "expressionsetdefinitionversion"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",
@@ -3909,7 +3901,6 @@
     "mktdatatranfield": "mktdatatranobject",
     "digitalexperience": "digitalexperiencebundle",
     "decisionmatrixdefinitionversion": "decisionmatrixdefinition",
-    "expressionsetdefinitionversion": "expressionsetdefinition",
     "aiscoringmodeldefversion": "aiscoringmodeldefinition"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Follow-up PR to #758 we had received an investigation that ExpressionSetVersion could not be retrieved separately (it was only coming through as child of the parent ExpressionSetDefinitionVersion. I removed the manual changes from that PR, ran the `update-registry` script, and both metadata types are now being retrieved as expected.

### What issues does this PR fix or reference?
@W-13207993@

### Functionality Before
ExpressionSetVersion (ExpressionSetDefinitionVersion) was not being retrieved.
https://github.com/forcedotcom/source-deploy-retrieve/assets/9795193/7aead06e-94ff-4095-8fb2-3bb6cee46323

### Functionality After
This metadata is now retrieved through VS Code's Org Browser & Manifest Builder as expected.
https://github.com/forcedotcom/source-deploy-retrieve/assets/9795193/0b937b3a-618f-463b-b183-5eb3bbcfb1d0
