### PR TITLE
fix: missing stdValue

### DIFF
--- a/src/registry/stdValueSetRegistry.json
+++ b/src/registry/stdValueSetRegistry.json
@@ -5,6 +5,7 @@
     "AccountOwnership",
     "AccountRating",
     "AccountType",
+    "AQLMUFInterval",
     "AQLMFrequencyInterval",
     "AssetStatus",
     "CampaignMemberStatus",


### PR DESCRIPTION
### What does this PR do?
Looks like there's a 2nd standard valueset that's nearly identical and we need both

### What issues does this PR fix or reference?
follow-on to https://github.com/forcedotcom/source-deploy-retrieve/pull/1031
see also https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1690202194657049
https://github.com/forcedotcom/cli/issues/2163

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
