### PR TITLE
@W-15638748 | Changes to support EnblProgramTaskSubCategory and LearningItemType

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -239,6 +239,7 @@
     "emailFolder": "emailfolder",
     "enablementMeasureDefinition": "enablementmeasuredefinition",
     "enablementProgramDefinition": "enablementprogramdefinition",
+    "enblProgramTaskSubCategory": "enblprogramtasksubcategory",
     "entitlementProcess": "entitlementprocess",
     "entitlementTemplate": "entitlementtemplate",
     "entityImplements": "entityimplements",
@@ -310,6 +311,7 @@
     "keywords": "keywordlist",
     "labels": "customlabels",
     "layout": "layout",
+    "learningItemType": "learningitemtype",
     "letter": "letterhead",
     "licenseDefinition": "licensedefinition",
     "lightningBolt": "lightningbolt",
@@ -2080,6 +2082,14 @@
       "strictDirectoryName": false,
       "suffix": "enablementProgramDefinition"
     },
+    "enblprogramtasksubcategory": {
+      "directoryName": "enblProgramTaskSubCategories",
+      "id": "enblprogramtasksubcategory",
+      "inFolder": false,
+      "name": "EnblProgramTaskSubCategory",
+      "strictDirectoryName": false,
+      "suffix": "enblProgramTaskSubCategory"
+    },
     "entitlementprocess": {
       "directoryName": "entitlementProcesses",
       "id": "entitlementprocess",
@@ -2805,6 +2815,14 @@
       "name": "LeadConvertSettings",
       "strictDirectoryName": false,
       "suffix": "LeadConvertSetting"
+    },
+    "learningitemtype": {
+      "directoryName": "learningItemTypes",
+      "id": "learningitemtype",
+      "inFolder": false,
+      "name": "LearningItemType",
+      "strictDirectoryName": false,
+      "suffix": "learningItemType"
     },
     "letterhead": {
       "directoryName": "letterhead",


### PR DESCRIPTION
We have created the new setup entities EnblProgramTaskSubCategory and LearningItemType and exposed them to mdApi.


### What does this PR do?
Supports EnblProgramTaskSubCategory and LearningItemType entities in retrieve/deploy

### What issues does this PR fix or reference?

The specified metadata type is unsupported: [EnblProgramTaskSubCategory] 
The specified metadata type is unsupported: [LearningItemType]
@W-15638748@

### Functionality Before
When we tried to retrieve this entity using sfdx commands getting the following error The specified metadata type is unsupported: [EnblProgramTaskSubCategory]. Same for the LearningItemType.

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
