### PR TITLE
fix: update metadata names for mobile settings and policies

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -8,574 +8,573 @@ Currently, there are 518/550 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|AIApplication|✅||
-|AIApplicationConfig|✅||
-|AIReplyRecommendationsSettings|✅||
-|AIScoringModelDefVersion|⚠️|Supports deploy/retrieve but not source tracking|
-|AIScoringModelDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AIUsecaseDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AccountForecastSettings|✅||
-|AccountInsightsSettings|✅||
-|AccountIntelligenceSettings|✅||
-|AccountRelationshipShareRule|✅||
-|AccountSettings|✅||
-|AccountingFieldMapping|✅||
-|AccountingModelConfig|✅||
-|AccountingSettings|✅||
-|AcctMgrTargetSettings|✅||
-|ActionLauncherItemDef|✅||
-|ActionLinkGroupTemplate|✅||
-|ActionPlanTemplate|✅||
-|ActionableListDefinition|✅||
-|ActionsSettings|✅||
-|ActivationPlatform|✅||
-|ActivitiesSettings|✅||
-|AddressSettings|✅||
-|AdvAccountForecastSet|✅||
-|AdvAcctForecastDimSource|✅||
-|AdvAcctForecastPeriodGroup|✅||
-|Ai4mSettings|✅||
-|AnalyticSnapshot|✅||
-|AnalyticsSettings|✅||
-|AnimationRule|✅||
-|ApexClass|✅||
-|ApexComponent|✅||
-|ApexEmailNotifications|✅||
-|ApexPage|✅||
-|ApexSettings|✅||
-|ApexTestSuite|✅||
-|ApexTrigger|✅||
-|AppAnalyticsSettings|✅||
-|AppExperienceSettings|✅||
-|AppMenu|✅||
-|ApplicationRecordTypeConfig|✅||
-|ApplicationSubtypeDefinition|✅||
-|AppointmentAssignmentPolicy|✅||
-|AppointmentSchedulingPolicy|✅||
-|ApprovalProcess|✅||
-|AssessmentConfiguration|❌|Not supported, but support could be added|
-|AssessmentQuestion|✅||
-|AssessmentQuestionSet|✅||
-|AssignmentRules|✅||
-|AssistantContextItem|✅||
-|AssistantDefinition|✅||
-|AssistantSkillQuickAction|✅||
-|AssistantSkillSobjectAction|✅||
-|AssistantVersion|✅||
-|AssociationEngineSettings|✅||
-|Audience|✅||
-|AuraDefinitionBundle|✅||
-|AuthProvider|✅||
-|AutoResponseRules|✅||
-|AutomatedContactsSettings|✅||
-|BatchCalcJobDefinition|✅||
-|BatchProcessJobDefinition|✅||
-|BenefitAction|✅||
-|BlacklistedConsumer|✅||
-|BldgEnrgyIntensityCnfg|✅||
-|BlockchainSettings|✅||
-|Bot|✅||
-|BotBlock|✅||
-|BotBlockVersion|❌|Not supported, but support could be added|
-|BotSettings|✅||
-|BotTemplate|✅||
-|BotVersion|✅||
-|BranchManagementSettings|✅||
-|BrandingSet|✅||
-|BriefcaseDefinition|✅||
-|BusinessHoursSettings|✅||
-|BusinessProcess|✅||
-|BusinessProcessGroup|✅||
-|BusinessProcessTypeDefinition|✅||
-|CMSConnectSource|✅||
-|CallCenter|✅||
-|CallCenterRoutingMap|✅||
-|CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
-|CampaignInfluenceModel|✅||
-|CampaignSettings|✅||
-|CanvasMetadata|✅||
-|CareBenefitVerifySettings|✅||
-|CareLimitType|✅||
-|CareProviderSearchConfig|✅||
-|CareRequestConfiguration|✅||
-|CareSystemFieldMapping|✅||
-|CaseSettings|✅||
-|CaseSubjectParticle|✅||
-|Certificate|✅||
-|ChannelLayout|✅||
-|ChannelObjectLinkingRule|✅||
-|ChatterAnswersSettings|✅||
-|ChatterEmailsMDSettings|✅||
-|ChatterExtension|✅||
-|ChatterSettings|✅||
-|ClaimFinancialSettings|✅||
-|ClaimMgmtFoundationEnabledSettings|✅||
-|ClauseCatgConfiguration|✅||
-|CleanDataService|✅||
-|CodeBuilderSettings|✅||
-|CollectionsDashboardSettings|✅||
-|CommandAction|✅||
-|CommerceSettings|✅||
-|CommunitiesSettings|✅||
-|Community|✅||
-|CommunityTemplateDefinition|✅||
-|CommunityThemeDefinition|✅||
-|CompactLayout|✅||
-|CompanySettings|✅||
-|ConnectedApp|✅||
-|ConnectedAppSettings|✅||
-|ContentAsset|✅||
-|ContentSettings|✅||
-|ContractSettings|✅||
-|ContractType|❌|Not supported, but support could be added|
-|ConversationVendorInfo|✅||
-|ConversationalIntelligenceSettings|✅||
-|CorsWhitelistOrigin|✅||
-|CspTrustedSite|✅||
-|CurrencySettings|✅||
-|CustomAddressFieldSettings|✅||
-|CustomApplication|✅||
-|CustomApplicationComponent|✅||
-|CustomFeedFilter|✅||
-|CustomField|✅||
-|CustomHelpMenuSection|✅||
-|CustomIndex|✅||
-|CustomLabels|✅||
-|CustomMetadata|✅||
-|CustomNotificationType|✅||
-|CustomObject|✅||
-|CustomObjectTranslation|✅||
-|CustomPageWebLink|✅||
-|CustomPermission|✅||
-|CustomSite|✅||
-|CustomTab|✅||
-|CustomValue|❌|Not supported, but support could be added|
-|CustomerDataPlatformSettings|✅||
-|CustomizablePropensityScoringSettings|✅||
-|Dashboard|✅||
-|DashboardFolder|✅||
-|DataCategoryGroup|✅||
-|DataConnectorIngestApi|✅||
-|DataConnectorS3|✅||
-|DataDotComSettings|✅||
-|DataImportManagementSettings|✅||
-|DataPackageKitDefinition|✅||
-|DataPackageKitObject|✅||
-|DataSource|✅||
-|DataSourceBundleDefinition|✅||
-|DataSourceObject|✅||
-|DataSourceTenant|✅||
-|DataSrcDataModelFieldMap|✅||
-|DataStreamDefinition|✅||
-|DataStreamTemplate|✅||
-|DataWeaveResource|✅||
-|DecisionMatrixDefinition|✅||
-|DecisionMatrixDefinitionVersion|✅||
-|DecisionTable|✅||
-|DecisionTableDatasetLink|✅||
-|DelegateGroup|✅||
-|DeploymentSettings|✅||
-|DevHubSettings|✅||
-|DigitalExperience|✅||
-|DigitalExperienceBundle|✅||
-|DigitalExperienceConfig|✅||
-|DisclosureDefinition|✅||
-|DisclosureDefinitionVersion|✅||
-|DisclosureType|✅||
-|DiscoveryAIModel|✅||
-|DiscoveryGoal|✅||
-|DiscoverySettings|✅||
-|DiscoveryStory|❌|Not supported, but support could be added|
-|Document|✅||
-|DocumentChecklistSettings|✅||
-|DocumentFolder|✅||
-|DocumentGenerationSetting|✅||
-|DocumentType|✅||
-|DuplicateRule|✅||
-|DynamicFormsSettings|✅||
-|EACSettings|✅||
-|ESignatureConfig|✅||
-|ESignatureEnvelopeConfig|✅||
-|EclairGeoData|✅||
-|EinsteinAgentSettings|✅||
-|EinsteinAssistantSettings|✅||
-|EinsteinDealInsightsSettings|✅||
-|EinsteinDocumentCaptureSettings|✅||
-|EmailAdministrationSettings|✅||
-|EmailFolder|✅||
-|EmailIntegrationSettings|✅||
-|EmailServicesFunction|✅||
-|EmailTemplate|✅||
-|EmailTemplateFolder|✅||
-|EmailTemplateSettings|✅||
-|EmbeddedServiceBranding|✅||
-|EmbeddedServiceConfig|✅||
-|EmbeddedServiceFlowConfig|✅||
-|EmbeddedServiceLiveAgent|✅||
-|EmbeddedServiceMenuSettings|✅||
-|EmployeeDataSyncProfile|❌|Not supported, but support could be added|
-|EmployeeFieldAccessSettings|✅||
-|EmployeeUserSettings|✅||
-|EnhancedNotesSettings|✅||
-|EntitlementProcess|✅||
-|EntitlementSettings|✅||
-|EntitlementTemplate|✅||
-|EscalationRules|✅||
-|EssentialsSettings|✅||
-|EventSettings|✅||
-|ExperienceBundle|✅||
-|ExperienceBundleSettings|✅||
-|ExperiencePropertyTypeBundle|✅||
-|ExplainabilityActionDefinition|✅||
-|ExplainabilityActionVersion|✅||
-|ExplainabilityMsgTemplate|✅||
-|ExpressionSetDefinition|✅||
-|ExpressionSetDefinitionVersion|✅||
-|ExpressionSetObjectAlias|❌|Not supported, but support could be added|
-|ExternalAIModel|❌|Not supported, but support could be added|
-|ExternalClientAppSettings|✅||
-|ExternalClientApplication|✅||
-|ExternalCredential|✅||
-|ExternalDataConnector|✅||
-|ExternalDataSource|✅||
-|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
-|ExternalDataTranField|❌|Not supported, but support could be added|
-|ExternalDataTranObject|❌|Not supported, but support could be added|
-|ExternalDocStorageConfig|❌|Not supported, but support could be added|
-|ExternalServiceRegistration|✅||
-|ExtlClntAppGlobalOauthSettings|✅||
-|ExtlClntAppOauthConfigurablePolicies|✅||
-|ExtlClntAppOauthSettings|✅||
-|FeatureParameterBoolean|✅||
-|FeatureParameterDate|✅||
-|FeatureParameterInteger|✅||
-|FieldRestrictionRule|✅||
-|FieldServiceMobileExtension|✅||
-|FieldServiceSettings|✅||
-|FieldSet|✅||
-|FieldSrcTrgtRelationship|✅||
-|FileUploadAndDownloadSecuritySettings|✅||
-|FilesConnectSettings|✅||
-|FlexiPage|✅||
-|Flow|✅||
-|FlowCategory|✅||
-|FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|FlowSettings|✅||
-|FlowTest|✅||
-|ForecastingFilter|✅||
-|ForecastingFilterCondition|✅||
-|ForecastingObjectListSettings|✅||
-|ForecastingSettings|✅||
-|ForecastingSourceDefinition|✅||
-|ForecastingType|✅||
-|ForecastingTypeSource|✅||
-|FormulaSettings|✅||
-|FuelType|✅||
-|FuelTypeSustnUom|✅||
-|FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
-|FundraisingConfig|❌|Not supported, but support could be added|
-|GatewayProviderPaymentMethodType|✅||
-|GlobalValueSet|✅||
-|GlobalValueSetTranslation|✅||
-|GoogleAppsSettings|✅||
-|Group|✅||
-|HighVelocitySalesSettings|✅||
-|HomePageComponent|✅||
-|HomePageLayout|✅||
-|IPAddressRange|✅||
-|Icon|✅||
-|IdeasSettings|✅||
-|IdentityProviderSettings|✅||
-|IdentityVerificationProcDef|✅||
-|IframeWhiteListUrlSettings|✅||
-|InboundCertificate|✅||
-|InboundNetworkConnection|✅||
-|IncidentMgmtSettings|✅||
-|IncludeEstTaxInQuoteSettings|✅||
-|Index|⚠️|Supports deploy/retrieve but not source tracking|
-|IndustriesAutomotiveSettings|✅||
-|IndustriesEinsteinFeatureSettings|✅||
-|IndustriesLoyaltySettings|✅||
-|IndustriesManufacturingSettings|✅||
-|IndustriesSettings|✅||
-|InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
-|IntegrationProviderDef|✅||
-|InterestTaggingSettings|✅||
-|InternalDataConnector|✅||
-|InvLatePymntRiskCalcSettings|✅||
-|InventorySettings|✅||
-|InvocableActionSettings|✅||
-|IoTSettings|✅||
-|KeywordList|✅||
-|KnowledgeGenerationSettings|✅||
-|KnowledgeSettings|✅||
-|LanguageSettings|✅||
-|Layout|✅||
-|LeadConfigSettings|✅||
-|LeadConvertSettings|✅||
-|Letterhead|✅||
-|LicensingSettings|✅||
-|LightningBolt|✅||
-|LightningComponentBundle|✅||
-|LightningExperienceSettings|✅||
-|LightningExperienceTheme|✅||
-|LightningMessageChannel|✅||
-|LightningOnboardingConfig|✅||
-|ListView|✅||
-|LiveAgentSettings|✅||
-|LiveChatAgentConfig|✅||
-|LiveChatButton|✅||
-|LiveChatDeployment|✅||
-|LiveChatSensitiveDataRule|✅||
-|LiveMessageSettings|✅||
-|LocationUse|✅||
-|LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
-|MacroSettings|✅||
-|MailMergeSettings|✅||
-|ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
-|ManagedTopics|✅||
-|MapsAndLocationSettings|✅||
-|MarketSegmentDefinition|✅||
-|MarketingAppExtActivity|❌|Not supported, but support could be added|
-|MarketingAppExtension|✅||
-|MatchingRules|✅||
-|MediaAdSalesSettings|✅||
-|MeetingsSettings|✅||
-|MessagingChannel|❌|Not supported, but support could be added (but not for tracking)|
-|MfgProgramTemplate|✅||
-|MfgServiceConsoleSettings|✅||
-|MilestoneType|✅||
-|MktCalcInsightObjectDef|✅||
-|MktDataTranObject|✅||
-|MlDomain|✅||
-|MobSecurityCertPinConfig|✅||
-|MobileApplicationDetail|✅||
-|MobileSecurityAssignment|✅||
-|MobileSecurityPolicy|✅||
-|MobileSettings|✅||
-|ModerationRule|✅||
-|MutingPermissionSet|✅||
-|MyDomainDiscoverableLogin|✅||
-|MyDomainSettings|✅||
-|NameSettings|✅||
-|NamedCredential|✅||
-|NavigationMenu|✅||
-|Network|✅||
-|NetworkBranding|✅||
-|NotificationTypeConfig|✅||
-|NotificationsSettings|✅||
-|OauthCustomScope|✅||
-|OauthOidcSettings|✅||
-|ObjectHierarchyRelationship|✅||
-|ObjectLinkingSettings|✅||
-|ObjectSourceTargetMap|✅||
-|OcrSampleDocument|✅||
-|OcrTemplate|✅||
-|OmniChannelPricingSettings|✅||
-|OmniChannelSettings|✅||
-|OmniDataTransform|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniIntegrationProcedure|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniInteractionAccessConfig|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniInteractionConfig|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniScript|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniSupervisorConfig|✅||
-|OmniUiCard|⚠️|Supports deploy/retrieve but not source tracking|
-|OnlineSalesSettings|✅||
-|OpportunityInsightsSettings|✅||
-|OpportunityScoreSettings|✅||
-|OpportunitySettings|✅||
-|OrderManagementSettings|✅||
-|OrderSettings|✅||
-|OrgSettings|✅||
-|OutboundNetworkConnection|✅||
-|PardotEinsteinSettings|✅||
-|PardotSettings|✅||
-|ParticipantRole|✅||
-|PartyDataModelSettings|✅||
-|PathAssistant|✅||
-|PathAssistantSettings|✅||
-|PaymentGatewayProvider|✅||
-|PaymentsManagementEnabledSettings|✅||
-|PaymentsSettings|✅||
-|PermissionSet|✅||
-|PermissionSetGroup|✅||
-|PermissionSetLicenseDefinition|✅||
-|PersonAccountOwnerPowerUser|✅||
-|PicklistSettings|✅||
-|PicklistValue|❌|Not supported, but support could be added|
-|PipelineInspMetricConfig|✅||
-|PlatformCachePartition|✅||
-|PlatformEventChannel|✅||
-|PlatformEventChannelMember|✅||
-|PlatformEventSettings|✅||
-|PlatformEventSubscriberConfig|✅||
-|PlatformSlackSettings|✅||
-|PortalDelegablePermissionSet|❌|Not supported, but support could be added|
-|PortalsSettings|✅||
-|PostTemplate|✅||
-|PredictionBuilderSettings|✅||
-|PresenceDeclineReason|✅||
-|PresenceUserConfig|✅||
-|PrivacySettings|✅||
-|ProcessFlowMigration|❌|Not supported, but support could be added|
-|ProductAttrDisplayConfig|❌|Not supported, but support could be added|
-|ProductAttributeSet|✅||
-|ProductSettings|✅||
-|ProductSpecificationRecType|❌|Not supported, but support could be added|
-|ProductSpecificationType|❌|Not supported, but support could be added|
-|Profile|✅||
-|ProfilePasswordPolicy|✅||
-|ProfileSessionSetting|✅||
-|Prompt|✅||
-|Queue|✅||
-|QueueRoutingConfig|✅||
-|QuickAction|✅||
-|QuickTextSettings|✅||
-|QuoteSettings|✅||
-|RealTimeEventSettings|✅||
-|RecAlrtDataSrcExpSetDef|❌|Not supported, but support could be added|
-|RecommendationBuilderSettings|✅||
-|RecommendationStrategy|✅||
-|RecordActionDeployment|✅||
-|RecordAlertCategory|✅||
-|RecordAlertDataSource|✅||
-|RecordAlertTemplate|❌|Not supported, but support could be added|
-|RecordPageSettings|✅||
-|RecordType|✅||
-|RedirectWhitelistUrl|✅||
-|ReferencedDashboard|❌|Not supported, but support could be added|
-|RegisteredExternalService|❌|Not supported, but support could be added|
-|RelatedRecordAssocCriteria|❌|Not supported, but support could be added|
-|RelationshipGraphDefinition|✅||
-|RemoteSiteSetting|✅||
-|Report|✅||
-|ReportFolder|✅||
-|ReportType|✅||
-|RestrictionRule|✅||
-|RetailExecutionSettings|✅||
-|Role|✅||
-|SalesAgreementSettings|✅||
-|SalesWorkQueueSettings|✅||
-|SamlSsoConfig|✅||
-|SandboxSettings|✅||
-|SchedulingObjective|✅||
-|SchedulingRule|✅||
-|SchemaSettings|✅||
-|ScoreCategory|✅||
-|SearchSettings|✅||
-|SecuritySettings|✅||
-|ServiceAISetupDefinition|✅||
-|ServiceAISetupField|✅||
-|ServiceChannel|✅||
-|ServiceCloudVoiceSettings|✅||
-|ServicePresenceStatus|✅||
-|ServiceProcess|❌|Not supported, but support could be added|
-|ServiceSetupAssistantSettings|✅||
-|SharingCriteriaRule|✅||
-|SharingGuestRule|✅||
-|SharingOwnerRule|✅||
-|SharingReason|✅||
-|SharingRules|⚠️|Supports deploy/retrieve but not source tracking|
-|SharingSet|✅||
-|SharingSettings|✅||
-|SharingTerritoryRule|✅||
-|SiteDotCom|✅||
-|SiteSettings|✅||
-|Skill|✅||
-|SkillType|✅||
-|SlackApp|✅||
-|SocialCustomerServiceSettings|✅||
-|SocialProfileSettings|✅||
-|SourceTrackingSettings|✅||
-|StandardValue|❌|Not supported, but support could be added|
-|StandardValueSet|✅||
-|StandardValueSetTranslation|✅||
-|StaticResource|✅||
-|StnryAssetEnvSrcCnfg|✅||
-|StreamingAppDataConnector|✅||
-|SubscriptionManagementSettings|✅||
-|SurveySettings|✅||
-|SustainabilityUom|✅||
-|SustnUomConversion|✅||
-|SvcCatalogCategory|✅||
-|SvcCatalogFulfillmentFlow|✅||
-|SvcCatalogItemDef|✅||
-|SynonymDictionary|✅||
-|SystemNotificationSettings|✅||
-|Territory|✅||
-|Territory2|✅||
-|Territory2Model|✅||
-|Territory2Rule|✅||
-|Territory2Settings|✅||
-|Territory2Type|✅||
-|TimeSheetTemplate|✅||
-|TimelineObjectDefinition|✅||
-|TopicsForObjects|✅||
-|TrailheadSettings|✅||
-|TransactionSecurityPolicy|✅||
-|Translations|✅||
-|TrialOrgSettings|✅||
-|UIObjectRelationConfig|✅||
-|UiPlugin|✅||
-|UserAccessPolicy|✅||
-|UserAuthCertificate|✅||
-|UserCriteria|✅||
-|UserEngagementSettings|✅||
-|UserInterfaceSettings|✅||
-|UserManagementSettings|✅||
-|UserProfileSearchScope|✅||
-|UserProvisioningConfig|✅||
-|ValidationRule|✅||
-|VehicleAssetEmssnSrcCnfg|✅||
-|ViewDefinition|✅||
-|VirtualVisitConfig|❌|Not supported, but support could be added|
-|VoiceSettings|✅||
-|WarrantyLifecycleMgmtSettings|✅||
-|WaveAnalyticAssetCollection|❌|Not supported, but support could be added|
-|WaveApplication|✅||
-|WaveComponent|✅||
-|WaveDashboard|✅||
-|WaveDataflow|✅||
-|WaveDataset|✅||
-|WaveLens|✅||
-|WaveRecipe|✅||
-|WaveTemplateBundle|✅||
-|WaveXmd|✅||
-|Web3Settings|✅||
-|WebLink|✅||
-|WebStoreBundle|❌|Not supported, but support could be added|
-|WebStoreTemplate|✅||
-|WebToXSettings|✅||
-|WorkDotComSettings|✅||
-|WorkSkillRouting|✅||
-|Workflow|✅||
-|WorkflowAlert|✅||
-|WorkflowFieldUpdate|✅||
-|WorkflowFlowAction|❌|Not supported, but support could be added|
-|WorkflowKnowledgePublish|✅||
-|WorkflowOutboundMessage|✅||
-|WorkflowRule|✅||
-|WorkflowSend|✅||
-|WorkflowTask|✅||
-|WorkforceEngagementSettings|✅||
-
-
+| Metadata Type                         | Support | Notes                                                            |
+| :------------------------------------ | :------ | :--------------------------------------------------------------- |
+| AIApplication                         | ✅      |                                                                  |
+| AIApplicationConfig                   | ✅      |                                                                  |
+| AIReplyRecommendationsSettings        | ✅      |                                                                  |
+| AIScoringModelDefVersion              | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AIScoringModelDefinition              | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AIUsecaseDefinition                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AccountForecastSettings               | ✅      |                                                                  |
+| AccountInsightsSettings               | ✅      |                                                                  |
+| AccountIntelligenceSettings           | ✅      |                                                                  |
+| AccountRelationshipShareRule          | ✅      |                                                                  |
+| AccountSettings                       | ✅      |                                                                  |
+| AccountingFieldMapping                | ✅      |                                                                  |
+| AccountingModelConfig                 | ✅      |                                                                  |
+| AccountingSettings                    | ✅      |                                                                  |
+| AcctMgrTargetSettings                 | ✅      |                                                                  |
+| ActionLauncherItemDef                 | ✅      |                                                                  |
+| ActionLinkGroupTemplate               | ✅      |                                                                  |
+| ActionPlanTemplate                    | ✅      |                                                                  |
+| ActionableListDefinition              | ✅      |                                                                  |
+| ActionsSettings                       | ✅      |                                                                  |
+| ActivationPlatform                    | ✅      |                                                                  |
+| ActivitiesSettings                    | ✅      |                                                                  |
+| AddressSettings                       | ✅      |                                                                  |
+| AdvAccountForecastSet                 | ✅      |                                                                  |
+| AdvAcctForecastDimSource              | ✅      |                                                                  |
+| AdvAcctForecastPeriodGroup            | ✅      |                                                                  |
+| Ai4mSettings                          | ✅      |                                                                  |
+| AnalyticSnapshot                      | ✅      |                                                                  |
+| AnalyticsSettings                     | ✅      |                                                                  |
+| AnimationRule                         | ✅      |                                                                  |
+| ApexClass                             | ✅      |                                                                  |
+| ApexComponent                         | ✅      |                                                                  |
+| ApexEmailNotifications                | ✅      |                                                                  |
+| ApexPage                              | ✅      |                                                                  |
+| ApexSettings                          | ✅      |                                                                  |
+| ApexTestSuite                         | ✅      |                                                                  |
+| ApexTrigger                           | ✅      |                                                                  |
+| AppAnalyticsSettings                  | ✅      |                                                                  |
+| AppExperienceSettings                 | ✅      |                                                                  |
+| AppMenu                               | ✅      |                                                                  |
+| ApplicationRecordTypeConfig           | ✅      |                                                                  |
+| ApplicationSubtypeDefinition          | ✅      |                                                                  |
+| AppointmentAssignmentPolicy           | ✅      |                                                                  |
+| AppointmentSchedulingPolicy           | ✅      |                                                                  |
+| ApprovalProcess                       | ✅      |                                                                  |
+| AssessmentConfiguration               | ❌      | Not supported, but support could be added                        |
+| AssessmentQuestion                    | ✅      |                                                                  |
+| AssessmentQuestionSet                 | ✅      |                                                                  |
+| AssignmentRules                       | ✅      |                                                                  |
+| AssistantContextItem                  | ✅      |                                                                  |
+| AssistantDefinition                   | ✅      |                                                                  |
+| AssistantSkillQuickAction             | ✅      |                                                                  |
+| AssistantSkillSobjectAction           | ✅      |                                                                  |
+| AssistantVersion                      | ✅      |                                                                  |
+| AssociationEngineSettings             | ✅      |                                                                  |
+| Audience                              | ✅      |                                                                  |
+| AuraDefinitionBundle                  | ✅      |                                                                  |
+| AuthProvider                          | ✅      |                                                                  |
+| AutoResponseRules                     | ✅      |                                                                  |
+| AutomatedContactsSettings             | ✅      |                                                                  |
+| BatchCalcJobDefinition                | ✅      |                                                                  |
+| BatchProcessJobDefinition             | ✅      |                                                                  |
+| BenefitAction                         | ✅      |                                                                  |
+| BlacklistedConsumer                   | ✅      |                                                                  |
+| BldgEnrgyIntensityCnfg                | ✅      |                                                                  |
+| BlockchainSettings                    | ✅      |                                                                  |
+| Bot                                   | ✅      |                                                                  |
+| BotBlock                              | ✅      |                                                                  |
+| BotBlockVersion                       | ❌      | Not supported, but support could be added                        |
+| BotSettings                           | ✅      |                                                                  |
+| BotTemplate                           | ✅      |                                                                  |
+| BotVersion                            | ✅      |                                                                  |
+| BranchManagementSettings              | ✅      |                                                                  |
+| BrandingSet                           | ✅      |                                                                  |
+| BriefcaseDefinition                   | ✅      |                                                                  |
+| BusinessHoursSettings                 | ✅      |                                                                  |
+| BusinessProcess                       | ✅      |                                                                  |
+| BusinessProcessGroup                  | ✅      |                                                                  |
+| BusinessProcessTypeDefinition         | ✅      |                                                                  |
+| CMSConnectSource                      | ✅      |                                                                  |
+| CallCenter                            | ✅      |                                                                  |
+| CallCenterRoutingMap                  | ✅      |                                                                  |
+| CallCoachingMediaProvider             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| CampaignInfluenceModel                | ✅      |                                                                  |
+| CampaignSettings                      | ✅      |                                                                  |
+| CanvasMetadata                        | ✅      |                                                                  |
+| CareBenefitVerifySettings             | ✅      |                                                                  |
+| CareLimitType                         | ✅      |                                                                  |
+| CareProviderSearchConfig              | ✅      |                                                                  |
+| CareRequestConfiguration              | ✅      |                                                                  |
+| CareSystemFieldMapping                | ✅      |                                                                  |
+| CaseSettings                          | ✅      |                                                                  |
+| CaseSubjectParticle                   | ✅      |                                                                  |
+| Certificate                           | ✅      |                                                                  |
+| ChannelLayout                         | ✅      |                                                                  |
+| ChannelObjectLinkingRule              | ✅      |                                                                  |
+| ChatterAnswersSettings                | ✅      |                                                                  |
+| ChatterEmailsMDSettings               | ✅      |                                                                  |
+| ChatterExtension                      | ✅      |                                                                  |
+| ChatterSettings                       | ✅      |                                                                  |
+| ClaimFinancialSettings                | ✅      |                                                                  |
+| ClaimMgmtFoundationEnabledSettings    | ✅      |                                                                  |
+| ClauseCatgConfiguration               | ✅      |                                                                  |
+| CleanDataService                      | ✅      |                                                                  |
+| CodeBuilderSettings                   | ✅      |                                                                  |
+| CollectionsDashboardSettings          | ✅      |                                                                  |
+| CommandAction                         | ✅      |                                                                  |
+| CommerceSettings                      | ✅      |                                                                  |
+| CommunitiesSettings                   | ✅      |                                                                  |
+| Community                             | ✅      |                                                                  |
+| CommunityTemplateDefinition           | ✅      |                                                                  |
+| CommunityThemeDefinition              | ✅      |                                                                  |
+| CompactLayout                         | ✅      |                                                                  |
+| CompanySettings                       | ✅      |                                                                  |
+| ConnectedApp                          | ✅      |                                                                  |
+| ConnectedAppSettings                  | ✅      |                                                                  |
+| ContentAsset                          | ✅      |                                                                  |
+| ContentSettings                       | ✅      |                                                                  |
+| ContractSettings                      | ✅      |                                                                  |
+| ContractType                          | ❌      | Not supported, but support could be added                        |
+| ConversationVendorInfo                | ✅      |                                                                  |
+| ConversationalIntelligenceSettings    | ✅      |                                                                  |
+| CorsWhitelistOrigin                   | ✅      |                                                                  |
+| CspTrustedSite                        | ✅      |                                                                  |
+| CurrencySettings                      | ✅      |                                                                  |
+| CustomAddressFieldSettings            | ✅      |                                                                  |
+| CustomApplication                     | ✅      |                                                                  |
+| CustomApplicationComponent            | ✅      |                                                                  |
+| CustomFeedFilter                      | ✅      |                                                                  |
+| CustomField                           | ✅      |                                                                  |
+| CustomHelpMenuSection                 | ✅      |                                                                  |
+| CustomIndex                           | ✅      |                                                                  |
+| CustomLabels                          | ✅      |                                                                  |
+| CustomMetadata                        | ✅      |                                                                  |
+| CustomNotificationType                | ✅      |                                                                  |
+| CustomObject                          | ✅      |                                                                  |
+| CustomObjectTranslation               | ✅      |                                                                  |
+| CustomPageWebLink                     | ✅      |                                                                  |
+| CustomPermission                      | ✅      |                                                                  |
+| CustomSite                            | ✅      |                                                                  |
+| CustomTab                             | ✅      |                                                                  |
+| CustomValue                           | ❌      | Not supported, but support could be added                        |
+| CustomerDataPlatformSettings          | ✅      |                                                                  |
+| CustomizablePropensityScoringSettings | ✅      |                                                                  |
+| Dashboard                             | ✅      |                                                                  |
+| DashboardFolder                       | ✅      |                                                                  |
+| DataCategoryGroup                     | ✅      |                                                                  |
+| DataConnectorIngestApi                | ✅      |                                                                  |
+| DataConnectorS3                       | ✅      |                                                                  |
+| DataDotComSettings                    | ✅      |                                                                  |
+| DataImportManagementSettings          | ✅      |                                                                  |
+| DataPackageKitDefinition              | ✅      |                                                                  |
+| DataPackageKitObject                  | ✅      |                                                                  |
+| DataSource                            | ✅      |                                                                  |
+| DataSourceBundleDefinition            | ✅      |                                                                  |
+| DataSourceObject                      | ✅      |                                                                  |
+| DataSourceTenant                      | ✅      |                                                                  |
+| DataSrcDataModelFieldMap              | ✅      |                                                                  |
+| DataStreamDefinition                  | ✅      |                                                                  |
+| DataStreamTemplate                    | ✅      |                                                                  |
+| DataWeaveResource                     | ✅      |                                                                  |
+| DecisionMatrixDefinition              | ✅      |                                                                  |
+| DecisionMatrixDefinitionVersion       | ✅      |                                                                  |
+| DecisionTable                         | ✅      |                                                                  |
+| DecisionTableDatasetLink              | ✅      |                                                                  |
+| DelegateGroup                         | ✅      |                                                                  |
+| DeploymentSettings                    | ✅      |                                                                  |
+| DevHubSettings                        | ✅      |                                                                  |
+| DigitalExperience                     | ✅      |                                                                  |
+| DigitalExperienceBundle               | ✅      |                                                                  |
+| DigitalExperienceConfig               | ✅      |                                                                  |
+| DisclosureDefinition                  | ✅      |                                                                  |
+| DisclosureDefinitionVersion           | ✅      |                                                                  |
+| DisclosureType                        | ✅      |                                                                  |
+| DiscoveryAIModel                      | ✅      |                                                                  |
+| DiscoveryGoal                         | ✅      |                                                                  |
+| DiscoverySettings                     | ✅      |                                                                  |
+| DiscoveryStory                        | ❌      | Not supported, but support could be added                        |
+| Document                              | ✅      |                                                                  |
+| DocumentChecklistSettings             | ✅      |                                                                  |
+| DocumentFolder                        | ✅      |                                                                  |
+| DocumentGenerationSetting             | ✅      |                                                                  |
+| DocumentType                          | ✅      |                                                                  |
+| DuplicateRule                         | ✅      |                                                                  |
+| DynamicFormsSettings                  | ✅      |                                                                  |
+| EACSettings                           | ✅      |                                                                  |
+| ESignatureConfig                      | ✅      |                                                                  |
+| ESignatureEnvelopeConfig              | ✅      |                                                                  |
+| EclairGeoData                         | ✅      |                                                                  |
+| EinsteinAgentSettings                 | ✅      |                                                                  |
+| EinsteinAssistantSettings             | ✅      |                                                                  |
+| EinsteinDealInsightsSettings          | ✅      |                                                                  |
+| EinsteinDocumentCaptureSettings       | ✅      |                                                                  |
+| EmailAdministrationSettings           | ✅      |                                                                  |
+| EmailFolder                           | ✅      |                                                                  |
+| EmailIntegrationSettings              | ✅      |                                                                  |
+| EmailServicesFunction                 | ✅      |                                                                  |
+| EmailTemplate                         | ✅      |                                                                  |
+| EmailTemplateFolder                   | ✅      |                                                                  |
+| EmailTemplateSettings                 | ✅      |                                                                  |
+| EmbeddedServiceBranding               | ✅      |                                                                  |
+| EmbeddedServiceConfig                 | ✅      |                                                                  |
+| EmbeddedServiceFlowConfig             | ✅      |                                                                  |
+| EmbeddedServiceLiveAgent              | ✅      |                                                                  |
+| EmbeddedServiceMenuSettings           | ✅      |                                                                  |
+| EmployeeDataSyncProfile               | ❌      | Not supported, but support could be added                        |
+| EmployeeFieldAccessSettings           | ✅      |                                                                  |
+| EmployeeUserSettings                  | ✅      |                                                                  |
+| EnhancedNotesSettings                 | ✅      |                                                                  |
+| EntitlementProcess                    | ✅      |                                                                  |
+| EntitlementSettings                   | ✅      |                                                                  |
+| EntitlementTemplate                   | ✅      |                                                                  |
+| EscalationRules                       | ✅      |                                                                  |
+| EssentialsSettings                    | ✅      |                                                                  |
+| EventSettings                         | ✅      |                                                                  |
+| ExperienceBundle                      | ✅      |                                                                  |
+| ExperienceBundleSettings              | ✅      |                                                                  |
+| ExperiencePropertyTypeBundle          | ✅      |                                                                  |
+| ExplainabilityActionDefinition        | ✅      |                                                                  |
+| ExplainabilityActionVersion           | ✅      |                                                                  |
+| ExplainabilityMsgTemplate             | ✅      |                                                                  |
+| ExpressionSetDefinition               | ✅      |                                                                  |
+| ExpressionSetDefinitionVersion        | ✅      |                                                                  |
+| ExpressionSetObjectAlias              | ❌      | Not supported, but support could be added                        |
+| ExternalAIModel                       | ❌      | Not supported, but support could be added                        |
+| ExternalClientAppSettings             | ✅      |                                                                  |
+| ExternalClientApplication             | ✅      |                                                                  |
+| ExternalCredential                    | ✅      |                                                                  |
+| ExternalDataConnector                 | ✅      |                                                                  |
+| ExternalDataSource                    | ✅      |                                                                  |
+| ExternalDataSrcDescriptor             | ❌      | Not supported, but support could be added                        |
+| ExternalDataTranField                 | ❌      | Not supported, but support could be added                        |
+| ExternalDataTranObject                | ❌      | Not supported, but support could be added                        |
+| ExternalDocStorageConfig              | ❌      | Not supported, but support could be added                        |
+| ExternalServiceRegistration           | ✅      |                                                                  |
+| ExtlClntAppGlobalOauthSettings        | ✅      |                                                                  |
+| ExtlClntAppOauthConfigurablePolicies  | ✅      |                                                                  |
+| ExtlClntAppOauthSettings              | ✅      |                                                                  |
+| FeatureParameterBoolean               | ✅      |                                                                  |
+| FeatureParameterDate                  | ✅      |                                                                  |
+| FeatureParameterInteger               | ✅      |                                                                  |
+| FieldRestrictionRule                  | ✅      |                                                                  |
+| FieldServiceMobileExtension           | ✅      |                                                                  |
+| FieldServiceSettings                  | ✅      |                                                                  |
+| FieldSet                              | ✅      |                                                                  |
+| FieldSrcTrgtRelationship              | ✅      |                                                                  |
+| FileUploadAndDownloadSecuritySettings | ✅      |                                                                  |
+| FilesConnectSettings                  | ✅      |                                                                  |
+| FlexiPage                             | ✅      |                                                                  |
+| Flow                                  | ✅      |                                                                  |
+| FlowCategory                          | ✅      |                                                                  |
+| FlowDefinition                        | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| FlowSettings                          | ✅      |                                                                  |
+| FlowTest                              | ✅      |                                                                  |
+| ForecastingFilter                     | ✅      |                                                                  |
+| ForecastingFilterCondition            | ✅      |                                                                  |
+| ForecastingObjectListSettings         | ✅      |                                                                  |
+| ForecastingSettings                   | ✅      |                                                                  |
+| ForecastingSourceDefinition           | ✅      |                                                                  |
+| ForecastingType                       | ✅      |                                                                  |
+| ForecastingTypeSource                 | ✅      |                                                                  |
+| FormulaSettings                       | ✅      |                                                                  |
+| FuelType                              | ✅      |                                                                  |
+| FuelTypeSustnUom                      | ✅      |                                                                  |
+| FunctionReference                     | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| FundraisingConfig                     | ❌      | Not supported, but support could be added                        |
+| GatewayProviderPaymentMethodType      | ✅      |                                                                  |
+| GlobalValueSet                        | ✅      |                                                                  |
+| GlobalValueSetTranslation             | ✅      |                                                                  |
+| GoogleAppsSettings                    | ✅      |                                                                  |
+| Group                                 | ✅      |                                                                  |
+| HighVelocitySalesSettings             | ✅      |                                                                  |
+| HomePageComponent                     | ✅      |                                                                  |
+| HomePageLayout                        | ✅      |                                                                  |
+| IPAddressRange                        | ✅      |                                                                  |
+| Icon                                  | ✅      |                                                                  |
+| IdeasSettings                         | ✅      |                                                                  |
+| IdentityProviderSettings              | ✅      |                                                                  |
+| IdentityVerificationProcDef           | ✅      |                                                                  |
+| IframeWhiteListUrlSettings            | ✅      |                                                                  |
+| InboundCertificate                    | ✅      |                                                                  |
+| InboundNetworkConnection              | ✅      |                                                                  |
+| IncidentMgmtSettings                  | ✅      |                                                                  |
+| IncludeEstTaxInQuoteSettings          | ✅      |                                                                  |
+| Index                                 | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| IndustriesAutomotiveSettings          | ✅      |                                                                  |
+| IndustriesEinsteinFeatureSettings     | ✅      |                                                                  |
+| IndustriesLoyaltySettings             | ✅      |                                                                  |
+| IndustriesManufacturingSettings       | ✅      |                                                                  |
+| IndustriesSettings                    | ✅      |                                                                  |
+| InstalledPackage                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| IntegrationProviderDef                | ✅      |                                                                  |
+| InterestTaggingSettings               | ✅      |                                                                  |
+| InternalDataConnector                 | ✅      |                                                                  |
+| InvLatePymntRiskCalcSettings          | ✅      |                                                                  |
+| InventorySettings                     | ✅      |                                                                  |
+| InvocableActionSettings               | ✅      |                                                                  |
+| IoTSettings                           | ✅      |                                                                  |
+| KeywordList                           | ✅      |                                                                  |
+| KnowledgeGenerationSettings           | ✅      |                                                                  |
+| KnowledgeSettings                     | ✅      |                                                                  |
+| LanguageSettings                      | ✅      |                                                                  |
+| Layout                                | ✅      |                                                                  |
+| LeadConfigSettings                    | ✅      |                                                                  |
+| LeadConvertSettings                   | ✅      |                                                                  |
+| Letterhead                            | ✅      |                                                                  |
+| LicensingSettings                     | ✅      |                                                                  |
+| LightningBolt                         | ✅      |                                                                  |
+| LightningComponentBundle              | ✅      |                                                                  |
+| LightningExperienceSettings           | ✅      |                                                                  |
+| LightningExperienceTheme              | ✅      |                                                                  |
+| LightningMessageChannel               | ✅      |                                                                  |
+| LightningOnboardingConfig             | ✅      |                                                                  |
+| ListView                              | ✅      |                                                                  |
+| LiveAgentSettings                     | ✅      |                                                                  |
+| LiveChatAgentConfig                   | ✅      |                                                                  |
+| LiveChatButton                        | ✅      |                                                                  |
+| LiveChatDeployment                    | ✅      |                                                                  |
+| LiveChatSensitiveDataRule             | ✅      |                                                                  |
+| LiveMessageSettings                   | ✅      |                                                                  |
+| LocationUse                           | ✅      |                                                                  |
+| LoyaltyProgramSetup                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| MacroSettings                         | ✅      |                                                                  |
+| MailMergeSettings                     | ✅      |                                                                  |
+| ManagedContentType                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| ManagedTopics                         | ✅      |                                                                  |
+| MapsAndLocationSettings               | ✅      |                                                                  |
+| MarketSegmentDefinition               | ✅      |                                                                  |
+| MarketingAppExtActivity               | ❌      | Not supported, but support could be added                        |
+| MarketingAppExtension                 | ✅      |                                                                  |
+| MatchingRules                         | ✅      |                                                                  |
+| MediaAdSalesSettings                  | ✅      |                                                                  |
+| MeetingsSettings                      | ✅      |                                                                  |
+| MessagingChannel                      | ❌      | Not supported, but support could be added (but not for tracking) |
+| MfgProgramTemplate                    | ✅      |                                                                  |
+| MfgServiceConsoleSettings             | ✅      |                                                                  |
+| MilestoneType                         | ✅      |                                                                  |
+| MktCalcInsightObjectDef               | ✅      |                                                                  |
+| MktDataTranObject                     | ✅      |                                                                  |
+| MlDomain                              | ✅      |                                                                  |
+| MobSecurityCertPinConfig              | ✅      |                                                                  |
+| MobileApplicationDetail               | ✅      |                                                                  |
+| MobileSecurityAssignment              | ✅      |                                                                  |
+| MobileSecurityPolicy                  | ✅      |                                                                  |
+| MobileSettings                        | ✅      |                                                                  |
+| ModerationRule                        | ✅      |                                                                  |
+| MutingPermissionSet                   | ✅      |                                                                  |
+| MyDomainDiscoverableLogin             | ✅      |                                                                  |
+| MyDomainSettings                      | ✅      |                                                                  |
+| NameSettings                          | ✅      |                                                                  |
+| NamedCredential                       | ✅      |                                                                  |
+| NavigationMenu                        | ✅      |                                                                  |
+| Network                               | ✅      |                                                                  |
+| NetworkBranding                       | ✅      |                                                                  |
+| NotificationTypeConfig                | ✅      |                                                                  |
+| NotificationsSettings                 | ✅      |                                                                  |
+| OauthCustomScope                      | ✅      |                                                                  |
+| OauthOidcSettings                     | ✅      |                                                                  |
+| ObjectHierarchyRelationship           | ✅      |                                                                  |
+| ObjectLinkingSettings                 | ✅      |                                                                  |
+| ObjectSourceTargetMap                 | ✅      |                                                                  |
+| OcrSampleDocument                     | ✅      |                                                                  |
+| OcrTemplate                           | ✅      |                                                                  |
+| OmniChannelPricingSettings            | ✅      |                                                                  |
+| OmniChannelSettings                   | ✅      |                                                                  |
+| OmniDataTransform                     | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniIntegrationProcedure              | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniInteractionAccessConfig           | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniInteractionConfig                 | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniScript                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniSupervisorConfig                  | ✅      |                                                                  |
+| OmniUiCard                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OnlineSalesSettings                   | ✅      |                                                                  |
+| OpportunityInsightsSettings           | ✅      |                                                                  |
+| OpportunityScoreSettings              | ✅      |                                                                  |
+| OpportunitySettings                   | ✅      |                                                                  |
+| OrderManagementSettings               | ✅      |                                                                  |
+| OrderSettings                         | ✅      |                                                                  |
+| OrgSettings                           | ✅      |                                                                  |
+| OutboundNetworkConnection             | ✅      |                                                                  |
+| PardotEinsteinSettings                | ✅      |                                                                  |
+| PardotSettings                        | ✅      |                                                                  |
+| ParticipantRole                       | ✅      |                                                                  |
+| PartyDataModelSettings                | ✅      |                                                                  |
+| PathAssistant                         | ✅      |                                                                  |
+| PathAssistantSettings                 | ✅      |                                                                  |
+| PaymentGatewayProvider                | ✅      |                                                                  |
+| PaymentsManagementEnabledSettings     | ✅      |                                                                  |
+| PaymentsSettings                      | ✅      |                                                                  |
+| PermissionSet                         | ✅      |                                                                  |
+| PermissionSetGroup                    | ✅      |                                                                  |
+| PermissionSetLicenseDefinition        | ✅      |                                                                  |
+| PersonAccountOwnerPowerUser           | ✅      |                                                                  |
+| PicklistSettings                      | ✅      |                                                                  |
+| PicklistValue                         | ❌      | Not supported, but support could be added                        |
+| PipelineInspMetricConfig              | ✅      |                                                                  |
+| PlatformCachePartition                | ✅      |                                                                  |
+| PlatformEventChannel                  | ✅      |                                                                  |
+| PlatformEventChannelMember            | ✅      |                                                                  |
+| PlatformEventSettings                 | ✅      |                                                                  |
+| PlatformEventSubscriberConfig         | ✅      |                                                                  |
+| PlatformSlackSettings                 | ✅      |                                                                  |
+| PortalDelegablePermissionSet          | ❌      | Not supported, but support could be added                        |
+| PortalsSettings                       | ✅      |                                                                  |
+| PostTemplate                          | ✅      |                                                                  |
+| PredictionBuilderSettings             | ✅      |                                                                  |
+| PresenceDeclineReason                 | ✅      |                                                                  |
+| PresenceUserConfig                    | ✅      |                                                                  |
+| PrivacySettings                       | ✅      |                                                                  |
+| ProcessFlowMigration                  | ❌      | Not supported, but support could be added                        |
+| ProductAttrDisplayConfig              | ❌      | Not supported, but support could be added                        |
+| ProductAttributeSet                   | ✅      |                                                                  |
+| ProductSettings                       | ✅      |                                                                  |
+| ProductSpecificationRecType           | ❌      | Not supported, but support could be added                        |
+| ProductSpecificationType              | ❌      | Not supported, but support could be added                        |
+| Profile                               | ✅      |                                                                  |
+| ProfilePasswordPolicy                 | ✅      |                                                                  |
+| ProfileSessionSetting                 | ✅      |                                                                  |
+| Prompt                                | ✅      |                                                                  |
+| Queue                                 | ✅      |                                                                  |
+| QueueRoutingConfig                    | ✅      |                                                                  |
+| QuickAction                           | ✅      |                                                                  |
+| QuickTextSettings                     | ✅      |                                                                  |
+| QuoteSettings                         | ✅      |                                                                  |
+| RealTimeEventSettings                 | ✅      |                                                                  |
+| RecAlrtDataSrcExpSetDef               | ❌      | Not supported, but support could be added                        |
+| RecommendationBuilderSettings         | ✅      |                                                                  |
+| RecommendationStrategy                | ✅      |                                                                  |
+| RecordActionDeployment                | ✅      |                                                                  |
+| RecordAlertCategory                   | ✅      |                                                                  |
+| RecordAlertDataSource                 | ✅      |                                                                  |
+| RecordAlertTemplate                   | ❌      | Not supported, but support could be added                        |
+| RecordPageSettings                    | ✅      |                                                                  |
+| RecordType                            | ✅      |                                                                  |
+| RedirectWhitelistUrl                  | ✅      |                                                                  |
+| ReferencedDashboard                   | ❌      | Not supported, but support could be added                        |
+| RegisteredExternalService             | ❌      | Not supported, but support could be added                        |
+| RelatedRecordAssocCriteria            | ❌      | Not supported, but support could be added                        |
+| RelationshipGraphDefinition           | ✅      |                                                                  |
+| RemoteSiteSetting                     | ✅      |                                                                  |
+| Report                                | ✅      |                                                                  |
+| ReportFolder                          | ✅      |                                                                  |
+| ReportType                            | ✅      |                                                                  |
+| RestrictionRule                       | ✅      |                                                                  |
+| RetailExecutionSettings               | ✅      |                                                                  |
+| Role                                  | ✅      |                                                                  |
+| SalesAgreementSettings                | ✅      |                                                                  |
+| SalesWorkQueueSettings                | ✅      |                                                                  |
+| SamlSsoConfig                         | ✅      |                                                                  |
+| SandboxSettings                       | ✅      |                                                                  |
+| SchedulingObjective                   | ✅      |                                                                  |
+| SchedulingRule                        | ✅      |                                                                  |
+| SchemaSettings                        | ✅      |                                                                  |
+| ScoreCategory                         | ✅      |                                                                  |
+| SearchSettings                        | ✅      |                                                                  |
+| SecuritySettings                      | ✅      |                                                                  |
+| ServiceAISetupDefinition              | ✅      |                                                                  |
+| ServiceAISetupField                   | ✅      |                                                                  |
+| ServiceChannel                        | ✅      |                                                                  |
+| ServiceCloudVoiceSettings             | ✅      |                                                                  |
+| ServicePresenceStatus                 | ✅      |                                                                  |
+| ServiceProcess                        | ❌      | Not supported, but support could be added                        |
+| ServiceSetupAssistantSettings         | ✅      |                                                                  |
+| SharingCriteriaRule                   | ✅      |                                                                  |
+| SharingGuestRule                      | ✅      |                                                                  |
+| SharingOwnerRule                      | ✅      |                                                                  |
+| SharingReason                         | ✅      |                                                                  |
+| SharingRules                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| SharingSet                            | ✅      |                                                                  |
+| SharingSettings                       | ✅      |                                                                  |
+| SharingTerritoryRule                  | ✅      |                                                                  |
+| SiteDotCom                            | ✅      |                                                                  |
+| SiteSettings                          | ✅      |                                                                  |
+| Skill                                 | ✅      |                                                                  |
+| SkillType                             | ✅      |                                                                  |
+| SlackApp                              | ✅      |                                                                  |
+| SocialCustomerServiceSettings         | ✅      |                                                                  |
+| SocialProfileSettings                 | ✅      |                                                                  |
+| SourceTrackingSettings                | ✅      |                                                                  |
+| StandardValue                         | ❌      | Not supported, but support could be added                        |
+| StandardValueSet                      | ✅      |                                                                  |
+| StandardValueSetTranslation           | ✅      |                                                                  |
+| StaticResource                        | ✅      |                                                                  |
+| StnryAssetEnvSrcCnfg                  | ✅      |                                                                  |
+| StreamingAppDataConnector             | ✅      |                                                                  |
+| SubscriptionManagementSettings        | ✅      |                                                                  |
+| SurveySettings                        | ✅      |                                                                  |
+| SustainabilityUom                     | ✅      |                                                                  |
+| SustnUomConversion                    | ✅      |                                                                  |
+| SvcCatalogCategory                    | ✅      |                                                                  |
+| SvcCatalogFulfillmentFlow             | ✅      |                                                                  |
+| SvcCatalogItemDef                     | ✅      |                                                                  |
+| SynonymDictionary                     | ✅      |                                                                  |
+| SystemNotificationSettings            | ✅      |                                                                  |
+| Territory                             | ✅      |                                                                  |
+| Territory2                            | ✅      |                                                                  |
+| Territory2Model                       | ✅      |                                                                  |
+| Territory2Rule                        | ✅      |                                                                  |
+| Territory2Settings                    | ✅      |                                                                  |
+| Territory2Type                        | ✅      |                                                                  |
+| TimeSheetTemplate                     | ✅      |                                                                  |
+| TimelineObjectDefinition              | ✅      |                                                                  |
+| TopicsForObjects                      | ✅      |                                                                  |
+| TrailheadSettings                     | ✅      |                                                                  |
+| TransactionSecurityPolicy             | ✅      |                                                                  |
+| Translations                          | ✅      |                                                                  |
+| TrialOrgSettings                      | ✅      |                                                                  |
+| UIObjectRelationConfig                | ✅      |                                                                  |
+| UiPlugin                              | ✅      |                                                                  |
+| UserAccessPolicy                      | ✅      |                                                                  |
+| UserAuthCertificate                   | ✅      |                                                                  |
+| UserCriteria                          | ✅      |                                                                  |
+| UserEngagementSettings                | ✅      |                                                                  |
+| UserInterfaceSettings                 | ✅      |                                                                  |
+| UserManagementSettings                | ✅      |                                                                  |
+| UserProfileSearchScope                | ✅      |                                                                  |
+| UserProvisioningConfig                | ✅      |                                                                  |
+| ValidationRule                        | ✅      |                                                                  |
+| VehicleAssetEmssnSrcCnfg              | ✅      |                                                                  |
+| ViewDefinition                        | ✅      |                                                                  |
+| VirtualVisitConfig                    | ❌      | Not supported, but support could be added                        |
+| VoiceSettings                         | ✅      |                                                                  |
+| WarrantyLifecycleMgmtSettings         | ✅      |                                                                  |
+| WaveAnalyticAssetCollection           | ❌      | Not supported, but support could be added                        |
+| WaveApplication                       | ✅      |                                                                  |
+| WaveComponent                         | ✅      |                                                                  |
+| WaveDashboard                         | ✅      |                                                                  |
+| WaveDataflow                          | ✅      |                                                                  |
+| WaveDataset                           | ✅      |                                                                  |
+| WaveLens                              | ✅      |                                                                  |
+| WaveRecipe                            | ✅      |                                                                  |
+| WaveTemplateBundle                    | ✅      |                                                                  |
+| WaveXmd                               | ✅      |                                                                  |
+| Web3Settings                          | ✅      |                                                                  |
+| WebLink                               | ✅      |                                                                  |
+| WebStoreBundle                        | ❌      | Not supported, but support could be added                        |
+| WebStoreTemplate                      | ✅      |                                                                  |
+| WebToXSettings                        | ✅      |                                                                  |
+| WorkDotComSettings                    | ✅      |                                                                  |
+| WorkSkillRouting                      | ✅      |                                                                  |
+| Workflow                              | ✅      |                                                                  |
+| WorkflowAlert                         | ✅      |                                                                  |
+| WorkflowFieldUpdate                   | ✅      |                                                                  |
+| WorkflowFlowAction                    | ❌      | Not supported, but support could be added                        |
+| WorkflowKnowledgePublish              | ✅      |                                                                  |
+| WorkflowOutboundMessage               | ✅      |                                                                  |
+| WorkflowRule                          | ✅      |                                                                  |
+| WorkflowSend                          | ✅      |                                                                  |
+| WorkflowTask                          | ✅      |                                                                  |
+| WorkforceEngagementSettings           | ✅      |                                                                  |
 
 ## Next Release (v59)
-v59 introduces the following new types.  Here's their current level of support
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|ConversationChannelDefinition|❌|Not supported, but support could be added|
-|DocumentTemplate|❌|Not supported, but support could be added|
-|FulfillmentStepType|❌|Not supported, but support could be added|
-|HlthCareProviderAfflRole|❌|Not supported, but support could be added|
+v59 introduces the following new types. Here's their current level of support
+
+| Metadata Type                 | Support | Notes                                     |
+| :---------------------------- | :------ | :---------------------------------------- |
+| ConversationChannelDefinition | ❌      | Not supported, but support could be added |
+| DocumentTemplate              | ❌      | Not supported, but support could be added |
+| FulfillmentStepType           | ❌      | Not supported, but support could be added |
+| HlthCareProviderAfflRole      | ❌      | Not supported, but support could be added |
 
 ## Additional Types
 
-> The following types are supported by this library but not in the coverage reports for either version.  These are typically
+> The following types are supported by this library but not in the coverage reports for either version. These are typically
 >
 > 1. types that have been removed from the metadata API but were supported in previous versions
 > 1. types that are available for pilots but not officially part of the metadata API (use with caution)
@@ -602,8 +601,8 @@ v59 introduces the following new types.  Here's their current level of support
 - CustomFieldTranslation
 - MatchingRule
 - MarketingResourceType
-- ExtlClntAppMobileConfigurablePolicies
-- ExtlClntAppMobileSettings
+- ExtlClntAppSampleConfigurablePolicies
+- ExtlClntAppSampleSettings
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "graceful-fs": "^4.2.11",
     "ignore": "^5.2.4",
     "jszip": "^3.10.1",
+    "jszip-utils": "^0.1.0",
     "mime": "2.6.0",
     "minimatch": "^5.1.6",
     "proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "graceful-fs": "^4.2.11",
     "ignore": "^5.2.4",
     "jszip": "^3.10.1",
-    "jszip-utils": "^0.1.0",
     "mime": "2.6.0",
     "minimatch": "^5.1.6",
     "proxy-agent": "^5.0.0",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1414,11 +1414,11 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobileconfigurablepolicies": {
-      "id": "extlclntappmobileconfigurablepolicies",
-      "name": "ExtlClntAppMobileConfigurablePolicies",
-      "suffix": "ecaMobPlcy",
-      "directoryName": "extlClntAppMobilePolicies",
+    "extlclntappsampleconfigurablepolicies": {
+      "id": "extlclntappsampleconfigurablepolicies",
+      "name": "ExtlClntAppSampleConfigurablePolicies",
+      "suffix": "ecaSmplPlcy",
+      "directoryName": "extlClntAppSamplePolicies",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -1430,11 +1430,11 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobilesettings": {
-      "id": "extlclntappmobilesettings",
-      "name": "ExtlClntAppMobileSettings",
-      "suffix": "ecaMob",
-      "directoryName": "extlClntAppMobileSettings",
+    "extlclntappsamplesettings": {
+      "id": "extlclntappsamplesettings",
+      "name": "ExtlClntAppSampleSettings",
+      "suffix": "ecaSmpl",
+      "directoryName": "extlClntAppSampleSettings",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -3621,8 +3621,8 @@
     "connectedApp": "connectedapp",
     "eca": "externalclientapplication",
     "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
-    "ecaMobPlcy": "extlclntappmobileconfigurablepolicies",
-    "ecaMob": "extlclntappmobilesettings",
+    "ecaSmplPlcy": "extlclntappsampleconfigurablepolicies",
+    "ecaSmpl": "extlclntappsamplesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "ecaGlblOauth": "extlclntappglobaloauthsettings",
     "appMenu": "appmenu",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,6 +3598,11 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
+jszip-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/jszip-utils/-/jszip-utils-0.1.0.tgz#8c04cdedcdb291e83f055f5b261b3a3188ceca0b"
+  integrity sha512-tBNe0o3HAf8vo0BrOYnLPnXNo5A3KsRMnkBFYjh20Y3GPYGfgyoclEMgvVchx0nnL+mherPi74yLPIusHUQpZg==
+
 jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,11 +3598,6 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
-jszip-utils@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/jszip-utils/-/jszip-utils-0.1.0.tgz#8c04cdedcdb291e83f055f5b261b3a3188ceca0b"
-  integrity sha512-tBNe0o3HAf8vo0BrOYnLPnXNo5A3KsRMnkBFYjh20Y3GPYGfgyoclEMgvVchx0nnL+mherPi74yLPIusHUQpZg==
-
 jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"


### PR DESCRIPTION
### What does this PR do?
update metadata names for mobile settings and policies

### What issues does this PR fix or reference?
[W-13519963](https://gus.lightning.force.com/a07EE00001SkRSAYA3)

### Functionality Before

Metadata name for mobile settings was ExtlClntAppMobileSettings.
Metadata name for mobile policies was ExtlClntAppMobileConfigurablePolicies.

### Functionality After

Metadata name for mobile settings is now ExtlClntAppSampleSettings.
Metadata name for mobile policies is now ExtlClntAppSampleConfigurablePolicies.