### PR TITLE
feat: build ComponentSet using metadata and an org connection

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -283,7 +283,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       }
     }
 
-    const connectionResolver = new ConnectionResolver(usernameOrConnection, options.registry);
+    const connectionResolver = new ConnectionResolver(usernameOrConnection, options.registry, options.metadataTypes);
     const manifest = await connectionResolver.resolve(options.componentFilter);
     const result = new ComponentSet([], options.registry);
     result.apiVersion = manifest.apiVersion;

--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -10,6 +10,7 @@
 import * as path from 'node:path';
 import { StateAggregator, Logger, SfError, Messages } from '@salesforce/core';
 import * as fs from 'graceful-fs';
+import * as minimatch from 'minimatch';
 import { ComponentSet } from '../collections';
 import { RegistryAccess } from '../registry';
 import { FileProperties } from '../client';
@@ -134,7 +135,8 @@ export class ComponentSetBuilder {
             })
               .getSourceComponents()
               .toArray()
-              .filter((cs) => new RegExp(splitEntry[1]).test(cs.fullName))
+              // using minimatch versus RegExp provides better (more expected) matching results
+              .filter((cs) => minimatch(cs.fullName, splitEntry[1]))
               .map((match) => {
                 compSetFilter.add(match);
                 componentSet?.add(match);
@@ -179,7 +181,8 @@ export class ComponentSetBuilder {
           componentFilter = (component: Partial<FileProperties>): boolean => {
             if (component.type && component.fullName) {
               const mdMapEntry = mdMap.get(component.type);
-              return !!mdMapEntry && mdMapEntry.some((mdName) => new RegExp(mdName).test(component.fullName as string));
+              // using minimatch versus RegExp provides better (more expected) matching results
+              return !!mdMapEntry && mdMapEntry.some((mdName) => minimatch(component.fullName as string, mdName));
             }
             return false;
           };

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -88,4 +88,8 @@ export interface FromConnectionOptions extends OptionalTreeRegistryOptions {
    * filter the result components to e.g. remove managed components
    */
   componentFilter?: (component: Partial<FileProperties>) => boolean;
+  /**
+   * array of metadata type names to use for `connection.metadata.list()`
+   */
+  metadataTypes?: string[];
 }

--- a/src/resolve/connectionResolver.ts
+++ b/src/resolve/connectionResolver.ts
@@ -39,12 +39,10 @@ export class ConnectionResolver {
     this.connection = connection;
     this.registry = registry;
     this.logger = Logger.childFromRoot(this.constructor.name);
-    if (mdTypes?.length) {
-      // ensure the types passed in are valid per the registry
-      this.mdTypeNames = mdTypes.filter((t) => this.registry.getTypeByName(t));
-    } else {
-      this.mdTypeNames = Object.values(defaultRegistry.types).map((t) => t.name);
-    }
+    this.mdTypeNames = mdTypes?.length
+      ? // ensure the types passed in are valid per the registry
+        mdTypes.filter((t) => this.registry.getTypeByName(t))
+      : Object.values(defaultRegistry.types).map((t) => t.name);
   }
 
   public async resolve(
@@ -54,9 +52,8 @@ export class ConnectionResolver {
     const childrenPromises: Array<Promise<FileProperties[]>> = [];
     const componentTypes: Set<MetadataType> = new Set();
     const lifecycle = Lifecycle.getInstance();
-    const componentPromises: Array<Promise<FileProperties[]>> = [];
 
-    this.mdTypeNames.forEach((type) => componentPromises.push(this.listMembers({ type })));
+    const componentPromises = this.mdTypeNames.map((type) => this.listMembers({ type }));
 
     (await Promise.all(componentPromises)).map(async (componentResult) => {
       for (const component of componentResult) {

--- a/test/collections/componentSetBuilder.test.ts
+++ b/test/collections/componentSetBuilder.test.ts
@@ -397,6 +397,36 @@ describe('ComponentSetBuilder', () => {
       expect(compSet.has(apexClassComponent)).to.equal(true);
     });
 
+    it('should create ComponentSet from org connection and metadata', async () => {
+      const mdCompSet = new ComponentSet();
+      mdCompSet.add(apexClassComponent);
+
+      fromSourceStub.returns(mdCompSet);
+      const packageDir1 = path.resolve('force-app');
+
+      componentSet.add(apexClassWildcardMatch);
+      fromConnectionStub.resolves(componentSet);
+      const options = {
+        sourcepath: undefined,
+        metadata: {
+          metadataEntries: ['ApexClass:MyClas*'],
+          directoryPaths: [packageDir1],
+        },
+        manifest: undefined,
+        org: {
+          username: 'manifest-test@org.com',
+          exclude: [],
+        },
+      };
+
+      const compSet = await ComponentSetBuilder.build(options);
+      expect(fromSourceStub.calledTwice).to.equal(true);
+      expect(fromConnectionStub.calledOnce).to.equal(true);
+      expect(compSet.size).to.equal(2);
+      expect(compSet.has(apexClassComponent)).to.equal(true);
+      expect(compSet.has(apexClassWildcardMatch)).to.equal(true);
+    });
+
     it('should create ComponentSet from manifest and multiple package', async () => {
       fileExistsSyncStub.returns(true);
 

--- a/test/resolve/connectionResolver.test.ts
+++ b/test/resolve/connectionResolver.test.ts
@@ -127,6 +127,39 @@ describe('ConnectionResolver', () => {
       ];
       expect(result.components).to.deep.equal(expected);
     });
+    it('should resolve components with specified types', async () => {
+      const metadataQueryStub = $$.SANDBOX.stub(connection.metadata, 'list');
+
+      metadataQueryStub.withArgs({ type: 'ApexClass' }).resolves([
+        {
+          ...StdFileProperty,
+          fileName: 'classes/MyApexClass1.class',
+          fullName: 'MyApexClass1',
+          type: 'ApexClass',
+        },
+        {
+          ...StdFileProperty,
+          fileName: 'classes/MyApexClass2.class',
+          fullName: 'MyApexClass2',
+          type: 'ApexClass',
+        },
+      ]);
+
+      const resolver = new ConnectionResolver(connection, undefined, ['ApexClass']);
+      const result = await resolver.resolve();
+      const expected: MetadataComponent[] = [
+        {
+          fullName: 'MyApexClass1',
+          type: registry.types.apexclass,
+        },
+        {
+          fullName: 'MyApexClass2',
+          type: registry.types.apexclass,
+        },
+      ];
+      expect(result.components).to.deep.equal(expected);
+      expect(metadataQueryStub.calledOnce).to.be.true;
+    });
     it('should resolve components with invalid type returned by metadata api', async () => {
       const metadataQueryStub = $$.SANDBOX.stub(connection.metadata, 'list');
       metadataQueryStub.withArgs({ type: 'CustomLabels' }).resolves([


### PR DESCRIPTION
### What does this PR do?
Enhances `ComponentSetBuilder.build()` to use both metadata and an org connection when defined in the options.  This allows metadata fullName retrieval from an org based on a pattern where the files are not in the local project.

### What issues does this PR fix or reference?
@W-14284096@
https://github.com/forcedotcom/cli/issues/2522

QA suggestions:
Use dreamhouse-lwc repo deployed to a scratch org.
1. deploy should work exactly as before the changes were made.  Deploy `"ApexClass:Test*"`, `"ApexClass:T*"`, `"ApexClass:Test*,ApexClass:Geo*"`, `"ApexClass:Test*,CustomObject:Prop*"`
2. retrieve with all requested files in the project.  Retrieve `"ApexClass:Test*"`, `"ApexClass:T*"`, `"ApexClass:Test*,ApexClass:Geo*"`, `"ApexClass:Test*,CustomObject:Prop*"`
3. retrieve with none of the requested files in the project.  Retrieve `"ApexClass:Test*"`, `"ApexClass:T*"`, `"ApexClass:Test*,ApexClass:Geo*"`, `"ApexClass:Test*,CustomObject:Prop*"`
4. You can even remove one of the `Test*` apex classes locally and keep the other one, then retrieve `"ApexClass:Test*"`.  It should retrieve all of them.