### PR TITLE
fix: support metadata type managedEventSubscription

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3652,6 +3652,14 @@
       "directoryName": "registeredExternalServices",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "managedeventsubscription": {
+      "id": "managedeventsubscription",
+      "name": "ManagedEventSubscription",
+      "suffix": "managedEventSubscription",
+      "directoryName": "managedEventSubscriptions",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -4054,7 +4062,8 @@
     "RecordAggregationDefinition": "recordaggregationdefinition",
     "webStoreBundle": "webstorebundle",
     "externalAIModel": "externalaimodel",
-    "registeredExternalService": "registeredexternalservice"
+    "registeredExternalService": "registeredexternalservice",
+    "managedEventSubscription": "managedeventsubscription"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?
Adde support to managedEventSubscription metadata to SF CLI
### What issues does this PR fix or reference?

#@W-14358125@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
