### PR TITLE
@W-14972256@ Expose EnablementMeasureDefinition to CLI

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3752,6 +3752,14 @@
       "directoryName": "genAiPromptTemplateActivations",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "enablementmeasuredefinition": {
+      "id": "enablementmeasuredefinition",
+      "name": "Enablementmeasuredefinition",
+      "suffix": "enablementMeasureDefinition",
+      "directoryName": "enablementMeasureDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   },
   "suffixes": {
@@ -4166,7 +4174,8 @@
     "managedEventSubscription": "managedeventsubscription",
     "extDataTranObjectTemplate": "extdatatranobjecttemplate",
     "genAiPromptTemplate": "genaiprompttemplate",
-    "genAiPromptTemplateActivation": "genaiprompttemplateactv"
+    "genAiPromptTemplateActivation": "genaiprompttemplateactv",
+    "enablementMeasureDefinition": "enablementmeasuredefinition"
   },
   "strictDirectoryNames": {
     "experiences": "experiencebundle",


### PR DESCRIPTION
### What does this PR do?
Expose new EnablementMeasureDefinition Metadata type to CLI / 2GP Packaging / Unlocked Packaging

### What issues does this PR fix or reference?
@W-14972256@
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001jVpAZYA0/view

### Functionality Before

EnablementMeasureDefinition not usable in CLI or 2nd gen packaging

### Functionality After

EnablementMeasureDefinition usable in CLI and 2nd gen packaging
