### PR TITLE
fix: @W-12612279 Adding FundraisingConfig to metadata registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3523,6 +3523,14 @@
       "directoryName": "SearchableObjDataSyncInfoSettings",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "fundraisingconfig": {
+      "id": "fundraisingconfig",
+      "name": "FundraisingConfig",
+      "suffix": "fundraisingConfig",
+      "directoryName": "fundraisingConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3909,7 +3917,8 @@
     "serviceprocess": "serviceprocess",
     "processflowmigration": "processflowmigration",
     "SearchableObjDataSyncInfoSetting": "searchableobjdatasyncinfo",
-    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration"
+    "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration",
+    "fundraisingConfig": "fundraisingconfig"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION

### What does this PR do?
Add FundraisingConfig to Metadata Registry.
### What issues does this PR fix or reference?

# @W-12612279@


### Functionality Before
unable to access FundraisingConfig metadata from CLI

### Functionality After
able to access FundraisingConfig metadata from CLI
