### PR TITLE
fix: spread/push argument limits

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -115,11 +115,7 @@ export class MetadataResolver {
       }
     }
 
-    for (const directory of dirQueue) {
-      components.push(...this.getComponentsFromPathRecursive(directory, inclusiveFilter));
-    }
-
-    return components;
+    return components.concat(dirQueue.flatMap((d) => this.getComponentsFromPathRecursive(d, inclusiveFilter)));
   }
 
   private resolveComponent(fsPath: string, isResolvingSource: boolean): SourceComponent | undefined {
@@ -269,7 +265,7 @@ export class MetadataResolver {
     let guesses;
 
     if (metaSuffix) {
-      guesses = this.registry.guessTypeBySuffix(metaSuffix)
+      guesses = this.registry.guessTypeBySuffix(metaSuffix);
     } else if (!metaSuffix && closeMetaSuffix) {
       guesses = this.registry.guessTypeBySuffix(closeMetaSuffix[1]);
     } else {
@@ -279,11 +275,11 @@ export class MetadataResolver {
     // If guesses were found, format an array of strings to be passed to SfError's actions
     return guesses && guesses.length > 0
       ? [
-          messages.getMessage('suggest_type_header', [ basename(fsPath) ]),
+          messages.getMessage('suggest_type_header', [basename(fsPath)]),
           ...guesses.map((guess) =>
             messages.getMessage('suggest_type_did_you_mean', [
               guess.suffixGuess,
-              (metaSuffix || closeMetaSuffix) ? '-meta.xml' : '',
+              metaSuffix || closeMetaSuffix ? '-meta.xml' : '',
               guess.metadataTypeGuess.name,
             ])
           ),

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -6,7 +6,10 @@
  */
 import { basename, join } from 'path';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
+import deepEqualInAnyOrder = require('deep-equal-in-any-order');
+
 import { assert, expect } from 'chai';
+import * as chai from 'chai';
 import { AnyJson, getString } from '@salesforce/ts-types';
 import { PollingClient, StatusResult, Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
@@ -35,6 +38,8 @@ import {
   DECOMPOSED_COMPONENT,
 } from '../mock/type-constants/customObjectConstant';
 import { COMPONENT } from '../mock/type-constants/apexClassConstant';
+
+chai.use(deepEqualInAnyOrder);
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sdr');
@@ -820,7 +825,7 @@ describe('MetadataApiDeploy', () => {
           },
         ];
 
-        expect(responses).to.deep.equal(expected);
+        expect(responses).to.deep.equalInAnyOrder(expected);
       });
 
       it('should report "Deleted" when no component in org', () => {


### PR DESCRIPTION
### What does this PR do?
found a bug where a really large mdapi retrieve (4000+ components) would cause `Maximum call stack size exceeded`

it's coming from mutating array (via push) of a spread of a really large array.  Each item in the the array is an entire SourceComponent and we know how massive that object is since each one contains the whole registry, etc.

This solution converts the one causing the bug and a few other potentially dangerous `x.push(...maybeLargeArray)` to `concat`/reassign, which can accept multiple arrays to concat, but then each one is only a 1 pointer to an array instead of thousands of items.  Seems to work.

https://javascript.plainenglish.io/deal-with-maximum-call-stack-size-exceeded-error-in-javascript-45c035161a78

This solved that problem 

### What issues does this PR fix or reference?.
@W-13783924@

QA: the referenced WI contains access to an org that can replicate the issue (was customer investigation)