### PR TITLE
fix: Qa/1202 - add support for ExtDataTranObjectTemplate and ExtDataTranFieldTemplate

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -595,8 +595,8 @@ v60 introduces the following new types.  Here's their current level of support
 |CommonEventSubscription|❌|Not supported, but support could be added|
 |EinsteinAISettings|✅||
 |EventLogObjectSettings|✅||
-|ExtDataTranFieldTemplate|❌|Not supported, but support could be added|
-|ExtDataTranObjectTemplate|❌|Not supported, but support could be added|
+|ExtDataTranFieldTemplate|✅||
+|ExtDataTranObjectTemplate|✅||
 |ExtlClntAppConfigurablePolicies|✅||
 |ExtlClntAppNotificationSettings|✅||
 |GenAiPlanner|❌|Not supported, but support could be added|

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3684,6 +3684,29 @@
       "directoryName": "managedEventSubscriptions",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "extdatatranobjecttemplate": {
+      "id": "extdatatranobjecttemplate",
+      "name": "ExtDataTranObjectTemplate",
+      "suffix": "extDataTranObjectTemplate",
+      "directoryName": "extDataTranObjectTemplates",
+      "strictDirectoryName": false,
+      "children": {
+        "types": {
+          "extdatatranfieldtemplate": {
+            "id": "extdatatranfieldtemplate",
+            "name": "extDataTranFieldTemplate",
+            "directoryName": "extDataTranFieldTemplates",
+            "suffix": "extDataTranFieldTemplate"
+          }
+        },
+        "suffixes": {
+          "extDataTranFieldTemplate": "extdatatranfieldtemplate"
+        },
+        "directories": {
+          "extDataTranFieldTemplates": "extdatatranfieldtemplate"
+        }
+      }
     }
   },
   "suffixes": {
@@ -4090,7 +4113,8 @@
     "webStoreBundle": "webstorebundle",
     "externalAIModel": "externalaimodel",
     "registeredExternalService": "registeredexternalservice",
-    "managedEventSubscription": "managedeventsubscription"
+    "managedEventSubscription": "managedeventsubscription",
+    "extDataTranObjectTemplate": "extdatatranobjecttemplate"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",
@@ -4154,6 +4178,7 @@
     "digitalexperience": "digitalexperiencebundle",
     "decisionmatrixdefinitionversion": "decisionmatrixdefinition",
     "expressionsetdefinitionversion": "expressionsetdefinition",
-    "aiscoringmodeldefversion": "aiscoringmodeldefinition"
+    "aiscoringmodeldefversion": "aiscoringmodeldefinition",
+    "extdatatranfieldtemplate": "extdatatranobjecttemplate"
   }
 }

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3718,6 +3718,7 @@
     "aiUsecaseDefinitions": "aiusecasedefinition",
     "aiScoringModelDefinition": "aiscoringmodeldefinition",
     "aiScoringModelDefVersion": "aiscoringmodeldefversion",
+    "extDataTranFieldTemplate": "extdatatranfieldtemplate",
     "mlDataDefinition": "mldatadefinition",
     "icon": "icon",
     "businessProcessGroup": "businessprocessgroup",


### PR DESCRIPTION
What does this PR do?
Adds new MetadataTypes 'ExtDataTranObjectTemplate' and 'ExtDataTranFieldTemplate' to the registry.

What issues does this PR fix or reference?
@W-14674743@

Functionality Before
force:mdapi:deploy didn't work for 'ExtDataTranObjectTemplate' and 'ExtDataTranFieldTemplate' meta data types

Functionality After
force:mdapi:deploy works for 'ExtDataTranObjectTemplate' and 'ExtDataTranFieldTemplate' meta data types

