### PR TITLE
@W-14972256@ Fix incorrect case for EnablementMeasureDefinition metadata type name

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -3755,7 +3755,7 @@
     },
     "enablementmeasuredefinition": {
       "id": "enablementmeasuredefinition",
-      "name": "Enablementmeasuredefinition",
+      "name": "EnablementMeasureDefinition",
       "suffix": "enablementMeasureDefinition",
       "directoryName": "enablementMeasureDefinitions",
       "inFolder": false,


### PR DESCRIPTION
### What does this PR do?
Fixed the incorrect case for the new EnablementMeasureDefinition metadata type name.

### What issues does this PR fix or reference?

@W-14972256@

### Functionality Before

`Entity type: 'Enablementmeasuredefinition' is unknown` when using `sf project retrieve start`

### Functionality After

Entity is retrieved correctly