### PR TITLE
Wr/improve did you mean

### DIFF
--- a/src/convert/transformers/defaultMetadataTransformer.ts
+++ b/src/convert/transformers/defaultMetadataTransformer.ts
@@ -100,9 +100,15 @@ const getXmlDestination = (
   //    - insert file extension behind the -meta.xml suffix if folder type and to 'source format'
   if (!component.content && !['digitalexperiencebundle'].includes(component.type.id)) {
     if (targetFormat === 'metadata') {
-      xmlDestination = folderContentType
-        ? xmlDestination.replace(`.${suffix}`, '')
-        : xmlDestination.slice(0, xmlDestination.lastIndexOf(META_XML_SUFFIX));
+      if (folderContentType) {
+        xmlDestination = xmlDestination.replace(`.${suffix}`, '');
+      } else if (xmlDestination.includes(META_XML_SUFFIX)) {
+        xmlDestination = xmlDestination.slice(0, xmlDestination.lastIndexOf(META_XML_SUFFIX));
+      } else {
+        void Lifecycle.getInstance().emitWarning(
+          `Potential metadata-format file ${xmlDestination} found in a source-format directory`
+        );
+      }
     } else {
       xmlDestination = folderContentType
         ? xmlDestination.replace(META_XML_SUFFIX, `.${suffix}${META_XML_SUFFIX}`)

--- a/src/convert/transformers/defaultMetadataTransformer.ts
+++ b/src/convert/transformers/defaultMetadataTransformer.ts
@@ -106,7 +106,7 @@ const getXmlDestination = (
         xmlDestination = xmlDestination.slice(0, xmlDestination.lastIndexOf(META_XML_SUFFIX));
       } else {
         void Lifecycle.getInstance().emitWarning(
-          `Potential metadata-format file ${xmlDestination} found in a source-format directory`
+          `Found a file (${xmlDestination}) that appears to be in metadata format, but the directory it's in is for source formatted files.`
         );
       }
     } else {

--- a/test/nuts/suggestType/suggestType.nut.ts
+++ b/test/nuts/suggestType/suggestType.nut.ts
@@ -92,10 +92,10 @@ describe('suggest types', () => {
     });
     expect(lifecycleSpy.calledOnce).to.be.true;
     expect(lifecycleSpy.args[0][0]).to.equal(
-      `Potential metadata-format file ${join(
+      `Found a file (${join(
         'enablementMeasureDefinitions',
         'measure.enablementMeasureDefinition'
-      )} found in a source-format directory`
+      )}) that appears to be in metadata format, but the directory it's in is for source formatted files.`
     );
 
     fs.rmSync('output', { recursive: true, force: true });

--- a/test/nuts/suggestType/suggestType.nut.ts
+++ b/test/nuts/suggestType/suggestType.nut.ts
@@ -90,8 +90,7 @@ describe('suggest types', () => {
       genUniqueDir: false,
       outputDirectory: 'output',
     });
-    expect(lifecycleSpy.callCount).to.equal(1);
-    expect(lifecycleSpy.args.flat()).to.deep.equal([
+    expect(lifecycleSpy.args.flat()).to.deep.include([
       `Found a file (${join(
         'enablementMeasureDefinitions',
         'measure.enablementMeasureDefinition'

--- a/test/nuts/suggestType/suggestType.nut.ts
+++ b/test/nuts/suggestType/suggestType.nut.ts
@@ -90,13 +90,13 @@ describe('suggest types', () => {
       genUniqueDir: false,
       outputDirectory: 'output',
     });
-    expect(lifecycleSpy.calledOnce).to.be.true;
-    expect(lifecycleSpy.args[0][0]).to.equal(
+    expect(lifecycleSpy.callCount).to.equal(1);
+    expect(lifecycleSpy.args.flat()).to.deep.equal([
       `Found a file (${join(
         'enablementMeasureDefinitions',
         'measure.enablementMeasureDefinition'
-      )}) that appears to be in metadata format, but the directory it's in is for source formatted files.`
-    );
+      )}) that appears to be in metadata format, but the directory it's in is for source formatted files.`,
+    ]);
 
     fs.rmSync('output', { recursive: true, force: true });
   });

--- a/test/nuts/suggestType/testProj/force-app/main/default/enablementMeasureDefinitions/measure.enablementMeasureDefinition
+++ b/test/nuts/suggestType/testProj/force-app/main/default/enablementMeasureDefinitions/measure.enablementMeasureDefinition
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?>

--- a/test/nuts/suggestType/testProj/force-app/main/default/enablementMeasureDefinitions/measure.enablementMeasureDefinition
+++ b/test/nuts/suggestType/testProj/force-app/main/default/enablementMeasureDefinitions/measure.enablementMeasureDefinition
@@ -1,1 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<EnablementMeasureDefinition>
+</EnablementMeasureDefinition>


### PR DESCRIPTION
### What does this PR do?

fixes a bug when a MD format file was converted to MD format, it would strip the last char from the file path, and then cause a error when trying to identify the metadata with the then incorrect suffix

fixes error
it now emits a warning when md format files are found and the `toFormat` is metadata

### What issues does this PR fix or reference?

@W-15783171@

### Functionality Before

```bash
 ➜  sf project convert source --output-dir md --source-dir force-app/main/default/enablementMeasureDefinitions
Error (1): /Users/william.ruemmele/projects/scratches/dreamhouse-lwc/md/enablementMeasureDefinitions/testing.enablementMeasureDefinitio: Could not infer a metadata type

Try this:

A metadata type lookup for "testing.enablementMeasureDefinitio" found the following close matches:
-- Did you mean ".enablementMeasureDefinition" instead for the "EnablementMeasureDefinition" metadata type?
```
### Functionality After

```bash
 ➜  ../../oss/plugin-deploy-retrieve/bin/run.js project convert source --output-dir md/format --source-dir force-app/main/default/enablementMeasureDefinitions 
Warning: Potential metadata-format file enablementMeasureDefinitions/testing.enablementMeasureDefinition found in a source-format directory
Source was successfully converted to Metadata API format and written to the location: /Users/william.ruemmele/projects/scratches/dreamhouse-lwc/md/format
```