### PR TITLE
fix: add mobile plugin types to registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1446,6 +1446,22 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "extlclntappmobileconfigurablepolicies": {
+      "id": "extlclntappmobileconfigurablepolicies",
+      "name": "ExtlClntAppMobileConfigurablePolicies",
+      "suffix": "ecaMobilePlcy",
+      "directoryName": "extlClntAppMobilePolicies",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappmobilesettings": {
+      "id": "extlclntappmobilesettings",
+      "name": "ExtlClntAppMobileSettings",
+      "suffix": "ecaMobile",
+      "directoryName": "extlClntAppMobileSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "appmenu": {
       "id": "appmenu",
       "name": "AppMenu",
@@ -3625,6 +3641,8 @@
     "ecaSmpl": "extlclntappsamplesettings",
     "ecaOauth": "extlclntappoauthsettings",
     "ecaGlblOauth": "extlclntappglobaloauthsettings",
+    "ecaMobilePlcy": "extlclntappmobileconfigurablepolicies",
+    "ecaMobile": "extlclntappmobilesettings",
     "appMenu": "appmenu",
     "delegateGroup": "delegategroup",
     "network": "network",


### PR DESCRIPTION
### What does this PR do?
Add metadata types for mobile settings and policies

### What issues does this PR fix or reference?
[@W-13681494@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001V4RYlYAN/view)

### Functionality Before
N/A

### Functionality After
Metadata name for mobile settings was ExtlClntAppMobileSettings.
Metadata name for mobile policies was ExtlClntAppMobileConfigurablePolicies.