### PR TITLE
fix(lint): current linter rules

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -221,7 +221,7 @@ export type RetrieveRequest = {
 
 export type RetrieveMessage = { fileName: string; problem: string };
 
-enum ManageableState {
+export enum ManageableState {
   Beta = 'beta',
   Deleted = 'deleted',
   Deprecated = 'deprecated',

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -214,7 +214,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
         resolveIncludeSet.add(component, deletionType);
       }
       const memberIsWildcard = component.fullName === ComponentSet.WILDCARD;
-      if (!memberIsWildcard || options.forceAddWildcards || !options.resolveSourcePaths) {
+      if (options.resolveSourcePaths === undefined || !memberIsWildcard || options.forceAddWildcards) {
         result.add(component, deletionType);
       }
     };

--- a/src/convert/replacements.ts
+++ b/src/convert/replacements.ts
@@ -195,7 +195,8 @@ export const getReplacements = async (
 export const matchesFile = (f: string, r: ReplacementConfig): boolean =>
   // filenames will be absolute.  We don't have convenient access to the pkgDirs,
   // so we need to be more open than an exact match
-  Boolean((r.filename && posixifyPaths(f).endsWith(r.filename)) || (r.glob && minimatch(f, `**/${r.glob}`)));
+  (typeof r.filename === 'string' && posixifyPaths(f).endsWith(r.filename)) ||
+  (typeof r.glob === 'string' && minimatch(f, `**/${r.glob}`));
 
 /**
  * Regardless of any components, return the ReplacementConfig that are valid with the current env.

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -200,7 +200,7 @@ export class ZipWriter extends ComponentWriter {
         chunk.writeInfos.map(async (writeInfo) => {
           // we don't want to prematurely zip folder types when their children might still be not in the zip
           // those files we'll leave open as ReadableStreams until the zip finalizes
-          if (chunk.component.type.folderType || chunk.component.type.folderContentType) {
+          if (Boolean(chunk.component.type.folderType) || Boolean(chunk.component.type.folderContentType)) {
             return this.addToZip(writeInfo.source, writeInfo.output);
           }
           // everything else can be zipped immediately to reduce the number of open files (windows has a low limit!) and help perf

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -197,7 +197,7 @@ const getContentType = async (component: SourceComponent): Promise<string> => {
 
   if (typeof output !== 'string') {
     throw new SfError(
-      `Expected a string for contentType in ${component.name} (${component.xml}) but got ${output?.toString()}`
+      `Expected a string for contentType in ${component.name} (${component.xml}) but got ${JSON.stringify(output)}`
     );
   }
   return output;

--- a/src/resolve/adapters/baseSourceAdapter.ts
+++ b/src/resolve/adapters/baseSourceAdapter.ts
@@ -166,7 +166,7 @@ export abstract class BaseSourceAdapter implements SourceAdapter {
 
     // inFolder types (report, dashboard, emailTemplate, document) and their folder
     // container types (reportFolder, dashboardFolder, emailFolder, documentFolder)
-    if (inFolder || folderContentType) {
+    if (folderContentType ?? inFolder) {
       return ensureString(
         parseNestedFullName(rootMetadata.path, directoryName),
         `Unable to calculate fullName from component at path: ${rootMetadata.path} (${this.type.name})`

--- a/src/resolve/manifestResolver.ts
+++ b/src/resolve/manifestResolver.ts
@@ -125,5 +125,5 @@ const isMemberNestedInFolder = (
   const isNestedInFolder = !fullName.includes('/') || members.some((m) => m.includes(`${fullName}/`));
   const isNonMatchingFolder = parentType && parentType.folderType !== parentType.id;
 
-  return (isInFolderType && isNestedInFolder) || (!isInFolderType && isNonMatchingFolder);
+  return isInFolderType ? isNestedInFolder : isNonMatchingFolder;
 };

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -197,7 +197,8 @@ export class MetadataResolver {
           (typeof type.strategies?.adapter === 'string' &&
             ['mixedContent', 'bundle'].includes(type.strategies.adapter)) ||
           // the file suffix (in source or mdapi format) matches the type suffix we think it is
-          (type.suffix && [type.suffix, `${type.suffix}${META_XML_SUFFIX}`].some((s) => fsPath.endsWith(s))) ||
+          (typeof type.suffix === 'string' &&
+            [type.suffix, `${type.suffix}${META_XML_SUFFIX}`].some((s) => fsPath.endsWith(s))) ||
           // the type has children and the file suffix (in source format) matches a child type suffix of the type we think it is
           (type.children?.types &&
             Object.values(type.children?.types)
@@ -283,7 +284,7 @@ export class MetadataResolver {
           ...guesses.map((guess) =>
             messages.getMessage('suggest_type_did_you_mean', [
               guess.suffixGuess,
-              metaSuffix || closeMetaSuffix ? '-meta.xml' : '',
+              typeof metaSuffix === 'string' || closeMetaSuffix ? '-meta.xml' : '',
               guess.metadataTypeGuess.name,
             ])
           ),

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -277,8 +277,8 @@ export class SourceComponent implements MetadataComponent {
     // It also applies to DigitalExperienceBundle types as we need to maintain the folder structure
     if (
       !suffix ||
-      inFolder ||
-      folderContentType ||
+      Boolean(inFolder) ||
+      typeof folderContentType === 'string' ||
       ['digitalexperiencebundle', 'digitalexperience'].includes(this.type.id)
     ) {
       return trimUntil(fsPath, directoryName, true);

--- a/src/utils/filePathGenerator.ts
+++ b/src/utils/filePathGenerator.ts
@@ -76,7 +76,7 @@ export const filePathsFromMetadataComponent = (
 
   // basic metadata (with or without folders)
   if (!type.children && !type.strategies) {
-    return (type.inFolder || type.folderType ? generateFolders({ fullName, type }, packageDirWithTypeDir) : []).concat([
+    return (type.inFolder ?? type.folderType ? generateFolders({ fullName, type }, packageDirWithTypeDir) : []).concat([
       join(packageDirWithTypeDir, `${fullName}.${type.suffix}${META_XML_SUFFIX}`),
     ]);
   }

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -125,6 +125,7 @@ export async function stubMetadataDeploy(
   const invokeResultStub = sandbox.stub();
   invokeStub.returns({
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     then: (f: (result: unknown | null) => void) => f(invokeResultStub()),
   });
 

--- a/test/resolve/connectionResolver.test.ts
+++ b/test/resolve/connectionResolver.test.ts
@@ -8,6 +8,7 @@
 import { assert, expect } from 'chai';
 import { MockTestOrgData, TestContext } from '@salesforce/core/lib/testSetup';
 import { Connection, Logger } from '@salesforce/core';
+import { ManageableState } from '../../src/client/types';
 import { ConnectionResolver } from '../../src/resolve';
 import { MetadataComponent, registry } from '../../src/';
 
@@ -324,7 +325,7 @@ describe('ConnectionResolver', () => {
 
       const resolver = new ConnectionResolver(connection);
       const result = await resolver.resolve(
-        (component) => !(component.namespacePrefix && component.manageableState !== 'unmanaged')
+        (component) => !(component.namespacePrefix && component.manageableState !== ManageableState.Unmanaged)
       );
       expect(result.components).to.deep.equal([]);
     });


### PR DESCRIPTION
### What does this PR do?
cleans up some things the linter didn't like.  Most of them are related to using truthiness on things that can be undefined in stuff chained by `||`.  A few were actual problems...the others are a bit much.  The logic was fine, but harder for the linter to know, with non-booleans, whether the `||` was being used a logical OR vs. fallback if falsy.

### What issues does this PR fix or reference?

kinda fallout from [@W-14373783@](https://gus.lightning.force.com/a07EE00001dDMpBYAW)
https://github.com/forcedotcom/eslint-config-salesforce-typescript/actions/runs/6720828841/job/18265239393
