### PR TITLE
Add Data Cloud More Connectors support for DataKit

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -21,6 +21,9 @@
     "managedtopic": "managedtopics",
     "matchingrule": "matchingrules",
     "mktdatatranfield": "mktdatatranobject",
+    "dataconnectionparamtmpl": "datastreamtemplate",
+    "mktdataconnectioncred": "mktdataconnection",
+    "mktdataconnectionparam": "mktdataconnection",
     "recordtype": "customobject",
     "sharingcriteriarule": "sharingrules",
     "sharingguestrule": "sharingrules",
@@ -187,6 +190,7 @@
     "dashboardFolder": "dashboardfolder",
     "dataCalcInsightTemplate": "datacalcinsighttemplate",
     "dataConnectorIngestApi": "dataconnectoringestapi",
+    "dataConnectionParamTmpl": "dataconnectionparamtmpl",
     "dataKitObjectTemplate": "datakitobjecttemplate",
     "dataPackageKitDefinition": "datapackagekitdefinition",
     "dataPipeline": "datapipeline",
@@ -330,6 +334,10 @@
     "mktCalcInsightObjectDef": "mktcalcinsightobjectdef",
     "mktDataTranField": "mktdatatranfield",
     "mktDataTranObject": "mktdatatranobject",
+    "mktDataConnection": "mktdataconnection",
+    "mktDataConnectionCred": "mktdataconnectioncred",
+    "mktDataConnectionParam": "mktdataconnectionparam",
+    "mktDataConnectionSrcParam": "mktdataconnectionsrcparam",
     "mlDataDefinition": "mldatadefinition",
     "mlDomain": "mldomain",
     "mlPrediction": "mlpredictiondefinition",
@@ -1713,6 +1721,22 @@
       "suffix": "dataStreamDefinition"
     },
     "datastreamtemplate": {
+      "children": {
+        "directories": {
+          "dataConnectionSourceParameters": "dataconnectionparamtmpl"
+        },
+        "suffixes": {
+          "dataConnectionParamTmpl": "dataconnectionparamtmpl"
+        },
+        "types": {
+          "dataconnectionparamtmpl": {
+            "directoryName": "dataConnectionSourceParameters",
+            "id": "dataconnectionparamtmpl",
+            "name": "DataConnectionParamTmpl",
+            "suffix": "dataConnectionParamTmpl"
+          }
+        }
+      },
       "directoryName": "dataStreamTemplates",
       "id": "datastreamtemplate",
       "name": "DataStreamTemplate",
@@ -2993,6 +3017,45 @@
       "name": "MktDataTranObject",
       "strictDirectoryName": false,
       "suffix": "mktDataTranObject"
+    },
+    "mktdataconnection": {
+      "children": {
+        "directories": {
+          "parameters": "mktdataconnectionparam",
+          "credentials": "mktdataconnectioncred"
+        },
+        "suffixes": {
+          "MktDataConnectionParam": "mktdataconnectionparam",
+          "MktDataConnectionCred": "mktdataconnectioncred"
+        },
+        "types": {
+          "mktdataconnectionparam": {
+            "directoryName": "parameters",
+            "id": "mktdataconnectionparam",
+            "name": "MktDataConnectionParam",
+            "suffix": "mktDataConnectionParam"
+          },
+          "mktdataconnectioncred": {
+            "directoryName": "credentials",
+            "id": "mktdataconnectioncred",
+            "name": "MktDataConnectionCred",
+            "suffix": "mktDataConnectionCred"
+          }
+        }
+      },
+      "directoryName": "MktDataConnections",
+      "id": "mktdataconnection",
+      "name": "MktDataConnection",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnection"
+    },
+    "mktdataconnectionsrcparam": {
+      "directoryName": "mktDataConnectionSrcParams",
+      "id": "mktdataconnectionsrcparam",
+      "inFolder": false,
+      "name": "MktDataConnectionSrcParam",
+      "strictDirectoryName": false,
+      "suffix": "mktDataConnectionSrcParam"
     },
     "mldatadefinition": {
       "directoryName": "mlDataDefinitions",


### PR DESCRIPTION
### What does this PR do?
Added MktDataConnection and it's Params, Creds and SrcParams as a packaged type.
Added DataConnectionParamTmpl part of DataStreamTemplate as a packaged type.

### What issues does this PR fix or reference?

@W-15035985 [DataKit] support 2GP for DataKit for DataStream on DCF
