### PR TITLE
fix: throw when expected file is ENOENT

### DIFF
--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -113,6 +113,9 @@ export class NodeFSTreeContainer extends TreeContainer {
   }
 
   public stream(fsPath: SourcePath): Readable {
+    if (!this.exists(fsPath)) {
+      throw new Error(`File not found: ${fsPath}`);
+    }
     return createReadStream(fsPath);
   }
 }

--- a/test/resolve/treeContainers.test.ts
+++ b/test/resolve/treeContainers.test.ts
@@ -117,9 +117,9 @@ describe('Tree Containers', () => {
 
     it('should use expected Node API for stream', () => {
       const readable = new Readable();
-      const createReadStreamStub = env.stub(fs, 'createReadStream');
       // @ts-ignore wants ReadStream but Readable works for testing
-      createReadStreamStub.withArgs(path).returns(readable);
+      env.stub(fs, 'createReadStream').returns(readable);
+      env.stub(fs, 'existsSync').returns(true);
       expect(tree.stream(path)).to.deep.equal(readable);
     });
   });


### PR DESCRIPTION
### What does this PR do?
SDR would exit streams early on ENOENT without throwing an error
this checks file existence before doing a readStream from the file

[this would be more efficient, on the happy path, to catch this error but it seems to buried inside nested streams and this is a simple fix.  It *would* error much earlier in the convert process if the error is going to happen.  Perf benchmarks suggest it has a negative impact]

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2011
@W-12769219@
