### PR TITLE
fix: change mdcoverage url for getCurrentApiVersion

### DIFF
--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -119,12 +119,7 @@ The %s operation is missing a job ID. Initialize an operation with an ID, or sta
 
 # missingApiVersion
 
-Could not determine an API version to use for the set of metadata components.
-
-# missingApiVersion.actions
-
-Set a `sourceApiVersion` or `apiVersion` on the ComponentSet.
-Set an API version to use with the environment variable, `SF_ORG_API_VERSION`.
+Could not determine an API version to use for the generated manifest. Tried looking for sourceApiVersion in sfdx-project.json, apiVersion from config vars, and the highest apiVersion from the APEX REST endpoint. Using API version 58.0 as a last resort.
 
 # invalid_xml_parsing
 

--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -117,6 +117,15 @@ A StaticResource must have an associated .resource file, missing %s.resource-met
 
 The %s operation is missing a job ID. Initialize an operation with an ID, or start a new job.
 
+# missingApiVersion
+
+Could not determine an API version to use for the set of metadata components.
+
+# missingApiVersion.actions
+
+Set a `sourceApiVersion` or `apiVersion` on the ComponentSet.
+Set an API version to use with the environment variable, `SF_ORG_API_VERSION`.
+
 # invalid_xml_parsing
 
 error parsing %s due to:\n message: %s\n line: %s\n code: %s

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -369,7 +369,17 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    * @returns Object representation of a package manifest
    */
   public async getObject(destructiveType?: DestructiveChangesType): Promise<PackageManifestObject> {
-    const version = this.sourceApiVersion ?? this.apiVersion ?? `${await getCurrentApiVersion()}.0`;
+    let version: string;
+    try {
+      version =
+        this.sourceApiVersion ??
+        this.apiVersion ??
+        process.env.SF_ORG_API_VERSION ??
+        `${await getCurrentApiVersion()}.0`;
+    } catch (err: unknown) {
+      const cause = err instanceof Error ? err : isString(err) ? Error(err) : undefined;
+      throw messages.createError('missingApiVersion', undefined, undefined, 1, cause);
+    }
 
     // If this ComponentSet has components marked for delete, we need to
     // only include those components in a destructiveChanges.xml and

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -6,7 +6,16 @@
  */
 /* eslint  @typescript-eslint/unified-signatures:0 */
 import { XMLBuilder } from 'fast-xml-parser';
-import { AuthInfo, Connection, Logger, Messages, SfError } from '@salesforce/core';
+import {
+  AuthInfo,
+  ConfigAggregator,
+  Connection,
+  Logger,
+  Messages,
+  OrgConfigProperties,
+  SfError,
+  SfProject,
+} from '@salesforce/core';
 import { isString } from '@salesforce/ts-types';
 import {
   MetadataApiDeploy,
@@ -369,17 +378,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    * @returns Object representation of a package manifest
    */
   public async getObject(destructiveType?: DestructiveChangesType): Promise<PackageManifestObject> {
-    let version: string;
-    try {
-      version =
-        this.sourceApiVersion ??
-        this.apiVersion ??
-        process.env.SF_ORG_API_VERSION ??
-        `${await getCurrentApiVersion()}.0`;
-    } catch (err: unknown) {
-      const cause = err instanceof Error ? err : isString(err) ? Error(err) : undefined;
-      throw messages.createError('missingApiVersion', undefined, undefined, 1, cause);
-    }
+    const version = await this.getApiVersion();
 
     // If this ComponentSet has components marked for delete, we need to
     // only include those components in a destructiveChanges.xml and
@@ -671,6 +670,52 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       destructiveChangesTypes.push(DestructiveChangesType.POST);
     }
     return destructiveChangesTypes;
+  }
+
+  /**
+   * Returns an API version to use as the value of the `version` field
+   * in a manifest (package.xml) for MDAPI calls in the following order
+   * of preference:
+   *
+   * 1. this.sourceApiVersion
+   * 2. this.apiVersion
+   * 3. sourceApiVersion set in sfdx-project.json
+   * 4. apiVersion from ConfigAggregator (config files and Env Vars)
+   * 5. http call to apexrest endpoint for highest apiVersion
+   * 6. hardcoded value of "58.0" as a last resort
+   *
+   * @returns string The resolved API version to use in a manifest
+   */
+  private async getApiVersion(): Promise<string> {
+    let version = this.sourceApiVersion ?? this.apiVersion;
+
+    if (!version) {
+      try {
+        const project = await SfProject.resolve();
+        const projectConfig = await project.resolveProjectConfig();
+        version = projectConfig?.sourceApiVersion as string;
+      } catch (e) {
+        // If there's any problem just move on to ConfigAggregator
+      }
+    }
+
+    if (!version) {
+      try {
+        version = ConfigAggregator.getValue(OrgConfigProperties.ORG_API_VERSION).value as string;
+      } catch (e) {
+        // If there's any problem just move on to the REST endpoint
+      }
+    }
+
+    if (!version) {
+      try {
+        version = `${await getCurrentApiVersion()}.0`;
+      } catch (e) {
+        version = '58.0';
+        this.logger.warn(messages.getMessage('missingApiVersion'));
+      }
+    }
+    return version;
   }
 }
 

--- a/src/registry/coverage.ts
+++ b/src/registry/coverage.ts
@@ -23,7 +23,7 @@ const getProxiedOptions = (url: string): OptionsOfTextResponseBody => ({
 
 export const getCurrentApiVersion = async (): Promise<number> =>
   (
-    await got(getProxiedOptions('https://mdcoverage.secure.force.com/services/apexrest/report')).json<{
+    await got(getProxiedOptions('https://dx-extended-coverage.my.salesforce-sites.com/services/apexrest/report')).json<{
       versions: { selected: number };
     }>()
   ).versions.selected;

--- a/src/registry/coverage.ts
+++ b/src/registry/coverage.ts
@@ -21,12 +21,17 @@ const getProxiedOptions = (url: string): OptionsOfTextResponseBody => ({
   url,
 });
 
-export const getCurrentApiVersion = async (): Promise<number> =>
-  (
-    await got(getProxiedOptions('https://dx-extended-coverage.my.salesforce-sites.com/services/apexrest/report')).json<{
-      versions: { selected: number };
-    }>()
-  ).versions.selected;
+type ApiVersion = {
+  label: string;
+  url: string;
+  version: string;
+};
+
+export const getCurrentApiVersion = async (): Promise<number> => {
+  const apiVersionsUrl = 'https://dx-extended-coverage.my.salesforce-sites.com/services/data';
+  const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).pop() as ApiVersion;
+  return +lastVersionEntry.version;
+};
 
 export const getCoverage = async (apiVersion: number): Promise<CoverageObject> => {
   const results = await Promise.allSettled(


### PR DESCRIPTION
### What does this PR do?
Changes the URL to get an API version from https://mdcoverage.secure.force.com/services/apexrest/report to https://dx-extended-coverage.my.salesforce-sites.com/services/data
If neither `sourceApiVersion` nor `apiVersion` were set on a `ComponentSet` before calling `getObject()`, will then look for and use (in order):
1. sourceApiVersion set in sfdx-project.json
2. apiVersion from ConfigAggregator (config files and Env Vars)
3. http call to /services/data endpoint for highest apiVersion
4. hardcoded value of "58.0" as a last resort

### What issues does this PR fix or reference?
@W-14621701@