### PR TITLE
fix: metadata type support for EventRelayConfig

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3554,6 +3554,14 @@
       "suffix": "pricingRecipe",
       "directoryName": "pricingRecipes",
       "strictDirectoryName": false
+    },
+    "eventrelayconfig": {
+      "id": "eventrelayconfig",
+      "name": "EventRelayConfig",
+      "suffix": "eventRelay",
+      "directoryName": "eventRelays",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -3944,7 +3952,8 @@
     "SearchableObjDataSyncInfoSetting": "searchableobjdatasyncinfo",
     "SearchCriteriaConfigurationSetting": "searchcriteriaconfiguration",
     "fundraisingConfig": "fundraisingconfig",
-    "pricingRecipe": "pricingrecipe"
+    "pricingRecipe": "pricingrecipe",
+    "eventRelay": "eventrelayconfig"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?
Adds support for [EventRelayConfig Metadata Type](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_eventrelayconfig.htm) to Metadata Registry 

### What issues does this PR fix or reference?

#### [@W-12157698](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001FhTAZYA3/view)

### Functionality Before
On running `sfdx force:mdapi:retrieve` or `sfdx force:mdapi:deploy` with EventRelayConfig as a part of pacakge.xml the observed behavior is 
`ERROR running force:mdapi:retrieve: The specified metadata type is unsupported: [eventrelayconfig]
`
### Functionality After
SFDX retrieve and SFDX deploy commands with EventRelayConfig work. 