### PR TITLE
chore: use import rather than fs read

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.0.3",
+    "@salesforce/core": "^8.1.0",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/ts-types": "^2.0.10",
     "fast-levenshtein": "^3.0.0",
@@ -39,7 +39,7 @@
     "proxy-agent": "^6.4.0"
   },
   "devDependencies": {
-    "@jsforce/jsforce-node": "^3.2.0",
+    "@jsforce/jsforce-node": "^3.2.1",
     "@salesforce/cli-plugins-testkit": "^5.3.16",
     "@salesforce/dev-scripts": "^10.2.2",
     "@types/deep-equal-in-any-order": "^1.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,3 +100,5 @@ export {
   RecompositionStrategy,
   TransformerStrategy,
 } from './registry';
+
+export { presetMap } from './registry/presets/presetMap';

--- a/src/registry/presets/presetMap.ts
+++ b/src/registry/presets/presetMap.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { MetadataRegistry } from '../types';
+
+// we have to import all presets explicitly for VSCE's esbuild bundling process
+import * as decomposeCustomLabelsBeta from './decomposeCustomLabelsBeta.json';
+import * as decomposePermissionSetBeta from './decomposePermissionSetBeta.json';
+import * as decomposeSharingRulesBeta from './decomposeSharingRulesBeta.json';
+import * as decomposeWorkflowBeta from './decomposeWorkflowBeta.json';
+
+export const presetMap = new Map<string, MetadataRegistry>([
+  ['decomposeCustomLabelsBeta', decomposeCustomLabelsBeta as MetadataRegistry],
+  ['decomposePermissionSetBeta', decomposePermissionSetBeta as MetadataRegistry],
+  ['decomposeSharingRulesBeta', decomposeSharingRulesBeta as MetadataRegistry],
+  ['decomposeWorkflowBeta', decomposeWorkflowBeta as MetadataRegistry],
+]);

--- a/src/registry/variants.ts
+++ b/src/registry/variants.ts
@@ -25,7 +25,7 @@ export type RegistryLoadInput = {
 export const getEffectiveRegistry = (input?: RegistryLoadInput): MetadataRegistry =>
   deepFreeze(firstLevelMerge(registryData as MetadataRegistry, loadVariants(input)));
 
-const presetsJsonMap: Map<string, string> = new Map();
+const presetsJsonMap: Map<string, MetadataRegistry> = new Map();
 
 /** read the project to get additional registry customizations and sourceBehaviorOptions */
 const loadVariants = ({ projectDir }: RegistryLoadInput = {}): MetadataRegistry => {
@@ -81,16 +81,15 @@ const maybeGetProject = (projectDir?: string): SfProjectJson | undefined => {
 };
 
 const loadPresetJson = (): void => {
-  presetsJsonMap.set('decomposeCustomLabelsBeta', JSON.stringify(decomposeCustomLabelsBeta));
-  presetsJsonMap.set('decomposePermissionSetBeta', JSON.stringify(decomposePermissionSetBeta));
-  presetsJsonMap.set('decomposeSharingRulesBeta', JSON.stringify(decomposeSharingRulesBeta));
-  presetsJsonMap.set('decomposeWorkflowBeta', JSON.stringify(decomposeWorkflowBeta));
+  presetsJsonMap.set('decomposeCustomLabelsBeta', decomposeCustomLabelsBeta as MetadataRegistry);
+  presetsJsonMap.set('decomposePermissionSetBeta', decomposePermissionSetBeta as MetadataRegistry);
+  presetsJsonMap.set('decomposeSharingRulesBeta', decomposeSharingRulesBeta as MetadataRegistry);
+  presetsJsonMap.set('decomposeWorkflowBeta', decomposeWorkflowBeta as MetadataRegistry);
 };
 
 const loadPreset = (preset: string): MetadataRegistry => {
   try {
-    const rawPreset = presetsJsonMap.get(preset);
-    return JSON.parse(rawPreset as string) as MetadataRegistry;
+    return presetsJsonMap.get(preset) as MetadataRegistry;
   } catch (e) {
     throw new Error(`Failed to load preset ${preset}. The value is invalid.`);
   }

--- a/src/registry/variants.ts
+++ b/src/registry/variants.ts
@@ -88,9 +88,9 @@ const loadPresetJson = (): void => {
 };
 
 const loadPreset = (preset: string): MetadataRegistry => {
-  try {
+  if (presetsJsonMap.has(preset)) {
     return presetsJsonMap.get(preset) as MetadataRegistry;
-  } catch (e) {
+  } else {
     throw new Error(`Failed to load preset ${preset}. The value is invalid.`);
   }
 };

--- a/src/registry/variants.ts
+++ b/src/registry/variants.ts
@@ -92,7 +92,7 @@ const loadPreset = (preset: string): MetadataRegistry => {
     const rawPreset = presetsJsonMap.get(preset);
     return JSON.parse(rawPreset as string) as MetadataRegistry;
   } catch (e) {
-    throw new Error(`Failed to load preset ${preset}. The value does not exist.`);
+    throw new Error(`Failed to load preset ${preset}. The value is invalid.`);
   }
 };
 

--- a/test/registry/presetTesting.ts
+++ b/test/registry/presetTesting.ts
@@ -16,10 +16,13 @@ type RegistryIterator = {
   registry: MetadataRegistry;
 };
 
-const registriesFromPresets = fs.readdirSync(presetFolder, { withFileTypes: true }).map((file) => ({
-  name: file.name,
-  registry: JSON.parse(fs.readFileSync(path.join(file.path, file.name), 'utf-8')) as MetadataRegistry,
-}));
+const registriesFromPresets = fs
+  .readdirSync(presetFolder, { withFileTypes: true })
+  .filter((file) => file.name.endsWith('.json'))
+  .map((file) => ({
+    name: file.name,
+    registry: JSON.parse(fs.readFileSync(path.join(file.path, file.name), 'utf-8')) as MetadataRegistry,
+  }));
 
 const allMerged = registriesFromPresets.reduce<MetadataRegistry>(
   (acc, { registry }) => firstLevelMerge(acc, registry),

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,26 @@
     strip-ansi "^6.0.0"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.2.1.tgz#00fab05919e0cbe91ae4d873377e56cfbc087b98"
+  integrity sha512-hjmZQbYVikm6ATmaErOp5NaKR2VofNZsrcGGHrdbGA+bAgpfg/+MA/HzRTb8BvYyPDq3RRc5A8Yk8gx9Vtcrxg==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    "@types/node" "^18.15.3"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.4.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    strip-ansi "^6.0.0"
+    xml2js "^0.6.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -570,6 +590,30 @@
   integrity sha512-HirswUFGQIF5Ipaa+5l3kulBOf3L25Z3fzf5QqEI4vOxgBKN2bEdKHCA/PROufi3/ejFstiXcn9/jfgyjDdBqA==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.0"
+    "@salesforce/kit" "^3.1.6"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.16.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.2.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.2.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.2"
+    ts-retry-promise "^0.8.1"
+
+"@salesforce/core@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.1.0.tgz#8ee25acdacf9d70a6249907a2fe3503461f18766"
+  integrity sha512-oItr8cdeMe67glJN3dP1Gh/kasD0DUT6S6RfcLTH32wwuZNQAwMXNgBOCvlskr8nxPZ+YSSw7CVuqYMUmCtUXA==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.2.1"
     "@salesforce/kit" "^3.1.6"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.10"
@@ -5020,7 +5064,16 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5079,7 +5132,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5573,7 +5633,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5586,6 +5646,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?
the unspecified imports or file reads makes esbuild unable to bundle the modules. This PR fixes the issue that the presets json files are not bundled.

### What issues does this PR fix or reference?

@W-16114122@

### Functionality Before
presets json modules are not able to be bundled without specifications, and results in the failure in extensions.

### Functionality After
presets json modules are able to be bundled directly. 