### PR TITLE
fix: update metadata names for mobile settings and policies

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -604,8 +604,8 @@ v59 introduces the following new types.  Here's their current level of support
 - CustomFieldTranslation
 - MatchingRule
 - MarketingResourceType
-- ExtlClntAppMobileConfigurablePolicies
-- ExtlClntAppMobileSettings
+- ExtlClntAppSampleConfigurablePolicies
+- ExtlClntAppSampleSettings
 - CustomExperience
 - ManagedTopic
 - DataPipeline

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1414,11 +1414,11 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobileconfigurablepolicies": {
-      "id": "extlclntappmobileconfigurablepolicies",
-      "name": "ExtlClntAppMobileConfigurablePolicies",
-      "suffix": "ecaMobPlcy",
-      "directoryName": "extlClntAppMobilePolicies",
+    "extlclntappsampleconfigurablepolicies": {
+      "id": "extlclntappsampleconfigurablepolicies",
+      "name": "ExtlClntAppSampleConfigurablePolicies",
+      "suffix": "ecaSmplPlcy",
+      "directoryName": "extlClntAppSamplePolicies",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -1430,11 +1430,11 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "extlclntappmobilesettings": {
-      "id": "extlclntappmobilesettings",
-      "name": "ExtlClntAppMobileSettings",
-      "suffix": "ecaMob",
-      "directoryName": "extlClntAppMobileSettings",
+    "extlclntappsamplesettings": {
+      "id": "extlclntappsamplesettings",
+      "name": "ExtlClntAppSampleSettings",
+      "suffix": "ecaSmpl",
+      "directoryName": "extlClntAppSampleSettings",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -3621,8 +3621,8 @@
     "connectedApp": "connectedapp",
     "eca": "externalclientapplication",
     "ecaOauthPlcy": "extlclntappoauthconfigurablepolicies",
-    "ecaMobPlcy": "extlclntappmobileconfigurablepolicies",
-    "ecaMob": "extlclntappmobilesettings",
+    "ecaSmplPlcy": "extlclntappsampleconfigurablepolicies",
+    "ecaSmpl": "extlclntappsamplesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "ecaGlblOauth": "extlclntappglobaloauthsettings",
     "appMenu": "appmenu",


### PR DESCRIPTION
### What does this PR do?
update metadata names for mobile settings and policies

### What issues does this PR fix or reference?
[W-13519963](https://gus.lightning.force.com/a07EE00001SkRSAYA3)

### Functionality Before
Metadata name for mobile settings was ExtlClntAppMobileSettings.
Metadata name for mobile policies was ExtlClntAppMobileConfigurablePolicies.

### Functionality After
Metadata name for mobile settings is now ExtlClntAppSampleSettings.
Metadata name for mobile policies is now ExtlClntAppSampleConfigurablePolicies.
