### PR TITLE
chore: adding StageDefinition to the metadataRegistry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -500,7 +500,8 @@
     "workflowTask": "workflowtask",
     "xmd": "wavexmd",
     "xml": "emailservicesfunction",
-    "xorghub": "xorghub"
+    "xorghub": "xorghub",
+    "stageDefinition": "stagedefinition"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4444,6 +4445,14 @@
       "inFolder": false,
       "name": "XOrgHub",
       "suffix": "xorghub"
+    },
+    "stagedefinition": {
+      "id": "stagedefinition",
+      "name": "StageDefinition",
+      "suffix": "stageDefinition",
+      "directoryName": "stageDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds source tracking for metadata entity: StageDefinition

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001r2EPCYA2/view
@W-15721482@

### Functionality Before

sfdx force:source commands did not work for StageDefinition metadata entity.

### Functionality After

sfdx force:source commands should work for StageDefinition metadata entity.
