### PR TITLE
fix: override forceignore defaults

### DIFF
--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -26,17 +26,16 @@ export class ForceIgnore {
       if (contents !== undefined) {
         // check for windows style separators (\) and warn
         if (contents.includes('\\')) {
-          const lifecycle = Lifecycle.getInstance();
-          // cannot await a method in a constructor
-          void lifecycle.emitWarning(
-            'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. We currently accept both separators, but we plan to stop supporting the backslash soon.'
+          // void because you cannot await a method in a constructor
+          void Lifecycle.getInstance().emitWarning(
+            'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. The ignore rules will not work as expected until you fix this.'
           );
           // TODO: change this in v56 to only emit warning but NOT fix file
           contents = contents.replace(/\\/g, '/');
         }
 
         // add the default ignore paths, and then parse the .forceignore file
-        this.parser = ignore().add(`${contents}\n${this.DEFAULT_IGNORE.join('\n')}`);
+        this.parser = ignore().add(`${this.DEFAULT_IGNORE.join('\n')}\n${contents ?? ''}`);
         this.forceIgnoreDirectory = dirname(forceIgnorePath);
       }
     } catch (e) {

--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -31,9 +31,9 @@ export class ForceIgnore {
             'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. The ignore rules will not work as expected until you fix this.'
           );
         }
-
         // add the default ignore paths, and then parse the .forceignore file
-        this.parser = ignore().add(`${this.DEFAULT_IGNORE.join('\n')}\n${contents ?? ''}`);
+        this.parser = ignore().add(`${this.DEFAULT_IGNORE.join('\n')}\n${contents}`);
+
         this.forceIgnoreDirectory = dirname(forceIgnorePath);
       }
     } catch (e) {

--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -21,7 +21,7 @@ export class ForceIgnore {
 
   public constructor(forceIgnorePath = '') {
     try {
-      let contents = readFileSync(forceIgnorePath, 'utf-8');
+      const contents = readFileSync(forceIgnorePath, 'utf-8');
       // check if file `.forceignore` exists
       if (contents !== undefined) {
         // check for windows style separators (\) and warn
@@ -30,8 +30,6 @@ export class ForceIgnore {
           void Lifecycle.getInstance().emitWarning(
             'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. The ignore rules will not work as expected until you fix this.'
           );
-          // TODO: change this in v56 to only emit warning but NOT fix file
-          contents = contents.replace(/\\/g, '/');
         }
 
         // add the default ignore paths, and then parse the .forceignore file

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -26,8 +26,6 @@ describe('ForceIgnore', () => {
     const forceIgnore = new ForceIgnore();
     expect(forceIgnore.accepts(path)).to.be.true;
     expect(forceIgnore.denies(path)).to.be.false;
-    expect(forceIgnore.accepts(path)).to.be.true;
-    expect(forceIgnore.accepts('.foo')).to.be.true;
   });
 
   it('Should ignore files with a given pattern', () => {
@@ -35,7 +33,6 @@ describe('ForceIgnore', () => {
     const forceIgnore = new ForceIgnore(forceIgnorePath);
     expect(forceIgnore.accepts(testPath)).to.be.false;
     expect(forceIgnore.denies(testPath)).to.be.true;
-    expect(forceIgnore.denies(join('some', '.foo'))).to.be.true;
   });
 
   it('windows separators no longer have any effect', () => {
@@ -65,22 +62,6 @@ describe('ForceIgnore', () => {
     const fi = new ForceIgnore(forceIgnorePath);
     // @ts-ignore private field
     expect(fi.parser, 'if constructor throws, parser is not defined').to.not.equal(undefined);
-  });
-
-  it('ignores files starting with dots because of defaults', () => {
-    const readStub = env.stub(fs, 'readFileSync');
-    // files starting with dots are in the DEFAULT_IGNORE
-    readStub.withArgs(forceIgnorePath).returns('force-app/main/default/classes/');
-    const fi = new ForceIgnore(forceIgnorePath);
-    expect(fi.denies(join('some', '.dotfile'))).to.equal(true);
-  });
-
-  it('Should allow user to override default ignore patterns', () => {
-    const readStub = env.stub(fs, 'readFileSync');
-    // files starting with dots are in the DEFAULT_IGNORE
-    readStub.withArgs(forceIgnorePath).returns('!**/.*');
-    const fi = new ForceIgnore(forceIgnorePath);
-    expect(fi.accepts(join('some', '.dotfile'))).to.equal(true);
   });
 
   it('Should have the correct default in the case the parsers are not initialized', () => {
@@ -127,6 +108,17 @@ describe('ForceIgnore', () => {
       const manifestPath = join(root, 'package2-manifest.json');
       expect(forceIgnore.accepts(manifestPath)).to.be.false;
       expect(forceIgnore.denies(manifestPath)).to.be.true;
+    });
+
+    it('Should allow .forceignore file to override defaults', () => {
+      // tamper with the file
+      env.restore();
+      env.stub(fs, 'readFileSync').returns('!**/.*');
+      forceIgnore = new ForceIgnore();
+
+      const dotFilePath = join(root, '.foo');
+      expect(forceIgnore.accepts(dotFilePath)).to.be.true;
+      expect(forceIgnore.denies(dotFilePath)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

SDR's was loading its defaults AFTER the user's `.forceignore` contents.  This change switches the order so that users can override the defaults (in this case, NOT ignoring `**/.*`) 

### What issues does this PR fix or reference?
@W-14892481@
https://github.com/forcedotcom/cli/issues/2666

## QA

by default, files starting with dots are ignored because of `DEFAULT_IGNORE`. 

With this change, you can add `!**/.*` to your `.forceignore` and it'll override the defaults.