### PR TITLE
fix: remove xml cache

### DIFF
--- a/test/convert/convertContext/recomposition.test.ts
+++ b/test/convert/convertContext/recomposition.test.ts
@@ -84,7 +84,7 @@ describe('Recomposition', () => {
           ],
         },
       ]);
-      expect(readFileSpy.callCount).to.equal(3);
+      expect(readFileSpy.callCount).to.equal(4);
     });
 
     it('should still recompose if parent xml is empty', async () => {
@@ -151,7 +151,7 @@ describe('Recomposition', () => {
         },
       ]);
 
-      expect(readFileSpy.callCount, JSON.stringify(readFileSpy.getCalls(), undefined, 2)).to.equal(1);
+      expect(readFileSpy.callCount, JSON.stringify(readFileSpy.getCalls(), undefined, 2)).to.equal(3);
     });
 
     describe('should only read unique child xml files once for non-decomposed components', () => {
@@ -224,7 +224,7 @@ describe('Recomposition', () => {
 
         await context.recomposition.finalize();
 
-        expect(readFileSpy.callCount).to.equal(context.recomposition.transactionState.size);
+        expect(readFileSpy.callCount).to.equal(3);
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?
module-scope cache causes problems for long-lived IDE usage.  this just removes it (goal is to compare the perf tests for EDA, which has a lot of decomposed stuff, to see if it matters at all)

### What issues does this PR fix or reference?
@W-15952068@