### PR TITLE
fix: handle string replacements for individual custom labels

### DIFF
--- a/src/convert/replacements.ts
+++ b/src/convert/replacements.ts
@@ -117,6 +117,12 @@ class ReplacementMarkingStream extends Transform {
     if (!chunk.isMarkedForDelete() && this.replacementConfigs?.length) {
       try {
         chunk.replacements = await getReplacements(chunk, this.replacementConfigs);
+        if (chunk.replacements && chunk.parent && chunk.type.name === 'CustomLabel') {
+          // Set replacements on the parent of a CustomLabel as well so that recomposing
+          // doesn't use the non-replaced content from parent cache.
+          // See RecompositionFinalizer.recompose() in convertContext.ts
+          chunk.parent.replacements = chunk.replacements;
+        }
       } catch (e) {
         if (!(e instanceof Error)) {
           throw e;

--- a/test/nuts/local/replacements/replacementsLabels.nut.ts
+++ b/test/nuts/local/replacements/replacementsLabels.nut.ts
@@ -71,7 +71,7 @@ describe('e2e replacements test (customLabels)', () => {
       await extractZip(zipBuffer, path.join(session.project.dir, 'unzipped'));
     });
 
-    it('label replacements as expected', async () => {
+    it('label replacements as expected (CustomLabels)', async () => {
       const labelsContents = await fs.promises.readFile(
         path.join(session.project.dir, 'unzipped', 'labels', 'CustomLabels.labels'),
         'utf8'
@@ -79,6 +79,29 @@ describe('e2e replacements test (customLabels)', () => {
       expect(labelsContents).to.not.include('original');
       expect(labelsContents).to.include('REPLACED_LABEL');
     });
+
+    it('label replacements as expected (CustomLabel)', async () => {
+      const converter = new MetadataConverter();
+      const cs = await ComponentSetBuilder.build({
+        metadata: {
+          metadataEntries: ['CustomLabel:Docs_CabinetId'],
+          directoryPaths: [path.join(session.project.dir, 'force-app')],
+        },
+      });
+      const { zipBuffer } = await converter.convert(cs, 'metadata', {
+        type: 'zip',
+      });
+      assert(zipBuffer, 'zipBuffer should be defined');
+      // extract zip files
+      await extractZip(zipBuffer, path.join(session.project.dir, 'unzipped2'));
+      const labelsContents = await fs.promises.readFile(
+        path.join(session.project.dir, 'unzipped2', 'labels', 'CustomLabels.labels'),
+        'utf8'
+      );
+      expect(labelsContents).to.not.include('original');
+      expect(labelsContents).to.include('REPLACED_LABEL');
+    });
+
     it('class replacements as expected', async () => {
       const classContents = await fs.promises.readFile(
         path.join(session.project.dir, 'unzipped', 'classes', 'replaceStuff.cls'),


### PR DESCRIPTION
### What does this PR do?
When individual `CustomLabel` metadata with string replacements are targeted for a deploy without the parent `CustomLabels` metadata, the string replacement won't occur due to the code using cached file content.  This PR sets replacements on a parent component when the child has string replacements.

[CustomLabel String replacement not working correctly with --manifest flag](https://github.com/forcedotcom/cli/issues/2755)
@W-15262083@