### PR TITLE
feat: add a wildcard expansion to metadata full names when building the CS

### DIFF
--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -107,14 +107,12 @@ export class ComponentSetBuilder {
           // The registry will throw if it doesn't know what this type is.
           registry.getTypeByName(splitEntry[0]);
 
-          // if there's a better way to detect
-          if (splitEntry[1]?.includes('*')) {
+          if (splitEntry[1]?.includes('*') && splitEntry[1]?.length > 1) {
             // get all components of the type, and then filter by the regex of the fullName
             ComponentSet.fromSource({
               fsPaths: directoryPaths,
               include: new ComponentSet([{ type: splitEntry[0], fullName: ComponentSet.WILDCARD }]),
             })
-              .getSourceComponents()
               .toArray()
               .filter((cs) => Boolean(cs.fullName.match(new RegExp(splitEntry[1].replace('*', '.*')))))
               .map((match) => {


### PR DESCRIPTION
### What does this PR do?
allows you to pass a wildcard as part of a full name when construction a component set via metadata
e.g.
`'FlexiPage:Property*' `

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2386 @W-13867893@

### Functionality Before

would error


### Functionality After
Deploys FlexiPages that match `Property*`
Retrieves as well*

*when the metadata already exists locally

```bash
force:source:deploy -m 'FlexiPage:Property*' 
...
DEPLOY PROGRESS | ████████████████████████████████████████ | 3/3 Components

=== Deployed Source

 FULL NAME            TYPE      PROJECT PATH                                                              
 ──────────────────── ───────── ───────────────────────────────────────────────────────────────────────── 
 Property_Explorer    FlexiPage force-app/main/default/flexipages/Property_Explorer.flexipage-meta.xml    
 Property_Finder      FlexiPage force-app/main/default/flexipages/Property_Finder.flexipage-meta.xml      
 Property_Record_Page FlexiPage force-app/main/default/flexipages/Property_Record_Page.flexipage-meta.xml 
```
