### PR TITLE
fix: Remove ExpressionSetDefinitionVersion to not allow user to deploy it explicitly

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -254,7 +254,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |ExplainabilityActionVersion|✅||
 |ExplainabilityMsgTemplate|✅||
 |ExpressionSetDefinition|✅||
-|ExpressionSetDefinitionVersion|✅||
+|ExpressionSetDefinitionVersion|❌|Not supported, but support could be added|
 |ExpressionSetObjectAlias|✅||
 |ExtDataTranFieldTemplate|❌|Not supported, but support could be added|
 |ExtDataTranObjectTemplate|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -12,7 +12,6 @@
     "decisionmatrixdefinitionversion": "decisionmatrixdefinition",
     "digitalexperience": "digitalexperiencebundle",
     "escalationrule": "escalationrules",
-    "expressionsetdefinitionversion": "expressionsetdefinition",
     "extdatatranfieldtemplate": "extdatatranobjecttemplate",
     "fieldset": "customobject",
     "formsection": "form",
@@ -251,7 +250,6 @@
     "explainabilityActionVersion": "explainabilityactionversion",
     "explainabilityMsgTemplate": "explainabilitymsgtemplate",
     "expressionSetDefinition": "expressionsetdefinition",
-    "expressionSetDefinitionVersion": "expressionsetdefinitionversion",
     "expressionSetMessageToken": "expressionsetmessagetoken",
     "expressionSetObjectAlias": "expressionsetobjectalias",
     "extDataTranFieldTemplate": "extdatatranfieldtemplate",
@@ -2231,22 +2229,6 @@
       "suffix": "explainabilityMsgTemplate"
     },
     "expressionsetdefinition": {
-      "children": {
-        "directories": {
-          "versions": "expressionsetdefinitionversion"
-        },
-        "suffixes": {
-          "expressionSetDefinitionVersion": "expressionsetdefinitionversion"
-        },
-        "types": {
-          "expressionsetdefinitionversion": {
-            "directoryName": "versions",
-            "id": "expressionsetdefinitionversion",
-            "name": "ExpressionSetDefinitionVersion",
-            "suffix": "expressionSetDefinitionVersion"
-          }
-        }
-      },
       "directoryName": "expressionSetDefinition",
       "id": "expressionsetdefinition",
       "inFolder": false,


### PR DESCRIPTION
…y or retrieve it explicilty

### What does this PR do?
 Remove ExpressionSetDefinitionVersion from metadataRegistry
### What issues does this PR fix or reference?
https://gus.lightning.force.com/a07EE00001tKsmDYAS
#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<insert gif and/or summary>
User was able to retrieve or deploy ExpressionSetDefinitionVersion entity explicitly
### Functionality After
User will not be able to retrieve or deploy ExpressionSetDefinitionVersion entity explicitly
<insert gif and/or summary>
