### PR TITLE
fix: if no component set to match against, skip checking server response

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -435,7 +435,9 @@ const buildFileResponsesFromComponentSet =
       )
       .concat(deleteNotFoundToFileResponses(cs)(responseMessages));
 
-    warnIfUnmatchedServerResult(fileResponses)(responseMessages);
+    if (cs.size) {
+      warnIfUnmatchedServerResult(fileResponses)(responseMessages);
+    }
     return fileResponses;
   };
 /**

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -880,6 +880,49 @@ describe('MetadataApiDeploy', () => {
         warnSpy.restore();
         emitSpy.restore();
       });
+      it('should NOT warn when empty component set used', () => {
+        // everything is an emit.  Warn calls emit, too.
+        const warnSpy = $$.SANDBOX.stub(Lifecycle.prototype, 'emitWarning');
+        const emitSpy = $$.SANDBOX.stub(Lifecycle.prototype, 'emit');
+
+        const component = matchingContentFile.COMPONENT;
+        const deployedSet = new ComponentSet([]);
+        const { fullName, type } = component;
+
+        const apiStatus: Partial<MetadataApiDeployStatus> = {
+          details: {
+            componentFailures: [
+              {
+                changed: 'true',
+                created: 'false',
+                deleted: 'false',
+                success: 'true',
+                fullName,
+                fileName: component.content,
+                componentType: type.name,
+              } as DeployMessage,
+              {
+                changed: 'false',
+                created: 'false',
+                deleted: 'true',
+                success: 'true',
+                fullName: 'myServerOnlyComponent',
+                fileName: 'myServerOnlyComponent',
+                componentType: type.name,
+              } as DeployMessage,
+            ],
+          },
+        };
+        const result = new DeployResult(apiStatus as MetadataApiDeployStatus, deployedSet);
+
+        const responses = result.getFileResponses();
+
+        expect(responses).to.deep.equal([]);
+        expect(warnSpy.called).to.be.false;
+
+        warnSpy.restore();
+        emitSpy.restore();
+      });
 
       it('should not report duplicates component', () => {
         const component = matchingContentFile.COMPONENT;


### PR DESCRIPTION
### What does this PR do?
if we don't have a component set, skip checking it against the server response
everything surrounding the method was on an iteration of the component set, this wasn't

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2862, @W-15735078@

### Functionality Before

doing a metadata deply/project report would result in incorrect warnings

### Functionality After

no incorrect warnings