### PR TITLE
fix: set forceIgnoredPaths on CS

### DIFF
--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -163,6 +163,7 @@ export class ComponentSetBuilder {
               );
             });
           }
+          componentSet.forceIgnoredPaths = resolvedComponents.forceIgnoredPaths;
         }
 
         resolvedComponents.toArray().map(addToComponentSet(componentSet));

--- a/test/collections/componentSetBuilder.test.ts
+++ b/test/collections/componentSetBuilder.test.ts
@@ -292,6 +292,7 @@ describe('ComponentSetBuilder', () => {
         },
       });
       expect(fromSourceStub.callCount).to.equal(1);
+      expect(compSet.forceIgnoredPaths).to.equal(undefined);
       const fromSourceArgs = fromSourceStub.firstCall.args[0] as FromSourceOptions;
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
       const filter = new ComponentSet();
@@ -333,6 +334,8 @@ describe('ComponentSetBuilder', () => {
         },
       });
       expect(fromSourceStub.callCount).to.equal(1);
+      expect(compSet.forceIgnoredPaths?.size).to.equal(1);
+      expect(compSet.forceIgnoredPaths).to.deep.equal(new Set([join('my', 'path', 'to', 'a', 'customobject.xml')]));
       const fromSourceArgs = fromSourceStub.firstCall.args[0] as FromSourceOptions;
       expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
       const filter = new ComponentSet();


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

[skip-validate-pr]

### Functionality Before

`ComponentSet.forceIgnoredPaths` was not being set

### Functionality After

it's now set