### PR TITLE
fix: add supportsPartialDelete to types where child types are not addressable

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1572,7 +1572,8 @@
       },
       "strictDirectoryName": true,
       "suffix": "objectTranslation",
-      "supportsWildcardAndName": true
+      "supportsWildcardAndName": true,
+      "supportsPartialDelete": true
     },
     "custompageweblink": {
       "directoryName": "weblinks",

--- a/src/registry/presets/decomposeCustomLabelsBeta.json
+++ b/src/registry/presets/decomposeCustomLabelsBeta.json
@@ -37,7 +37,8 @@
         "decomposition": "topLevel",
         "transformer": "decomposed"
       },
-      "suffix": "labels"
+      "suffix": "labels",
+      "supportsPartialDelete": true
     }
   }
 }

--- a/src/registry/presets/decomposePermissionSetBeta.json
+++ b/src/registry/presets/decomposePermissionSetBeta.json
@@ -180,7 +180,8 @@
         "transformer": "decomposed"
       },
       "strictDirectoryName": true,
-      "suffix": "permissionset"
+      "suffix": "permissionset",
+      "supportsPartialDelete": true
     }
   }
 }

--- a/src/registry/presets/decomposeSharingRulesBeta.json
+++ b/src/registry/presets/decomposeSharingRulesBeta.json
@@ -75,7 +75,8 @@
         "transformer": "decomposed"
       },
       "strictDirectoryName": true,
-      "suffix": "sharingRules"
+      "suffix": "sharingRules",
+      "supportsPartialDelete": true
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Add supportsPartialDelete to types where child types are not addressable to support file deletions of decomposed metadata (SDR presets)

### What issues does this PR fix or reference?

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

In case of a child component file deletion for a decomposed metadata type where child components are `not addressable` `@salesforce/source-tracking` marks the parent component for deletion

### Functionality After

In case of a child component file deletion for a decomposed metadata type where child components are `not addressable` `@salesforce/source-tracking` marks the parent component for deployment
