### PR TITLE
fix: add searchcustomization to registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3523,6 +3523,14 @@
       "directoryName": "SearchableObjDataSyncInfoSettings",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "searchcustomization": {
+      "id": "searchcustomization",
+      "name": "SearchCustomization",
+      "suffix": "SearchCustomization",
+      "directoryName": "SearchCustomizations",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3909,7 +3917,8 @@
     "serviceprocess": "serviceprocess",
     "processflowmigration": "processflowmigration",
     "SearchableObjDataSyncInfoSetting": "searchableobjdatasyncinfo",
-    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration"
+    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration",
+    "SearchCustomization": "searchcustomization"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?
adds searchcustomization metadata type to the registry

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
