### PR TITLE
@W-15215917: feat: add AffinityScoreDefinition metadatatype

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -109,6 +109,7 @@
     "aiScoringModelDefinition": "aiscoringmodeldefinition",
     "aiUsecaseDefinitions": "aiusecasedefinition",
     "aiapplicationconfig": "aiapplicationconfig",
+    "affinityScoreDefinition": "affinityscoredefinition",
     "animationRule": "animationrule",
     "app": "customapplication",
     "appMenu": "appmenu",
@@ -681,6 +682,14 @@
       "name": "AIUsecaseDefinition",
       "strictDirectoryName": false,
       "suffix": "aiUsecaseDefinitions"
+    },
+    "affinityscoredefinition": {
+      "directoryName": "affinityScoreDefinitions",
+      "id": "affinityscoredefinition",
+      "inFolder": false,
+      "name": "AffinityScoreDefinition",
+      "strictDirectoryName": false,
+      "suffix": "affinityScoreDefinitions"
     },
     "analyticsnapshot": {
       "directoryName": "analyticSnapshots",


### PR DESCRIPTION
### What does this PR do?

It registers AffinityScoreDefinition as a metadata type so that we can make AffinityScoreDefinition entity packageable. 

### What issues does this PR fix or reference?

# packaging tests are failing because our entity isn't packageable, @W-15215917@