### PR TITLE
@W-16265033 [MlModels] Revert some top-level types from metadata registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -339,9 +339,6 @@
     "mktDataTranObject": "mktdatatranobject",
     "mlDataDefinition": "mldatadefinition",
     "mlDomain": "mldomain",
-    "mlModel": "mlmodelartifact",
-    "mlModelConnection": "mlmodelconnection",
-    "mlModelSchema": "mlmodelschema",
     "mlPrediction": "mlpredictiondefinition",
     "mlRecommendation": "mlrecommendationdefinition",
     "mobSecurityCertPinConfig": "mobsecuritycertpinconfig",
@@ -3064,30 +3061,6 @@
       "inFolder": false,
       "name": "MlDomain",
       "suffix": "mlDomain"
-    },
-    "mlmodelartifact": {
-      "directoryName": "mlModels",
-      "id": "mlmodelartifact",
-      "inFolder": false,
-      "name": "MlModelArtifact",
-      "strictDirectoryName": false,
-      "suffix": "mlModel"
-    },
-    "mlmodelconnection": {
-      "directoryName": "mlModelConnections",
-      "id": "mlmodelconnection",
-      "inFolder": false,
-      "name": "MlModelConnection",
-      "strictDirectoryName": false,
-      "suffix": "mlModelConnection"
-    },
-    "mlmodelschema": {
-      "directoryName": "mlModelSchemas",
-      "id": "mlmodelschema",
-      "inFolder": false,
-      "name": "MlModelSchema",
-      "strictDirectoryName": false,
-      "suffix": "mlModelSchema"
     },
     "mlpredictiondefinition": {
       "directoryName": "mlPredictions",


### PR DESCRIPTION
Revert metadata registries for mlmodelartifact, mlmodelconnection and mlmodelschema top level components
@W-15020853@

Functionality Before:
Able to use CLI commands for deploying/retrieving ml-model metadata in test orgs ONLY.

Functionality After:
NOT able to use CLI commands for deploying/retrieving ml-model metadata anywhere.
