### PR TITLE
@W-14902095 feat: adding gen ai prompt template support

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3736,6 +3736,22 @@
           "extDataTranFieldTemplates": "extdatatranfieldtemplate"
         }
       }
+    },
+    "genaiprompttemplate": {
+      "id": "genaiprompttemplate",
+      "name": "GenAiPromptTemplate",
+      "suffix": "genAiPromptTemplate",
+      "directoryName": "genAiPromptTemplates",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "genaiprompttemplateactv": {
+      "id": "genaiprompttemplateactv",
+      "name": "GenAiPromptTemplateActv",
+      "suffix": "genAiPromptTemplateActivation",
+      "directoryName": "genAiPromptTemplateActivations",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -4148,7 +4164,9 @@
     "externalAIModel": "externalaimodel",
     "registeredExternalService": "registeredexternalservice",
     "managedEventSubscription": "managedeventsubscription",
-    "extDataTranObjectTemplate": "extdatatranobjecttemplate"
+    "extDataTranObjectTemplate": "extdatatranobjecttemplate",
+    "genAiPromptTemplate": "genaiprompttemplate",
+    "genAiPromptTemplateActivation": "genaiprompttemplateactv"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
Adding support for GenAiPromptTemplates
adding these metadata types:
genaiprompttemplate and genaiprompttemplateactv

#<https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ivtJDYAY/view>, @W-14902095@
