### PR TITLE
fix: metadataRegistry entries for IdentityVerificationProcDev were incorrect

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3319,7 +3319,7 @@
     "identityverificationprocdef": {
       "id": "identityverificationprocdef",
       "name": "IdentityVerificationProcDef",
-      "suffix": "identityverificationprocdef",
+      "suffix": "IdentityVerificationProcDef",
       "directoryName": "IdentityVerificationProcDefs",
       "inFolder": false,
       "strictDirectoryName": false
@@ -4106,7 +4106,7 @@
     "dwl": "dataweaveresource",
     "aq": "assessmentquestion",
     "aqs": "assessmentquestionset",
-    "identityverificationprocdef": "identityverificationprocdef",
+    "IdentityVerificationProcDef": "identityverificationprocdef",
     "digitalExperience": "digitalexperiencebundle",
     "digitalExperienceConfig": "digitalexperienceconfig",
     "forecastingFilter": "forecastingfilter",


### PR DESCRIPTION
Fixed metadataRegistry entries for IdentityVerificationProcDev.  The casing was wrong.

I tested this with an org that had a few of this type and was able to retrieve them with this change.

[skip-validate-pr]