### PR TITLE
 @W-14771527: Changes to support EnablementProgramDefiniton

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -234,6 +234,7 @@
     "email": "emailtemplate",
     "emailFolder": "emailfolder",
     "enablementMeasureDefinition": "enablementmeasuredefinition",
+    "enablementProgramDefinition": "enablementprogramdefinition",
     "entitlementProcess": "entitlementprocess",
     "entitlementTemplate": "entitlementtemplate",
     "entityImplements": "entityimplements",
@@ -2034,6 +2035,14 @@
       "name": "EnablementMeasureDefinition",
       "strictDirectoryName": false,
       "suffix": "enablementMeasureDefinition"
+    },
+    "enablementprogramdefinition": {
+      "directoryName": "enablementPrograms",
+      "id": "enablementprogramdefinition",
+      "inFolder": false,
+      "name": "EnablementProgramDefinition",
+      "strictDirectoryName": false,
+      "suffix": "enablementProgram"
     },
     "entitlementprocess": {
       "directoryName": "entitlementProcesses",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -2037,12 +2037,12 @@
       "suffix": "enablementMeasureDefinition"
     },
     "enablementprogramdefinition": {
-      "directoryName": "enablementPrograms",
+      "directoryName": "enablementProgramDefinitions",
       "id": "enablementprogramdefinition",
       "inFolder": false,
       "name": "EnablementProgramDefinition",
       "strictDirectoryName": false,
-      "suffix": "enablementProgram"
+      "suffix": "enablementProgramDefinition"
     },
     "entitlementprocess": {
       "directoryName": "entitlementProcesses",


### PR DESCRIPTION
We have created a new setup entity EnablementProgramDefinition and exposed it to mdApi.

### What does this PR do?
Supports EnablementProgramDefinition entity in retrieve/deploy

### What issues does this PR fix or reference?
The specified metadata type is unsupported: [enablementprogramdefinition]

@W-14771527@

### Functionality Before
When we tried to retrieve this entity using sfdx commands getting the following error The specified metadata type is unsupported: [enablementprogramdefinition]

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
