### PR TITLE
fix: one-off handling of 1 html entity

### DIFF
--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -258,8 +258,20 @@ export class JsToXml extends Readable {
     });
 
     const builtXml = String(builder.build(this.xmlObject));
-    const xmlContent = XML_DECL.concat(builtXml);
+    const xmlContent = XML_DECL.concat(handleSpecialEntities(builtXml));
     this.push(xmlContent);
     this.push(null);
   }
 }
+
+/**
+ * use this function to handle special html entities.
+ * XmlBuilder will otherwise replace ex: `&#160;` with `'&amp;#160;'` (escape the &)
+ * This is a separate function to allow for future handling of other special entities
+ *
+ * See https://github.com/NaturalIntelligence/fast-xml-parser/blob/fa5a7339a5ae2ca4aea8a256179b82464dbf510e/docs/v4/5.Entities.md
+ * The parser can call addEntities to support more, but the Builder does not have that option.
+ * You also can't use Builder.tagValueProcessor to use this function
+ * because the escaping of `&` happens AFTER that is called.
+ * */
+const handleSpecialEntities = (xml: string): string => xml.replaceAll('&amp;#160;', '&#160;');

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -544,12 +544,12 @@ describe('Streams', () => {
       expect(jsToXml.read().toString()).to.be.equal(expectedBody);
     });
 
-    it.skip('should transform js with html encoding to xml', () => {
+    it('should transform js with html encoding to xml', () => {
       const xmlObj = {
         TestType: {
           [XML_NS_KEY]: XML_NS_URL,
           foo: '3 results,&#160;and 1 other',
-          many: [{ test: 'first&#1601st' }, { test: 'second&#1602nd' }],
+          many: [{ test: 'first&#160;1st' }, { test: 'second&#160;2nd' }],
         },
       };
       const jsToXml = new streams.JsToXml(xmlObj);
@@ -557,10 +557,10 @@ describe('Streams', () => {
       expectedBody += `<TestType xmlns="${XML_NS_URL}">\n`;
       expectedBody += '    <foo>3 results,&#160;and 1 other</foo>\n';
       expectedBody += '    <many>\n';
-      expectedBody += '        <test>first&#1601st</test>\n';
+      expectedBody += '        <test>first&#160;1st</test>\n';
       expectedBody += '    </many>\n';
       expectedBody += '    <many>\n';
-      expectedBody += '        <test>second&#1602nd</test>\n';
+      expectedBody += '        <test>second&#160;2nd</test>\n';
       expectedBody += '    </many>\n';
       expectedBody += '</TestType>\n';
 


### PR DESCRIPTION
### What does this PR do?
- manual string.replaceAll for the htmlEntity in this issue, with convenient expansion in the future.
- see comment about the other options that I found out won't work 

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2448
@W-14079220@

QA: see comment on issue about what happens when you run retrieve on these (it's never worked, and still doesnt).

The value retrieved from the org turns into a space even when retrieving in mdapi format, so there's nothing we an do about that but raise a bug for the Labels team