### PR TITLE
fix: expand mdTransfer error

### DIFF
--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -116,7 +116,7 @@ export abstract class MetadataTransfer<
       return result;
     } catch (e) {
       const err = e as Error | SfError;
-      const error = new SfError(messages.getMessage('md_request_fail', [err.message]), 'MetadataTransferError', err);
+      const error = new SfError(messages.getMessage('md_request_fail', [err.message]), 'MetadataTransferError');
 
       if (error.stack && err.stack) {
         // append the original stack to this new error


### PR DESCRIPTION
### What does this PR do?

updates `MetadataTransfer.pollStatus` error handling to expand the mdTransfer error with error data/actions if the failure throws an SfError.

An example of this is STL throwing on source-tracking after a CLI deploy (which happens on the postdeploy hook on SDR).
One customer is getting the `multiple git error` iso-git failure on STL but the path errors don't show up in the CLI final error.
See this thread:
https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1711480148180689

### What issues does this PR fix or reference?

@W-15347866@

### Functionality Before

errors in post retrieve/deploy get swallowed in mdTransfer catch block.

### Functionality After

mdTransfer will include cause error data (if instanceof SfError) and actions.

<insert gif and/or summary>
