### PR TITLE
fix: remove duplicates from file responses

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -86,7 +86,8 @@ export class DeployResult implements MetadataTransferResult {
           );
       }
     }
-    return this.fileResponses;
+    // removes duplicates from the file responses by parsing the object into a string, used as the key of the map
+    return [...new Map(this.fileResponses.map((v) => [JSON.stringify(v), v])).values()];
   }
 
   private createResponses(component: SourceComponent, responseMessages: DeployMessage[]): FileResponse[] {

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -819,6 +819,63 @@ describe('MetadataApiDeploy', () => {
         expect(responses).to.deep.equal(expected);
       });
 
+      it('should not report duplicates component', () => {
+        const component = matchingContentFile.COMPONENT;
+        const deployedSet = new ComponentSet([component]);
+        const { fullName, type, content } = component;
+        const problem = 'something went wrong';
+        const problemType = 'Error';
+        const apiStatus: Partial<MetadataApiDeployStatus> = {
+          details: {
+            componentFailures: [
+              {
+                changed: 'false',
+                created: 'false',
+                deleted: 'false',
+                success: 'false',
+                lineNumber: '3',
+                columnNumber: '5',
+                problem,
+                problemType,
+                fullName,
+                fileName: component.content,
+                componentType: type.name,
+              } as DeployMessage,
+              {
+                changed: 'false',
+                created: 'false',
+                deleted: 'false',
+                success: 'false',
+                lineNumber: '3',
+                columnNumber: '5',
+                problem,
+                problemType,
+                fullName,
+                fileName: component.content,
+                componentType: type.name,
+              } as DeployMessage,
+            ],
+          },
+        };
+        const result = new DeployResult(apiStatus as MetadataApiDeployStatus, deployedSet);
+
+        const responses = result.getFileResponses();
+        const expected: FileResponse[] = [
+          {
+            fullName,
+            type: type.name,
+            state: ComponentStatus.Failed,
+            filePath: content,
+            error: `${problem} (3:5)`,
+            lineNumber: 3,
+            columnNumber: 5,
+            problemType,
+          },
+        ];
+
+        expect(responses).to.deep.equal(expected);
+      });
+
       it('should report children of deployed component', () => {
         const component = DECOMPOSED_COMPONENT;
         const deployedSet = new ComponentSet([component]);


### PR DESCRIPTION
### What does this PR do?
removes duplicates from file responses

before:
```bash
 ➜  bug sf project deploy start --metadata-dir dup
Debugger listening on ws://127.0.0.1:9229/b0f755b5-6e94-4861-8126-144a41f751ba
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Deploying <version specified in manifest> metadata to test-bavzogrje67w@example.com using the v58.0 SOAP API.
Deploy ID: 0Af8N00000uI9ZCSA0
Status: Failed | ████████████████████████████████████████ | 2/2 Components (Errors:2) | 0/0 Tests (Errors:0)
Debugger ending on ws://127.0.0.1:9229/b0f755b5-6e94-4861-8126-144a41f751ba
For help, see: https://nodejs.org/en/docs/inspector

Component Failures [2]
===============================================================
| Type  Name             Problem                    Line:Column 
| ───── ──────────────── ────────────────────────── ─────────── 
| Error GeocodingService Unexpected token 'static'. 2:12        
| Error GeocodingService Unexpected token 'static'. 2:12   
```

after
```bash
 ➜  bug sf project deploy start --metadata-dir dup
Debugger listening on ws://127.0.0.1:9229/9d509851-7f65-44b6-b4ac-2392d048451d
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Deploying <version specified in manifest> metadata to test-bavzogrje67w@example.com using the v58.0 SOAP API.
Deploy ID: 0Af8N00000uILdqSAG
Status: Failed | ████████████████████████████████████████ | 2/2 Components (Errors:2) | 0/0 Tests (Errors:0)

Component Failures [1]
===============================================================
| Type  Name             Problem                    Line:Column 
| ───── ──────────────── ────────────────────────── ─────────── 
| Error GeocodingService Unexpected token 'static'. 2:12      
```
### What issues does this PR fix or reference?

@W-14262002@
