### PR TITLE
fix: definition/version types 

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -9,7 +9,6 @@
     "customfield": "customobject",
     "customfieldtranslation": "customobjecttranslation",
     "customlabel": "customlabels",
-    "decisionmatrixdefinitionversion": "decisionmatrixdefinition",
     "digitalexperience": "digitalexperiencebundle",
     "escalationrule": "escalationrules",
     "extdatatranfieldtemplate": "extdatatranobjecttemplate",
@@ -203,7 +202,7 @@
     "datacategorygroup": "datacategorygroup",
     "datatype": "customdatatype",
     "decisionMatrixDefinition": "decisionmatrixdefinition",
-    "decisionMatrixDefinitionVersion": "decisionmatrixdefinitionversion",
+    "decisionMatrixVersion": "decisionmatrixdefinitionversion",
     "decisionTable": "decisiontable",
     "decisionTableDatasetLink": "decisiontabledatasetlink",
     "delegateGroup": "delegategroup",
@@ -1765,28 +1764,20 @@
       "suffix": "dwl"
     },
     "decisionmatrixdefinition": {
-      "children": {
-        "directories": {
-          "versions": "decisionmatrixdefinitionversion"
-        },
-        "suffixes": {
-          "decisionMatrixDefinitionVersion": "decisionmatrixdefinitionversion"
-        },
-        "types": {
-          "decisionmatrixdefinitionversion": {
-            "directoryName": "versions",
-            "id": "decisionmatrixdefinitionversion",
-            "name": "DecisionMatrixDefinitionVersion",
-            "suffix": "decisionMatrixDefinitionVersion"
-          }
-        }
-      },
       "directoryName": "decisionMatrixDefinition",
       "id": "decisionmatrixdefinition",
       "inFolder": false,
       "name": "DecisionMatrixDefinition",
       "strictDirectoryName": false,
       "suffix": "decisionMatrixDefinition"
+    },
+    "decisionmatrixdefinitionversion": {
+      "directoryName": "decisionMatrixVersion",
+      "id": "decisionmatrixdefinitionversion",
+      "inFolder": false,
+      "name": "DecisionMatrixDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "decisionMatrixVersion"
     },
     "decisiontable": {
       "directoryName": "decisionTables",
@@ -2236,6 +2227,14 @@
       "name": "ExpressionSetDefinition",
       "strictDirectoryName": false,
       "suffix": "expressionSetDefinition"
+    },
+    "expressionsetdefinitionversion": {
+      "directoryName": "expressionSetVersion",
+      "id": "expressionsetdefinitionversion",
+      "inFolder": false,
+      "name": "ExpressionSetDefinitionVersion",
+      "strictDirectoryName": false,
+      "suffix": "expressionSetVersion"
     },
     "expressionsetmessagetoken": {
       "directoryName": "expressionSetMessageToken",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -249,6 +249,7 @@
     "explainabilityActionVersion": "explainabilityactionversion",
     "explainabilityMsgTemplate": "explainabilitymsgtemplate",
     "expressionSetDefinition": "expressionsetdefinition",
+    "expressionSetVersion": "expressionsetdefinitionversion",
     "expressionSetMessageToken": "expressionsetmessagetoken",
     "expressionSetObjectAlias": "expressionsetobjectalias",
     "extDataTranFieldTemplate": "extdatatranfieldtemplate",

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
### What does this PR do?
Correct the metadata registry entry for DecisionMatrixDefinition.  Add DecisionMatrixDefinitionVersion and ExpressionSetDefinitionVersion.  It should be parent/child but the type's packaging code wasn't implemented that way.

### What issues does this PR fix or reference?
@W-15489723@
https://github.com/forcedotcom/cli/issues/2823
