### PR TITLE
fix: use appexchange org for last resort api version

### DIFF
--- a/src/registry/coverage.ts
+++ b/src/registry/coverage.ts
@@ -9,6 +9,8 @@
 import { OptionsOfTextResponseBody } from 'got';
 import got from 'got';
 import { ProxyAgent } from 'proxy-agent';
+import { isString } from '@salesforce/ts-types';
+import { SfError } from '@salesforce/core';
 import { CoverageObject } from '../../src/registry/types';
 
 const getProxiedOptions = (url: string): OptionsOfTextResponseBody => ({
@@ -31,9 +33,16 @@ let apiVer: number;
 
 export const getCurrentApiVersion = async (): Promise<number> => {
   if (apiVer === undefined) {
-    const apiVersionsUrl = 'https://appexchange.salesforce.com/services/data';
-    const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).pop() as ApiVersion;
-    apiVer = +lastVersionEntry.version;
+    try {
+      const apiVersionsUrl = 'https://appexchange.salesforce.com/services/data';
+      const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).at(-1) as ApiVersion;
+      apiVer = +lastVersionEntry.version;
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : SfError.wrap(isString(e) ? e : 'unknown');
+      const eMsg = 'Unable to get a current API version from the appexchange org';
+      const eActions = ['Provide an API version explicitly', 'Set an API version in the project configuration'];
+      throw new SfError(eMsg, 'ApiVersionRetrievalError', eActions, err);
+    }
   }
   return apiVer;
 };

--- a/src/registry/coverage.ts
+++ b/src/registry/coverage.ts
@@ -27,10 +27,15 @@ type ApiVersion = {
   version: string;
 };
 
+let apiVer: number;
+
 export const getCurrentApiVersion = async (): Promise<number> => {
-  const apiVersionsUrl = 'https://dx-extended-coverage.my.salesforce-sites.com/services/data';
-  const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).pop() as ApiVersion;
-  return +lastVersionEntry.version;
+  if (apiVer === undefined) {
+    const apiVersionsUrl = 'https://org62.my.salesforce-sites.com/services/data';
+    const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).pop() as ApiVersion;
+    apiVer = +lastVersionEntry.version;
+  }
+  return apiVer;
 };
 
 export const getCoverage = async (apiVersion: number): Promise<CoverageObject> => {

--- a/src/registry/coverage.ts
+++ b/src/registry/coverage.ts
@@ -31,7 +31,7 @@ let apiVer: number;
 
 export const getCurrentApiVersion = async (): Promise<number> => {
   if (apiVer === undefined) {
-    const apiVersionsUrl = 'https://org62.my.salesforce-sites.com/services/data';
+    const apiVersionsUrl = 'https://appexchange.salesforce.com/services/data';
     const lastVersionEntry = (await got(getProxiedOptions(apiVersionsUrl)).json<ApiVersion[]>()).pop() as ApiVersion;
     apiVer = +lastVersionEntry.version;
   }


### PR DESCRIPTION
### What does this PR do?
When an API version is needed yet not provided in other ways to the SDR APIs, make a call to the appexchange org to get the most recent API version.  Also, save the result so that all other calls to `getCurrentApiVersion()` on the same process use that value rather than making another call to that endpoint.

### What issues does this PR fix or reference?
@W-14848514@
