### PR TITLE
Sh/better mdapi tmp retrieve

### DIFF
--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -104,6 +104,9 @@ export class MetadataApiDeploy extends MetadataTransfer<
     this.options = Object.assign({}, options);
     this.isRestDeploy = !!options.apiOptions?.rest;
     this.registry = options.registry ?? new RegistryAccess();
+    if (this.mdapiTempDir) {
+      this.mdapiTempDir = join(this.mdapiTempDir, `${new Date().toISOString()}_deploy`);
+    }
   }
 
   /**

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { basename, join } from 'node:path';
+import { basename, join, sep } from 'node:path';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import chai, { assert, expect } from 'chai';
 import { AnyJson, getString } from '@salesforce/ts-types';
@@ -100,7 +100,10 @@ describe('MetadataApiDeploy', () => {
 
           expect(deployStub.calledOnce).to.be.true;
           expect(deployStub.firstCall.args[0]).to.equal(zipBuffer);
-          expect(getString(convertStub.secondCall.args[2], 'outputDirectory', '')).to.equal('test');
+          // @ts-expect-error protected property
+          const expectedDir = join(operation.mdapiTempDir, 'metadata');
+          expect(expectedDir.startsWith(`test${sep}`)).to.be.true;
+          expect(getString(convertStub.secondCall.args[2], 'outputDirectory', '')).to.equal(expectedDir);
         } finally {
           delete process.env.SF_MDAPI_TEMP_DIR;
         }

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { fail } from 'node:assert';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { Messages } from '@salesforce/core';
 import { assert, expect } from 'chai';
 import chai = require('chai');
@@ -311,11 +311,16 @@ describe('MetadataApiRetrieve', () => {
             successes: toRetrieve,
           });
           $$.SANDBOX.stub(fs.promises, 'writeFile');
+          $$.SANDBOX.stub(fs, 'mkdirSync');
+          $$.SANDBOX.stub(fs, 'writeFileSync');
 
           await operation.start();
           await operation.pollStatus();
 
-          expect(getString(convertStub.secondCall.args[2], 'outputDirectory', '')).to.equal('test');
+          // @ts-expect-error protected property
+          const expectedDir = join(operation.mdapiTempDir, 'source');
+          expect(expectedDir.startsWith(`test${sep}`)).to.be.true;
+          expect(getString(convertStub.secondCall.args[2], 'outputDirectory', '')).to.equal(expectedDir);
         } finally {
           delete process.env.SF_MDAPI_TEMP_DIR;
         }


### PR DESCRIPTION
### What does this PR do?
Changes the filesystem structure of output when SF_MDAPI_TEMP_DIR is set to make it easier to see what it contains.
For retrieves, the raw metadata zip is written along with the manifest, in addition to the converted source metadata and manifest.

### What issues does this PR fix or reference?
@W-15846019@