### PR TITLE
fix: allow the same SC in delete and deploy manifests

### DIFF
--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -259,10 +259,8 @@ export class SourceComponent implements MetadataComponent {
       delete this.destructiveChangesType;
     } else {
       this.markedForDelete = true;
-      // eslint-disable-next-line no-unused-expressions
-      destructiveChangeType === DestructiveChangesType.PRE
-        ? (this.destructiveChangesType = DestructiveChangesType.PRE)
-        : (this.destructiveChangesType = DestructiveChangesType.POST);
+      this.destructiveChangesType =
+        destructiveChangeType === DestructiveChangesType.PRE ? DestructiveChangesType.PRE : DestructiveChangesType.POST;
     }
   }
 

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -1262,6 +1262,8 @@ describe('ComponentSet', () => {
       expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
       expect(set.has(component)).to.be.true;
       expect(set.getSourceComponents().toArray().length).to.equal(1);
+      // @ts-ignore - private
+      expect(set.manifestComponents.size).to.equal(1);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
allows the same source component to be placed in all types of manifests (pre/post/manifest) simultaneously

### What issues does this PR fix or reference?

@W-15231435@

### Functionality Before

you could not pre-deploy-delete, deploy, or deploy, post-deploy-delete the same MD

### Functionality After

now you can 🚀 