### PR TITLE
fix: add ExtlClntAppNotificationSettings to registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1481,6 +1481,14 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
+    "extlclntappnotificationsettings": {
+      "id": "extlclntappnotificationsettings",
+      "name": "ExtlClntAppNotificationSettings",
+      "suffix": "ecaNotifications",
+      "directoryName": "extlClntAppNotifSettings",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
     "appmenu": {
       "id": "appmenu",
       "name": "AppMenu",
@@ -3870,6 +3878,7 @@
     "ecaGlblOauth": "extlclntappglobaloauthsettings",
     "ecaMobilePlcy": "extlclntappmobileconfigurablepolicies",
     "ecaMobile": "extlclntappmobilesettings",
+    "ecaNotifications": "extlclntappnotificationsettings",
     "appMenu": "appmenu",
     "delegateGroup": "delegategroup",
     "network": "network",


### PR DESCRIPTION
### What does this PR do?

Adds ExtlClntAppNotificationSettings type to the registry.

### What issues does this PR fix or reference?

[@W-14035929@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ZcRR3YAN/view)

### Functionality Before

N/A

### Functionality After

ExtlClntAppNotificationSettings metadata type is exposed in registry.