### PR TITLE
Sm/connection-resolve-skip-missing-components

### DIFF
--- a/.sfdevrc.json
+++ b/.sfdevrc.json
@@ -6,8 +6,11 @@
       "output": ["lib/**", "*.tsbuildinfo"],
       "clean": "if-file-deleted"
     },
+    "test": {
+      "dependencies": ["test:only", "test:compile", "test:registry-validation"]
+    },
     "test:only": {
-      "command": "nyc mocha \"test/**/*.test.ts\"",
+      "command": "nyc mocha \"test/**/*.test.ts\" --exclude \"test/registry/registryValidation.test.ts\"",
       "env": {
         "FORCE_COLOR": "2"
       },

--- a/package.json
+++ b/package.json
@@ -172,11 +172,21 @@
     "test": {
       "dependencies": [
         "test:only",
-        "test:compile"
+        "test:compile",
+        "test:registry-validation"
       ]
     },
+    "test:registry-validation": {
+      "command": "mocha \"test/registry/registryValidation.test.ts\"",
+      "files": [
+        "test/registry/registryValidation.test.ts",
+        "src/registry/*.json",
+        "**/tsconfig.json"
+      ],
+      "output": []
+    },
     "test:only": {
-      "command": "nyc mocha \"test/**/*.test.ts\"",
+      "command": "nyc mocha \"test/**/*.test.ts\" --exclude \"test/registry/registryValidation.test.ts\"",
       "env": {
         "FORCE_COLOR": "2"
       },

--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { PollingClient, StatusResult, Connection, Logger, SfError, Messages } from '@salesforce/core';
-import { Duration, ensureArray } from '@salesforce/kit';
 import { retry, NotRetryableError, RetryError } from 'ts-retry-promise';
+import { PollingClient, StatusResult, Connection, Logger, Messages, Lifecycle } from '@salesforce/core';
+import { Duration, ensureArray } from '@salesforce/kit';
 import { ensurePlainObject, ensureString, isPlainObject } from '@salesforce/ts-types';
 import { RegistryAccess, registry as defaultRegistry, MetadataType } from '../registry';
 import { standardValueSet } from '../registry/standardvalueset';
@@ -43,12 +43,12 @@ export class ConnectionResolver {
     const Aggregator: Array<Partial<FileProperties>> = [];
     const childrenPromises: Array<Promise<FileProperties[]>> = [];
     const componentTypes: Set<MetadataType> = new Set();
-
+    const lifecycle = Lifecycle.getInstance();
     const componentPromises: Array<Promise<FileProperties[]>> = [];
     for (const type of Object.values(defaultRegistry.types)) {
       componentPromises.push(this.listMembers({ type: type.name }));
     }
-    (await Promise.all(componentPromises)).map((componentResult) => {
+    (await Promise.all(componentPromises)).map(async (componentResult) => {
       for (const component of componentResult) {
         let componentType: MetadataType;
         if (typeof component.type === 'string' && component.type.length) {
@@ -61,12 +61,13 @@ export class ConnectionResolver {
           );
           component.type = componentType.name;
         } else {
-          // has no type and has no filename!
-          throw new SfError(
-            messages.getMessage('error_could_not_infer_type', [component.fullName]),
-            'TypeInferenceError',
-            [messages.getMessage('suggest_type_more_suggestions')]
-          );
+          // has no type and has no filename!  Warn and skip that component.
+          // eslint-disable-next-line no-await-in-loop
+          await Promise.all([
+            lifecycle.emitWarning(messages.getMessage('error_could_not_infer_type', [component.fullName])),
+            lifecycle.emitTelemetry({ TypeInferenceError: component, from: 'ConnectionResolver' }),
+          ]);
+          continue;
         }
 
         Aggregator.push(component);

--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -60,7 +60,7 @@ export class ConnectionResolver {
             `No type found for ${component.fileName} when matching by suffix.  Check the file extension.`
           );
           component.type = componentType.name;
-        } else if (component.type !== undefined && component.fileName !== undefined) {
+        } else if (component.type === undefined && component.fileName === undefined) {
           // has no type and has no filename!  Warn and skip that component.
           // eslint-disable-next-line no-await-in-loop
           await Promise.all([


### PR DESCRIPTION
### What does this PR do?
when metadata components are retrieved from connectionResolver, but we can't tell what they are because they're missing important information, warn and send to telemetry, and skip the offending component. 

We still throw when we have filename/type and can't resolve it. 

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2229
@W-13623848@