### PR TITLE
fix!: use more jsforce typings

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { CodeCoverageWarning, RunTestFailure, RunTestSuccess } from 'jsforce/lib/api/metadata';
 import { ComponentSet } from '../collections';
 import { PackageTypeMembers } from '../collections/types';
 import { SourcePath } from '../common/types';
@@ -167,29 +168,9 @@ export interface LocationsNotCovered {
   time: string;
 }
 
-export interface CodeCoverageWarnings {
-  id: string;
-  message: string;
-  namespace: string;
-}
-
-export interface Failures {
-  id: string;
-  message: string;
-  methodName: string;
-  name: string;
-  packageName: string;
-  stackTrace: string;
-  time: string;
-  type: string;
-}
-
-export interface Successes {
-  id: string;
-  methodName: string;
-  name: string;
-  time: string;
-}
+export type CodeCoverageWarnings = CodeCoverageWarning;
+export type Failures = RunTestFailure;
+export type Successes = RunTestSuccess;
 
 type BooleanString = 'true' | 'false' | true | false;
 


### PR DESCRIPTION
### What does this PR do?
SDR has TS types for all the mdapi responses.  One of them was wrong: 
https://github.com/salesforcecli/plugin-deploy-retrieve/pull/633
forcedotcom/cli#2149 @W-13481008@

while we're making a major version, I took several jsforce2 types and used them for SDR.  There's a few differences/corrections, so wanted to get this in the major version.

jsforce2 types are generated from the wsdl, so they tend to be more accurate except for array types which it can't tell are optional or not.  If it weren't for that problem, I'd use jsforce's types even more extensively.
