### PR TITLE
feat: warn about .forceignore and the unpackaged folder

### DIFF
--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -31,6 +31,11 @@ export class ForceIgnore {
             'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. The ignore rules will not work as expected until you fix this.'
           );
         }
+        if (contents.includes('**/unpackaged/**')) {
+          void Lifecycle.getInstance().emitWarning(
+            'Your .forceignore file contains the "**/unpackaged/**" rule. This will cause all files to be ignored during a retrieve.'
+          );
+        }
         // add the default ignore paths, and then parse the .forceignore file
         this.parser = ignore().add(`${this.DEFAULT_IGNORE.join('\n')}\n${contents}`);
 


### PR DESCRIPTION
### What does this PR do?
warn when user are ignoring everything in a retrieve (which brings stuff down inside `/unpackaged`) 

### What issues does this PR fix or reference?
prevents the pain https://github.com/forcedotcom/cli/issues/2399 (just had another user hitting the same problem)

[@W-15667616@](https://gus.lightning.force.com/a07EE00001qX0WLYA0)
