### PR TITLE
Cd/forceignore bug

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -71,7 +71,11 @@ export class MetadataResolver {
     const components: SourceComponent[] = [];
     const ignore = new Set();
 
-    if (this.tree instanceof NodeFSTreeContainer && this.forceIgnore?.denies(dir)) {
+    // don't apply forceignore rules against dirs
+    // `forceignore.denies` will pass a relative path to node-ignore, e.g.
+    // `path/to/force-app` -> `force-app`, note that there's no trailing slash
+    // so node-ignore will treat it as a file.
+    if (!this.tree.isDirectory(dir) && this.forceIgnore?.denies(dir)) {
       return components;
     }
 

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -71,7 +71,7 @@ export class MetadataResolver {
     const components: SourceComponent[] = [];
     const ignore = new Set();
 
-    if (this.forceIgnore?.denies(dir)) {
+    if (this.tree instanceof NodeFSTreeContainer && this.forceIgnore?.denies(dir)) {
       return components;
     }
 

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -689,32 +689,32 @@ describe('MetadataResolver', () => {
         ]);
       });
 
-      it('should not return components if the directory is forceignored', () => {
-        const dirPath = xmlInFolder.COMPONENT_FOLDER_PATH;
-        testUtil.stubForceIgnore({ seed: dirPath, deny: [dirPath] });
-        const access = testUtil.createMetadataResolver([
-          {
-            dirPath,
-            children: [xmlInFolder.XML_NAMES[0], xmlInFolder.XML_NAMES[1]],
-          },
-        ]);
-        testUtil.stubAdapters([
-          {
-            type: registry.types.document,
-            componentMappings: [
-              {
-                path: xmlInFolder.XML_PATHS[0],
-                component: xmlInFolder.COMPONENTS[0],
-              },
-              {
-                path: xmlInFolder.XML_PATHS[1],
-                component: xmlInFolder.COMPONENTS[1],
-              },
-            ],
-          },
-        ]);
-        expect(access.getComponentsFromPath(dirPath).length).to.equal(0);
-      });
+      // it('should not return components if the directory is forceignored', () => {
+      //   const dirPath = xmlInFolder.COMPONENT_FOLDER_PATH;
+      //   testUtil.stubForceIgnore({ seed: dirPath, deny: [dirPath] });
+      //   const access = testUtil.createMetadataResolver([
+      //     {
+      //       dirPath,
+      //       children: [xmlInFolder.XML_NAMES[0], xmlInFolder.XML_NAMES[1]],
+      //     },
+      //   ]);
+      //   testUtil.stubAdapters([
+      //     {
+      //       type: registry.types.document,
+      //       componentMappings: [
+      //         {
+      //           path: xmlInFolder.XML_PATHS[0],
+      //           component: xmlInFolder.COMPONENTS[0],
+      //         },
+      //         {
+      //           path: xmlInFolder.XML_PATHS[1],
+      //           component: xmlInFolder.COMPONENTS[1],
+      //         },
+      //       ],
+      //     },
+      //   ]);
+      //   expect(access.getComponentsFromPath(dirPath).length).to.equal(0);
+      // });
     });
 
     it('should ignore directories as fsPaths', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -689,32 +689,35 @@ describe('MetadataResolver', () => {
         ]);
       });
 
-      // it('should not return components if the directory is forceignored', () => {
-      //   const dirPath = xmlInFolder.COMPONENT_FOLDER_PATH;
-      //   testUtil.stubForceIgnore({ seed: dirPath, deny: [dirPath] });
-      //   const access = testUtil.createMetadataResolver([
-      //     {
-      //       dirPath,
-      //       children: [xmlInFolder.XML_NAMES[0], xmlInFolder.XML_NAMES[1]],
-      //     },
-      //   ]);
-      //   testUtil.stubAdapters([
-      //     {
-      //       type: registry.types.document,
-      //       componentMappings: [
-      //         {
-      //           path: xmlInFolder.XML_PATHS[0],
-      //           component: xmlInFolder.COMPONENTS[0],
-      //         },
-      //         {
-      //           path: xmlInFolder.XML_PATHS[1],
-      //           component: xmlInFolder.COMPONENTS[1],
-      //         },
-      //       ],
-      //     },
-      //   ]);
-      //   expect(access.getComponentsFromPath(dirPath).length).to.equal(0);
-      // });
+      it('should not return components if the directory is forceignored', () => {
+        const dirPath = xmlInFolder.COMPONENT_FOLDER_PATH;
+        testUtil.stubForceIgnore({
+          seed: dirPath,
+          deny: [join(dirPath, 'a.report-meta.xml'), join(dirPath, 'b.report-meta.xml')],
+        });
+        const access = testUtil.createMetadataResolver([
+          {
+            dirPath,
+            children: [xmlInFolder.XML_NAMES[0], xmlInFolder.XML_NAMES[1]],
+          },
+        ]);
+        testUtil.stubAdapters([
+          {
+            type: registry.types.document,
+            componentMappings: [
+              {
+                path: xmlInFolder.XML_PATHS[0],
+                component: xmlInFolder.COMPONENTS[0],
+              },
+              {
+                path: xmlInFolder.XML_PATHS[1],
+                component: xmlInFolder.COMPONENTS[1],
+              },
+            ],
+          },
+        ]);
+        expect(access.getComponentsFromPath(dirPath).length).to.equal(0);
+      });
     });
 
     it('should ignore directories as fsPaths', () => {


### PR DESCRIPTION
### What does this PR do?

Updates the metadata resolver to skip the first forceignore check when resolving components recursively if the dir is a folder.

in the linked GH issue below, when building the component set from the API response SDR is trying checking if [`unpackaged`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_retrieve_request.htm) should be ignored here:
https://github.com/forcedotcom/source-deploy-retrieve/blob/f288319e55378d1a7caca5bcd762b77b2c59f30a/src/resolve/metadataResolver.ts#L74

`forceignore.denies` will pass a relative path to `node-ignore` that doesn't have a trailing slash so it is treated as a file when matching the forceignore rules against it:
https://github.com/forcedotcom/source-deploy-retrieve/blob/f288319e55378d1a7caca5bcd762b77b2c59f30a/src/resolve/forceIgnore.ts#L66 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2404
@W-13948748@
