### PR TITLE
Merge profiles on retrieve - POC and to discuss - NOT READY TO MERGE

### DIFF
--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -26,6 +26,10 @@ Could not find parent type for %s (%s)
 
 Component conversion failed: %s
 
+# error_invalid_merge_strategy
+
+Invalid merge strategy - '%s' (must be merge or replace)
+
 # error_merge_metadata_target_unsupported
 
 Merge convert for metadata target format currently unsupported
@@ -37,6 +41,14 @@ Missing adapter '%s' for metadata type '%s'
 # error_missing_transformer
 
 Missing transformer '%s' for metadata type '%s'
+
+# error_missing_transformerConfig
+
+Missing transformerConfig for metadata type '%s' - required for 'merged' transformer
+
+# error_missing_transformerConfig_mappingKey
+
+Missing mappingKey for transformerConfig with metadata type '%s'
 
 # error_missing_type_definition
 

--- a/src/convert/transformers/mergedMetadataTransformer.ts
+++ b/src/convert/transformers/mergedMetadataTransformer.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { Messages } from '@salesforce/core';
+import { ensureArray } from '@salesforce/kit';
+import { JsonArray, JsonMap } from '@salesforce/ts-types';
+import { WriteInfo } from '../types';
+import { SourceComponent } from '../../resolve';
+import { JsToXml } from '../streams';
+import { MergeStrategy } from '../../registry';
+import { DefaultMetadataTransformer } from './defaultMetadataTransformer';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sdr');
+
+/**
+ * The merged metadata transformer.
+ *
+ * Merge incomming metadata with metadata that is already on disk.
+ * This is useful for profiles because retrieved profile metadata is
+ * dependant upon the other metadata types included in the same retrieve.
+ *
+ * If there is no existing metadata - fallback to default behaviour.
+ */
+export class MergedMetadataTransformer extends DefaultMetadataTransformer {
+  // eslint-disable-next-line @typescript-eslint/require-await, class-methods-use-this
+  public async toSourceFormat(component: SourceComponent, mergeWith?: SourceComponent): Promise<WriteInfo[]> {
+    if (!mergeWith?.xml) {
+      return super.toSourceFormat(component, mergeWith);
+    }
+
+    const config = component.type.strategies?.transformerConfig;
+
+    if (!config) {
+      throw messages.createError('error_missing_transformerConfig', [component.type?.name]);
+    }
+
+    const { rootNode, defaultHandling, nodeHandling } = config;
+
+    const source: JsonMap = await component.parseXml();
+    const target: JsonMap = await mergeWith.parseXml();
+
+    if (!(rootNode in source)) {
+      // Nothing to merge into profile
+      return [];
+    }
+
+    if (!(rootNode in target)) {
+      target[rootNode] = {} as JsonMap;
+    }
+
+    for (const [nodeName, nodeEntryOrEntries] of Object.entries(source[rootNode] as JsonMap)) {
+      if (nodeName.startsWith('@')) {
+        continue;
+      }
+
+      const nodeEntries = ensureArray(nodeEntryOrEntries) as JsonArray;
+      const { strategy, mappingKey } = nodeHandling[nodeName] || defaultHandling;
+
+      let updatedNodeEntries;
+
+      switch (strategy) {
+        case MergeStrategy.Replace:
+          updatedNodeEntries = nodeEntries;
+          break;
+
+        case MergeStrategy.Merge:
+          // @ts-ignore: Object is possibly 'null'.
+          if (!target[rootNode][nodeName]) {
+            updatedNodeEntries = nodeEntries;
+            continue;
+          }
+
+          if (!mappingKey) {
+            throw messages.createError('error_missing_transformerConfig_mappingKey', [component.type?.name]);
+          }
+
+          // @ts-ignore: Object is possibly 'null'.
+          updatedNodeEntries = mergeNodes(mappingKey, nodeEntries, ensureArray(target[rootNode][nodeName]));
+          break;
+        default:
+          throw messages.createError('error_invalid_merge_strategy', [strategy]);
+      }
+
+      // @ts-ignore: Object is possibly 'null'.
+      target[rootNode][nodeName] = updatedNodeEntries;
+    }
+
+    const sortedTarget = {};
+    // @ts-ignore: Object is possibly 'null'.
+    sortedTarget[rootNode] = {};
+
+    // @ts-ignore: Object is possibly 'null'.
+    for (const nodeName of Object.keys(target[rootNode]).sort()) {
+      // @ts-ignore: Object is possibly 'null'.
+      sortedTarget[rootNode][nodeName] = target[rootNode][nodeName];
+    }
+
+    // TODO: implement deleteOnEmpty - if target contains any nodes that don't exist in source + have deleteOnEmpty enabled - delete those nodes from target
+    // e.g. ip address ranges - these are always returned with Profile, if they are not there - they've been removed
+    // (unlike say fieldPermissions where they are not there because no fields are being retrieved)
+
+    return [
+      {
+        source: new JsToXml(sortedTarget),
+        output: mergeWith.xml,
+      },
+    ];
+  }
+}
+
+const mergeNodes = (mappingKey: string, sourceNodes: JsonArray, targetNodes: JsonArray): JsonArray => {
+  // @ts-ignore: Object is possibly 'null'.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  const sourceKeys = sourceNodes.map((node) => node[mappingKey]);
+
+  // @ts-ignore: Object is possibly 'null'.
+  const mergedEntries = targetNodes.filter((node) => !sourceKeys.includes(node[mappingKey]));
+  mergedEntries.push(...sourceNodes);
+  mergedEntries.sort((a, b) => {
+    // @ts-ignore: Object is possibly 'null'.
+    if (a[mappingKey] > b[mappingKey]) {
+      return 1;
+    }
+
+    // @ts-ignore: Object is possibly 'null'.
+    if (a[mappingKey] < b[mappingKey]) {
+      return -1;
+    }
+
+    return 0;
+  });
+
+  return mergedEntries;
+};

--- a/src/convert/transformers/metadataTransformerFactory.ts
+++ b/src/convert/transformers/metadataTransformerFactory.ts
@@ -13,6 +13,7 @@ import { DefaultMetadataTransformer } from './defaultMetadataTransformer';
 import { DecomposedMetadataTransformer } from './decomposedMetadataTransformer';
 import { StaticResourceMetadataTransformer } from './staticResourceMetadataTransformer';
 import { NonDecomposedMetadataTransformer } from './nonDecomposedMetadataTransformer';
+import { MergedMetadataTransformer } from './mergedMetadataTransformer';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sdr');
@@ -40,6 +41,12 @@ export class MetadataTransformerFactory {
         return new StaticResourceMetadataTransformer(this.registry, this.context);
       case TransformerStrategy.NonDecomposed:
         return new NonDecomposedMetadataTransformer(this.registry, this.context);
+      case TransformerStrategy.Merged:
+        if (process.env.SF_ENABLE_EXPERIMENTAL_PROFILE_MERGE === 'true') {
+          return new MergedMetadataTransformer(this.registry, this.context);
+        } else {
+          return new DefaultMetadataTransformer(this.registry, this.context);
+        }
       default:
         throw messages.createError('error_missing_transformer', [type.name, transformerId]);
     }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -14,4 +14,5 @@ export {
   DecompositionStrategy,
   RecompositionStrategy,
   TransformerStrategy,
+  MergeStrategy,
 } from './types';

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -985,7 +985,48 @@
       "suffix": "profile",
       "directoryName": "profiles",
       "inFolder": false,
-      "strictDirectoryName": false
+      "strictDirectoryName": false,
+      "strategies": {
+        "adapter": "default",
+        "transformer": "merged",
+        "transformerConfig": {
+          "rootNode": "Profile",
+          "defaultHandling": {
+            "strategy": "replace",
+            "deleteOnEmpty": false
+          },
+          "nodeHandling": {
+            "TODO": {
+              "strategy": "merge",
+              "mappingKey": "Add remaining profile permission types where they should be merged instead of replaced - set deleteOnEmpty"
+            },
+            "classAccesses": {
+              "strategy": "merge",
+              "mappingKey": "apexClass"
+            },
+            "fieldPermissions": {
+              "strategy": "merge",
+              "mappingKey": "field"
+            },
+            "loginIpRanges": {
+              "strategy": "replace",
+              "deleteOnEmpty": true
+            },
+            "objectPermissions": {
+              "strategy": "merge",
+              "mappingKey": "object"
+            },
+            "pageAccesses": {
+              "strategy": "merge",
+              "mappingKey": "apexPage"
+            },
+            "tabVisibilities": {
+              "strategy": "merge",
+              "mappingKey": "tab"
+            }
+          }
+        }
+      }
     },
     "permissionset": {
       "id": "permissionset",

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -147,10 +147,25 @@ export interface MetadataType {
       | 'nonDecomposed'
       | 'digitalExperience'
       | 'bundle';
-    transformer?: 'decomposed' | 'staticResource' | 'nonDecomposed' | 'standard';
+    transformer?: 'decomposed' | 'staticResource' | 'nonDecomposed' | 'standard' | 'merged';
+    transformerConfig?: MergedTransformerConfig;
     decomposition?: 'topLevel' | 'folderPerType';
     recomposition?: 'startEmpty';
   };
+}
+
+interface MergedTransformerConfig {
+  rootNode: string;
+  defaultHandling: MergedTransformerConfigHandler;
+  nodeHandling: {
+    [node: string]: MergedTransformerConfigHandler;
+  };
+}
+
+interface MergedTransformerConfigHandler {
+  strategy: 'replace' | 'merge';
+  mappingKey?: string;
+  deleteOnEmpty?: boolean;
 }
 
 /**
@@ -206,6 +221,12 @@ export const enum TransformerStrategy {
   Decomposed = 'decomposed',
   StaticResource = 'staticResource',
   NonDecomposed = 'nonDecomposed',
+  Merged = 'merged',
+}
+
+export const enum MergeStrategy {
+  Replace = 'replace',
+  Merge = 'merge',
 }
 
 interface Channel {


### PR DESCRIPTION
Profiles suck - this PR attempts to make them suck a little bit less. It's a POC and my attempt to prompt a discussion - **it's in no way ready to merge**.

## Background

_I fully expect that anyone reading a PR against this repo will know this already but lets set the scene..._

When profiles are retrieved from Salesforce they only contain basic profile information i.e. description, user permissions, etc. If the same retrieve contains metadata types that have profile permissions (e.g. objects, fields, apps, classes, etc), the profile metadata will also contain permissions for that metadata. However, it'll only contain the permissions for metadata contained in that retrieve and any existing profile metadata file will be completely overwritten.

This effectively means you can't use source commands and track profiles. You kind of can, if you maintain a manifest and retrieve all metadata with permissions alongside the profiles but this isn't ideal for so many reasons.

I can understand why this has never worked - profiles are a pain in the ass and are largely superseded by Permission Sets and Permission Set Groups. In the coming years, object and field permissions will be completely removed from profiles.

So why invest time in something that doesn't have a future?
1) It's going to be years before object permissions are completely removed from profiles (2026 I believe?)
2) Designing new orgs with Permission Sets + Groups is very sensible but we don't always have that luxury with existing orgs and so have to work with what's there, and that's always profiles
3) Even when object permissions are removed from profiles - there will still likely be app defaults, layout assignments, etc.

## Proposal

When converting from MD API to Source format, merge retrieved profile permissions into the existing profile file. If an existing file doesn't exist, fallback to the way it works at the moment.

There would need to be configuration to determine how to merge the files, I propose the following. Two merge strategies:
- Replace - completely replace the existing node with whatever has been retrieved. To be used for metadata that is always retrieved in profiles i.e. user permissions, description, custom, ips, etc.
- Merge - interlace retrieved permissions with those that are already there identified by a mapping key. To be used for metadata that is selectively retrieved depending on other retrieved types i.e. field permissions, object permissions, etc.

This is an example of the configuration used in the POC:

```
  "profile": {
      "id": "profile",
      ...
      "strategies": {
        "adapter": "default",
        "transformer": "merged",
        "transformerConfig": {
          "rootNode": "Profile",
          "defaultHandling": {
            "strategy": "replace",
            "deleteOnEmpty": false
          },
          "nodeHandling": {
            "classAccesses": {
              "strategy": "merge",
              "mappingKey": "apexClass"
            },
            "fieldPermissions": {
              "strategy": "merge",
              "mappingKey": "field"
            },
            "loginIpRanges": {
              "strategy": "replace",
              "deleteOnEmpty": true
            },
            "objectPermissions": {
              "strategy": "merge",
              "mappingKey": "object"
            }
          }
        }
      }
    }
```
Note, I've also considered an attribute along the lines of 'deleteOnEmpty' (not implemented yet in the POC) to cover metadata that may genuinely have been removed from the org (opposed to just not retrieved) e.g. loginIpRanges.

This does mean there is additional configuration to be maintained. It's not ideal to maintain a list of the permission types in profiles and how to merge them. However, this is mitigated by having a default configuration of replace i.e. do what it does now. Also, the profile metadata type seldom changes.

I've tucked the functionality away behind an environment variable (`SF_ENABLE_EXPERIMENTAL_PROFILE_MERGE`) - having a flag to explicitly turn this feature on or off is probably a good idea. Though, since profile retrieving doesn't work at the moment, arguably a flag to turn off is probably the better way around.

## Limitations / Potential Issues

- Deletions - for example, if a field is removed from an object in the org - the retrieved profile won't contain a permission and the result of the merge will be that that field remains unchanged (not removed)
- Sorting - we'll have to do sorting of permissions on the client side (i.e. in the library) but that may not exactly match the sorting done server side (i.e. by the MD API) so depending on method of retrieving - metadata may move around slightly

## TODO

- Discuss this change on the PR or open a discussion in forcedotcom/cli (have started here as there is code)

If the idea is a 'go'er', I'm willing to invest my time to finish off the PR.

That will involve:

- Fixing all the TypeScript compile and es-lint errors (I've littered it with ignores to make the build compile, I rarely write TypeScript... and so far I'm not rushing to start a new TypeScript project anytime soon...)
- Add remaining nodeHandling configurations
- Implement deleteOnEmpty
- Write unit tests
- Reviews

## Conclusion

Ultimately, (and I mean no offence to anyone) I don't think we can make the handling of profiles much worse than it already is - therefore, there is no downside to giving this a shot.

Before:
![Before](https://github.com/forcedotcom/source-deploy-retrieve/assets/678641/d068e68d-a3b2-4c48-a05a-a213e3f7b4e7)

After:
<img width="816" alt="After" src="https://github.com/forcedotcom/source-deploy-retrieve/assets/678641/a8c12e24-bed9-4778-99c8-08e292ef5496">