### PR TITLE
fix: recompose decomposed xml using xmlElementName where it exists

### DIFF
--- a/src/convert/convertContext.ts
+++ b/src/convert/convertContext.ts
@@ -93,7 +93,7 @@ class RecompositionFinalizer extends ConvertTransactionFinalizer<RecompositionSt
       if (!child.parent) {
         throw messages.createError('noParent', [child.fullName, child.type.name]);
       }
-      const { directoryName: groupName } = child.type;
+      const groupName = child.type.xmlElementName ?? child.type.directoryName;
       const { name: parentName } = child.parent.type;
       const childSourceComponent = child as SourceComponent;
 


### PR DESCRIPTION
### What does this PR do?

### before:
recomposition of decomposed objects uses the directory name as the xml element.

This was fine for CustomObject.field because `/fields` is the child directoryName AND happens to be XML element `<fields>`

### after:
Use the registry's xmlElementName if provided, default to the directoryName otherwise.

### What issues does this PR fix or reference?

needed to make these work, though there are bigger mdapi issues there.
 
@W-14335636@
@W-13478725@