### PR TITLE
feat: rename presets property

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -156,13 +156,13 @@ It's possible that the registry isn't what a user wants
 There are two options available if you're in an sfdx project.
 
 - `registryCustomizations`: add your own partial of the the registry that'll be merged into the registry. It's a json object just like the registry itself.
-- `registryPresets`: SDR defines "preset" registryCustomizations and you say which ones you want applied. Each one is a partial, and you can have any or all of them by listing them. Names correspond to something in src/registry/presets, so your project file could use
+- `sourceBehaviorOptions`: SDR defines "preset" registryCustomizations and you say which ones you want applied. Each one is a partial, and you can have any or all of them by listing them. Names correspond to something in src/registry/presets, so your project file could use
 
 ```json
-  "registryPresets": ["decomposePermissionSetBeta", "decomposeSharingRulesBeta"]
+  "sourceBehaviorOptions": ["decomposePermissionSetBeta", "decomposeSharingRulesBeta"]
 ```
 
-if you want only those 2 presets.
+if you want only those 2 sourceBehaviorOptions.
 
 The naming convention is `decomposeFoo` where `Foo` is the top-level metadata type, and refers to `/presets/Foo.json`.
 

--- a/src/Presets.md
+++ b/src/Presets.md
@@ -1,4 +1,4 @@
-# Available Registry Presets
+# Available sourceBehaviorOptions
 
 ## `decomposePermissionSetBeta`
 

--- a/test/snapshot/sampleProjects/preset-PermSet/sfdx-project.json
+++ b/test/snapshot/sampleProjects/preset-PermSet/sfdx-project.json
@@ -7,7 +7,7 @@
       "path": "force-app"
     }
   ],
-  "registryPresets": ["decomposePermissionSetBeta"],
+  "sourceBehaviorOptions": ["decomposePermissionSetBeta"],
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "60.0"
 }

--- a/test/snapshot/sampleProjects/preset-decomposeLabels/sfdx-project.json
+++ b/test/snapshot/sampleProjects/preset-decomposeLabels/sfdx-project.json
@@ -7,7 +7,7 @@
       "path": "force-app"
     }
   ],
-  "registryPresets": ["decomposeCustomLabelsBeta"],
+  "sourceBehaviorOptions": ["decomposeCustomLabelsBeta"],
   "sfdcLoginUrl": "https://login.salesforce.com",
   "sourceApiVersion": "60.0"
 }

--- a/test/snapshot/sampleProjects/preset-sharingRules/sfdx-project.json
+++ b/test/snapshot/sampleProjects/preset-sharingRules/sfdx-project.json
@@ -7,7 +7,7 @@
       "path": "force-app"
     }
   ],
-  "registryPresets": ["decomposeSharingRulesBeta"],
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "52.0"
+  "sourceApiVersion": "52.0",
+  "sourceBehaviorOptions": ["decomposeSharingRulesBeta"]
 }

--- a/test/snapshot/sampleProjects/preset-workflow-mpd/sfdx-project.json
+++ b/test/snapshot/sampleProjects/preset-workflow-mpd/sfdx-project.json
@@ -1,15 +1,15 @@
 {
+  "namespace": "",
   "packageDirectories": [
     {
-      "path": "force-app",
-      "default": true
+      "default": true,
+      "path": "force-app"
     },
     {
       "path": "another-package"
     }
   ],
-  "registryPresets": ["decomposeWorkflowBeta"],
-  "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "60.0"
+  "sourceApiVersion": "60.0",
+  "sourceBehaviorOptions": ["decomposeWorkflowBeta"]
 }

--- a/test/snapshot/sampleProjects/preset-workflow/sfdx-project.json
+++ b/test/snapshot/sampleProjects/preset-workflow/sfdx-project.json
@@ -7,7 +7,7 @@
       "path": "force-app"
     }
   ],
-  "registryPresets": ["decomposeWorkflowBeta"],
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "60.0"
+  "sourceApiVersion": "60.0",
+  "sourceBehaviorOptions": ["decomposeWorkflowBeta"]
 }


### PR DESCRIPTION
### What does this PR do?
support the new name `sourceBehaviorOptions`

beta presest still work ok.  The change in forcedotcom schemas will help the few beta users migrate

### What issues does this PR fix or reference?
@W-15792360@