### PR TITLE
fix: non-zip conversions return empty arrays for converted and deleted

### DIFF
--- a/src/convert/metadataConverter.ts
+++ b/src/convert/metadataConverter.ts
@@ -105,7 +105,7 @@ const getResult =
       };
     }
 
-    return { packagePath };
+    return { packagePath, converted: [], deleted: [] };
   };
 
 function getPackagePath(


### PR DESCRIPTION
[skip-validate-pr]

restore a unspecified type behavior that packaging was relying on