### PR TITLE
refactor: real-time manifestFiles calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@salesforce/core": "^7.3.9",
-    "@salesforce/kit": "^3.1.1",
+    "@salesforce/kit": "^3.1.2",
     "@salesforce/ts-types": "^2.0.9",
     "fast-levenshtein": "^3.0.0",
     "fast-xml-parser": "^4.3.6",

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -46,7 +46,7 @@ export type DeploySetOptions = Omit<MetadataApiDeployOptions, 'components'>;
 export type RetrieveSetOptions = Omit<MetadataApiRetrieveOptions, 'components'>;
 type ComponentMapMap = DecodeableMap<string, DecodeableMap<string, SourceComponent>>;
 
-const KEY_DELIMITER = '#';
+const KEY_DELIMITER = '#-#';
 const NOT_DESTRUCTIVE = 'SDR_NOT_DESTRUCTIVE';
 
 /**
@@ -753,7 +753,7 @@ const filterComponentsByDestructiveKey =
   (components: ComponentMapMap): ComponentMapMap =>
     new DecodeableMap(
       [...components.entries()].filter(([k]) =>
-        destructiveType ? k.endsWith(destructiveType) : k.endsWith(NOT_DESTRUCTIVE)
+        k.endsWith(`${KEY_DELIMITER}${destructiveType ? destructiveType : NOT_DESTRUCTIVE}`)
       )
     );
 

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -418,7 +418,7 @@ describe('ComponentSet', () => {
         });
 
         expect(result).to.deep.equal(expected);
-        expect(!!compSet.getTypesOfDestructiveChanges().length).to.be.true;
+        expect(compSet.getTypesOfDestructiveChanges().length).to.equal(1);
       });
 
       describe('includes filter', () => {
@@ -460,7 +460,7 @@ describe('ComponentSet', () => {
 
           expect(result).to.deep.equal(expected);
         });
-        it('components marked for delete do not impact the inludes filter', () => {
+        it('components marked for delete do not impact the includes filter', () => {
           getComponentsStub.restore();
 
           // these *would* match except they're marked fo deletion so the include filter doesn't use them.
@@ -1295,7 +1295,7 @@ describe('ComponentSet', () => {
 
     it('should add metadata component marked for delete to package components', () => {
       const set = new ComponentSet(undefined, registryAccess);
-      expect(!!set.getTypesOfDestructiveChanges().length).to.be.false;
+      expect(set.getTypesOfDestructiveChanges().length).to.equal(0);
 
       const component = new SourceComponent({
         name: mixedContentSingleFile.COMPONENT.name,
@@ -1304,14 +1304,14 @@ describe('ComponentSet', () => {
       });
       set.add(component, DestructiveChangesType.POST);
 
-      expect(!!set.getTypesOfDestructiveChanges().length).to.be.true;
+      expect(set.getTypesOfDestructiveChanges()).to.deep.equal([DestructiveChangesType.POST]);
       expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
-      expect(set.has(component)).to.be.true;
+      expect(set.has(component, DestructiveChangesType.POST)).to.be.true;
     });
 
-    it('should delete metadata from package components, if its present in destructive changes', () => {
+    it('allow a component in both deploy and destructive manifests', () => {
       const set = new ComponentSet(undefined, registryAccess);
-      expect(!!set.getTypesOfDestructiveChanges().length).to.be.false;
+      expect(set.getTypesOfDestructiveChanges().length).to.equal(0);
 
       const component = new SourceComponent({
         name: mixedContentSingleFile.COMPONENT.name,
@@ -1320,20 +1320,24 @@ describe('ComponentSet', () => {
       });
       set.add(component, DestructiveChangesType.POST);
 
-      expect(!!set.getTypesOfDestructiveChanges().length).to.be.true;
+      expect(set.getTypesOfDestructiveChanges().length).to.equal(1);
       expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.POST);
       expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
 
-      set.add(component);
+      // create a new instance of component2 because the original mutates the component
+      const component2 = new SourceComponent({
+        name: mixedContentSingleFile.COMPONENT.name,
+        type: mixedContentSingleFile.COMPONENT.type,
+        xml: mixedContentSingleFile.COMPONENT.xml,
+      });
+      set.add(component2);
       set.setDestructiveChangesType(DestructiveChangesType.PRE);
       expect(set.getDestructiveChangesType()).to.equal(DestructiveChangesType.PRE);
       expect(set.getSourceComponents().first()?.isMarkedForDelete()).to.be.true;
-      expect(set.has(component)).to.be.true;
-      expect(set.getSourceComponents().toArray().length).to.equal(1);
+      expect(set.has(component2)).to.be.true;
+      expect(set.getSourceComponents().toArray().length).to.equal(2);
       expect(set.destructiveChangesPre.size).to.equal(0);
       expect(set.destructiveChangesPost.size).to.equal(1);
-      // @ts-ignore - private
-      expect(set.manifestComponents.size).to.equal(1);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,10 +624,10 @@
     typescript "^5.4.3"
     wireit "^0.14.4"
 
-"@salesforce/kit@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.1.tgz#d2147a50887214763cdf1c456d306b6da554d928"
-  integrity sha512-Cjkh+USp5PtdZmD30r1Y7d+USpIhQz9B48w76esBtYpgqzhyj806LHkVgEfmorLNq2Qe8EO5rtUYd+XZ3rnV9w==
+"@salesforce/kit@^3.1.1", "@salesforce/kit@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.2.tgz#270741c54c70969df19ef17f8979b4ef1fa664b2"
+  integrity sha512-si+ddvZDgx9q5czxAANuK5xhz3pv+KGspQy1wyia/7HDPKadA0QZkLTzUnO1Ju4Mux32CNHEb2y9lw9jj+eVTA==
   dependencies:
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"


### PR DESCRIPTION
instead of storing and maintaining various maps in a ComponentSet, defer that work until we need to build a manifest.

does some work to keep `CS.has` consistent with existing behavior (match anything in CS.components` but also lets you pass in a destructive type to be more specific about what counts as a match
