### PR TITLE
fix: Wr/coft mpd

### DIFF
--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -139,9 +139,6 @@ export class StandardWriter extends ComponentWriter {
         // queue is empty when that call exits and overall less memory is consumed.
         await Promise.all(
           chunk.writeInfos.map((info: WriteInfo) => {
-            // assertion logic: the rootDestination is required in this subclass of ComponentWriter but the super doesn't know that
-            // the eslint comment should remain until strictMode is fully implemented
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             const fullDest = isAbsolute(info.output) ? info.output : join(this.rootDestination as string, info.output);
             if (!existsSync(fullDest)) {
               for (const ignoredPath of this.forceIgnoredPaths) {

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -130,11 +130,17 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
             }
             // if no child component is found to merge with yet, mark it as so in the state
             else if (!this.getDecomposedState(childComponent)?.foundMerge) {
-              // if the child can't exist without the parent, redirect the output to the parents output, rather than the default output
               if (mergeWith?.content && childComponent.type.unaddressableWithoutParent && childComponent.type.suffix) {
+                // if the child can't exist without the parent, and we found a parent (mergeWith) redirect the output to the parents output, rather than the default output
                 writeInfos.push({
                   source,
-                  output: path.join(mergeWith.content, entryName + '.' + childComponent.type.suffix + '-meta.xml'),
+                  output: path.join(mergeWith.content, `${entryName}.${childComponent.type.suffix}${META_XML_SUFFIX}`),
+                });
+              } else if (!mergeWith) {
+                // if the child can't exist without a parent, and there's no parent found, redirect to the default pkg dir
+                writeInfos.push({
+                  source,
+                  output: getDefaultOutput(childComponent),
                 });
               } else {
                 this.setDecomposedState(childComponent, {

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -114,33 +114,6 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
             this.forceIgnore
           );
         }
-      } else if (
-        triggerIsAChild &&
-        this.type.children &&
-        !component &&
-        this.type.children.types[childTypeId].unaddressableWithoutParent
-      ) {
-        /*
-         if we're parsing an unaddressableWithoutParent type, and there's no component for it, then it's likely that the parent resides outside the current package we're building
-         e.g. a COT in a managed package, with the COFT in a different package, so we'll address the child as a parent so that the two will be built together
-
-         this will result in a incorrect type being displayed
-
-         STATE   FULL NAME          TYPE                    PROJECT PATH
-         ─────── ────────────────── ─────────────────────── ─────────────────────────────────────────────────────────────────────────────────────────
-         Changed customObject__c-es CustomObjectTranslation ...default/objectTranslations/customObject__c-es/customField__c.fieldTranslation-meta.xml
-
-         notice how it says CustomObjectTranslation even though the suffix is a .fieldTranslation
-        */
-        return new SourceComponent(
-          {
-            name: baseName(pathToContent),
-            type: this.type,
-            content: pathToContent,
-          },
-          this.tree,
-          this.forceIgnore
-        );
       } else if (!component) {
         // This is most likely metadata found within a CustomObject folder that is not a
         // child type of CustomObject. E.g., Layout, SharingRules, ApexClass.

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -120,10 +120,18 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
         !component &&
         this.type.children.types[childTypeId].unaddressableWithoutParent
       ) {
-        // if we're parsing an unaddressableWithoutParent type, and there's no component for it
-        // it's likely that the parent resides outside of the current package we're building
-        // e.g. a COT in a managed package, with the COFT in a different package
-        // so we'll address the child as a parent
+        /*
+         if we're parsing an unaddressableWithoutParent type, and there's no component for it, then it's likely that the parent resides outside the current package we're building
+         e.g. a COT in a managed package, with the COFT in a different package, so we'll address the child as a parent so that the two will be built together
+
+         this will result in a incorrect type being displayed
+
+         STATE   FULL NAME          TYPE                    PROJECT PATH
+         ─────── ────────────────── ─────────────────────── ─────────────────────────────────────────────────────────────────────────────────────────
+         Changed customObject__c-es CustomObjectTranslation ...default/objectTranslations/customObject__c-es/customField__c.fieldTranslation-meta.xml
+
+         notice how it says CustomObjectTranslation even though the suffix is a .fieldTranslation
+        */
         return new SourceComponent(
           {
             name: baseName(pathToContent),

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -89,7 +89,7 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
       const childTypeId = this.type.children?.suffixes?.[metaXml.suffix];
       const triggerIsAChild = !!childTypeId;
       const strategy = this.type.strategies?.decomposition;
-
+      // look at changing this
       if (triggerIsAChild && this.type.children && !this.type.children.types[childTypeId].unaddressableWithoutParent) {
         if (strategy === DecompositionStrategy.FolderPerType || isResolvingSource) {
           let parent = component;
@@ -115,6 +115,24 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
             this.forceIgnore
           );
         }
+      } else if (
+        triggerIsAChild &&
+        this.type.children &&
+        this.type.children.types[childTypeId].unaddressableWithoutParent
+      ) {
+        let parent = component;
+        if (!parent) {
+          parent = new SourceComponent(
+            {
+              name: baseName(pathToContent),
+              type: this.type.children.types[childTypeId],
+            },
+            this.tree,
+            this.forceIgnore
+          );
+        }
+        parent.content = pathToContent;
+        return parent;
       } else if (!component) {
         // This is most likely metadata found within a CustomObject folder that is not a
         // child type of CustomObject. E.g., Layout, SharingRules, ApexClass.

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -123,10 +123,11 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
         // if we're parsing an unaddressableWithoutParent type, and there's no component for it
         // it's likely that the parent resides outside of the current package we're building
         // e.g. a COT in a managed package, with the COFT in a different package
+        // so we'll address the child as a parent
         return new SourceComponent(
           {
             name: baseName(pathToContent),
-            type: this.type.children.types[childTypeId],
+            type: this.type,
             content: pathToContent,
           },
           this.tree,

--- a/src/resolve/adapters/decomposedSourceAdapter.ts
+++ b/src/resolve/adapters/decomposedSourceAdapter.ts
@@ -89,7 +89,6 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
       const childTypeId = this.type.children?.suffixes?.[metaXml.suffix];
       const triggerIsAChild = !!childTypeId;
       const strategy = this.type.strategies?.decomposition;
-      // look at changing this
       if (triggerIsAChild && this.type.children && !this.type.children.types[childTypeId].unaddressableWithoutParent) {
         if (strategy === DecompositionStrategy.FolderPerType || isResolvingSource) {
           let parent = component;
@@ -118,21 +117,21 @@ export class DecomposedSourceAdapter extends MixedContentSourceAdapter {
       } else if (
         triggerIsAChild &&
         this.type.children &&
+        !component &&
         this.type.children.types[childTypeId].unaddressableWithoutParent
       ) {
-        let parent = component;
-        if (!parent) {
-          parent = new SourceComponent(
-            {
-              name: baseName(pathToContent),
-              type: this.type.children.types[childTypeId],
-            },
-            this.tree,
-            this.forceIgnore
-          );
-        }
-        parent.content = pathToContent;
-        return parent;
+        // if we're parsing an unaddressableWithoutParent type, and there's no component for it
+        // it's likely that the parent resides outside of the current package we're building
+        // e.g. a COT in a managed package, with the COFT in a different package
+        return new SourceComponent(
+          {
+            name: baseName(pathToContent),
+            type: this.type.children.types[childTypeId],
+            content: pathToContent,
+          },
+          this.tree,
+          this.forceIgnore
+        );
       } else if (!component) {
         // This is most likely metadata found within a CustomObject folder that is not a
         // child type of CustomObject. E.g., Layout, SharingRules, ApexClass.

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@
     typescript "^4.9.5"
     wireit "^0.9.5"
 
-"@salesforce/kit@^3.0.11", "@salesforce/kit@^3.0.13":
+"@salesforce/kit@^3.0.13":
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.13.tgz#10b47ad6e0e27c3a9f97eb6a5cdcfffa9ba1f163"
   integrity sha512-HLQ5L5bBi0tsMeH5ZHJAhHUpvNUNPQoNJt2O82Jf6C60GGsrlzwzQ5ONAHGNBgKSZ7HLr0UGL5xaA+hE9uOcgw==


### PR DESCRIPTION
### What does this PR do?

allows `CustomFieldTranslation` MDT to be retrieved across MPDs

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2124 @W-13193003@

### Functionality Before

with a remote change to a CFT, the parent COT being in the non-default package dir, and running a `force source pull`
```bash
 ➜  pull
Preparing retrieve request... ⣾
Preparing retrieve request... MetadataTransferError
Error (1): Metadata API request failed: Unexpected child metadata [/Users/william.ruemmele/projects/scratches/sfdx-translation-bug/package-a-app/main/default/objectTranslations/customObject__c-es/customField__c.fieldTranslation-meta.xml] found for parent type [CustomObjectTranslation]
```
### Functionality After

```bash
 ➜  sf force source pull                                
Warning: We plan to deprecate this command in the future. Try using the "project retrieve start" command instead.
Loading source tracking information... ⣽
Updating source tracking... done
=== Retrieved Source

 STATE   FULL NAME                         TYPE                    PROJECT PATH                                                                                                   
 ─────── ───────────────────────────────── ─────────────────────── ────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 Changed customObject__c-es.customField__c CustomFieldTranslation  package-a-app/main/default/objectTranslations/customObject__c-es/customField__c.fieldTranslation-meta.xml      
 Changed customObject__c-es                CustomObjectTranslation package-b-app/main/default/objectTranslations/customObject__c-es/customObject__c-es.objectTranslation-meta.xml 
```

notice `package-a` and `package-b` as the two different packages written to, `a` is default, where new MD is written to, and `b` contains the parent COT