### PR TITLE
fix: manifests for custom object can omit parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.2.1",
+    "@salesforce/core": "^8.2.3",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/ts-types": "^2.0.10",
     "fast-levenshtein": "^3.0.0",
@@ -39,8 +39,8 @@
     "proxy-agent": "^6.4.0"
   },
   "devDependencies": {
-    "@jsforce/jsforce-node": "^3.2.4",
-    "@salesforce/cli-plugins-testkit": "^5.3.18",
+    "@jsforce/jsforce-node": "^3.3.1",
+    "@salesforce/cli-plugins-testkit": "^5.3.19",
     "@salesforce/dev-scripts": "^10.2.2",
     "@types/deep-equal-in-any-order": "^1.0.1",
     "@types/fast-levenshtein": "^0.0.4",

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -406,64 +406,41 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
    * @returns Object representation of a package manifest
    */
   public async getObject(destructiveType?: DestructiveChangesType): Promise<PackageManifestObject> {
-    const version = await this.getApiVersion();
-
     // If this ComponentSet has components marked for delete, we need to
     // only include those components in a destructiveChanges.xml and
     // all other components in the regular manifest.
-    let components = this.components;
-    if (this.getTypesOfDestructiveChanges().length) {
-      components = destructiveType ? this.destructiveComponents[destructiveType] : this.manifestComponents;
-    }
+    const components = this.getTypesOfDestructiveChanges().length
+      ? destructiveType
+        ? this.destructiveComponents[destructiveType]
+        : this.manifestComponents
+      : this.components;
 
     const typeMap = new Map<string, string[]>();
 
-    const addToTypeMap = (type: MetadataType, fullName: string): void => {
-      if (type.isAddressable !== false) {
-        const typeName = type.name;
-        if (!typeMap.has(typeName)) {
-          typeMap.set(typeName, []);
-        }
-        const typeEntry = typeMap.get(typeName);
-        if (fullName === ComponentSet.WILDCARD && !type.supportsWildcardAndName && !destructiveType) {
-          // if the type doesn't support mixed wildcards and specific names, overwrite the names to be a wildcard
-          typeMap.set(typeName, [fullName]);
-        } else if (
-          typeEntry &&
-          !typeEntry.includes(fullName) &&
-          (!typeEntry.includes(ComponentSet.WILDCARD) || type.supportsWildcardAndName)
-        ) {
-          // if the type supports both wildcards and names, add them regardless
-          typeMap.get(typeName)?.push(fullName);
-        }
-      }
-    };
-
-    for (const key of components.keys()) {
+    [...components.entries()].map(([key, cmpMap]) => {
       const [typeId, fullName] = splitOnFirstDelimiter(key);
-      let type = this.registry.getTypeByName(typeId);
-
-      if (type.folderContentType) {
-        type = this.registry.getTypeByName(type.folderContentType);
-      }
-      addToTypeMap(
-        type,
-        // they're reassembled like CustomLabels.MyLabel
-        this.registry.getParentType(type.name)?.strategies?.recomposition === 'startEmpty' && fullName.includes('.')
-          ? fullName.split('.')[1]
-          : fullName
-      );
+      const type = this.registry.getTypeByName(typeId);
 
       // Add children
-      const componentMap = components.get(key);
-      if (componentMap) {
-        for (const comp of componentMap.values()) {
-          for (const child of comp.getChildren()) {
-            addToTypeMap(child.type, child.fullName);
-          }
-        }
-      }
-    }
+      [...(cmpMap?.values() ?? [])]
+        .flatMap((c) => c.getChildren())
+        .map((child) => addToTypeMap({ typeMap, type: child.type, fullName: child.fullName, destructiveType }));
+
+      // new logic: if this is a decomposed type, we have to determine whether
+      // 2. skip its inclusion in the manifest if
+      // 3. every element from its xml is an addressable child and is in the cs (ex: it's only CustomField)
+
+      addToTypeMap({
+        typeMap,
+        type: type.folderContentType ? this.registry.getTypeByName(type.folderContentType) : type,
+        fullName:
+          this.registry.getParentType(type.name)?.strategies?.recomposition === 'startEmpty' && fullName.includes('.')
+            ? // they're reassembled like CustomLabels.MyLabel
+              fullName.split('.')[1]
+            : fullName,
+        destructiveType,
+      });
+    });
 
     const typeMembers = Array.from(typeMap.entries())
       .map(([typeName, members]) => ({ members: members.sort(), name: typeName }))
@@ -473,7 +450,7 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       Package: {
         ...{
           types: typeMembers,
-          version,
+          version: await this.getApiVersion(),
         },
         ...(this.fullName ? { fullName: this.fullName } : {}),
       },
@@ -749,4 +726,35 @@ const simpleKey = (component: ComponentLike): string => {
 const splitOnFirstDelimiter = (input: string): [string, string] => {
   const indexOfSplitChar = input.indexOf(KEY_DELIMITER);
   return [input.substring(0, indexOfSplitChar), input.substring(indexOfSplitChar + 1)];
+};
+
+/** side effect: mutates the typeMap property */
+const addToTypeMap = ({
+  typeMap,
+  type,
+  fullName,
+  destructiveType,
+}: {
+  typeMap: Map<string, string[]>;
+  type: MetadataType;
+  fullName: string;
+  destructiveType?: DestructiveChangesType;
+}): void => {
+  if (type.isAddressable === false) return;
+  const typeName = type.name;
+  if (!typeMap.has(typeName)) {
+    typeMap.set(typeName, []);
+  }
+  const typeEntry = typeMap.get(typeName);
+  if (fullName === ComponentSet.WILDCARD && !type.supportsWildcardAndName && !destructiveType) {
+    // if the type doesn't support mixed wildcards and specific names, overwrite the names to be a wildcard
+    typeMap.set(typeName, [fullName]);
+  } else if (
+    typeEntry &&
+    !typeEntry.includes(fullName) &&
+    (!typeEntry.includes(ComponentSet.WILDCARD) || type.supportsWildcardAndName)
+  ) {
+    // if the type supports both wildcards and names, add them regardless
+    typeMap.get(typeName)?.push(fullName);
+  }
 };

--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -431,7 +431,8 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       if (
         type.strategies?.transformer === 'decomposed' &&
         // exclude (ex: CustomObjectTranslation) where there are no addressable children
-        Object.values(type.children?.types ?? {}).every((t) => t.unaddressableWithoutParent !== true)
+        Object.values(type.children?.types ?? {}).some((t) => t.unaddressableWithoutParent !== true) &&
+        Object.values(type.children?.types ?? {}).some((t) => t.isAddressable !== false)
       ) {
         const parentComp = [...(cmpMap?.values() ?? [])].find((c) => c.fullName === fullName);
         if (parentComp?.xml && !objectHasSomeRealValues(type)(parentComp.parseXmlSync())) {

--- a/src/convert/convertContext/recompositionFinalizer.ts
+++ b/src/convert/convertContext/recompositionFinalizer.ts
@@ -7,7 +7,7 @@
 import { join } from 'node:path';
 import { JsonMap } from '@salesforce/ts-types';
 import { Messages } from '@salesforce/core';
-import { extractUniqueElementValue, getXmlElement } from '../../utils/decomposed';
+import { extractUniqueElementValue, getXmlElement, unwrapAndOmitNS } from '../../utils/decomposed';
 import { MetadataComponent } from '../../resolve/types';
 import { XML_NS_KEY, XML_NS_URL } from '../../common/constants';
 import { ComponentSet } from '../../collections/componentSet';
@@ -199,19 +199,3 @@ const getXmlFromCache =
     }
     return xmlCache.get(key) ?? {};
   };
-
-/** composed function, exported from module for test */
-export const unwrapAndOmitNS =
-  (outerType: string) =>
-  (xml: JsonMap): JsonMap =>
-    omitNsKey(unwrapXml(outerType)(xml));
-
-/** Remove the namespace key from the json object.  Only the parent needs one */
-const omitNsKey = (obj: JsonMap): JsonMap =>
-  Object.fromEntries(Object.entries(obj).filter(([key]) => key !== XML_NS_KEY)) as JsonMap;
-
-const unwrapXml =
-  (outerType: string) =>
-  (xml: JsonMap): JsonMap =>
-    // assert that the outerType is also a metadata type name (ex: CustomObject)
-    (xml[outerType] as JsonMap) ?? xml;

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -12,7 +12,7 @@ import { ensureArray } from '@salesforce/kit';
 import { Messages } from '@salesforce/core';
 import { calculateRelativePath } from '../../utils/path';
 import { ForceIgnore } from '../../resolve/forceIgnore';
-import { extractUniqueElementValue } from '../../utils/decomposed';
+import { extractUniqueElementValue, objectHasSomeRealValues } from '../../utils/decomposed';
 import type { MetadataComponent } from '../../resolve/types';
 import { DecompositionStrategy, type MetadataType } from '../../registry/types';
 import { SourceComponent } from '../../resolve/sourceComponent';
@@ -24,7 +24,7 @@ import { ComponentSet } from '../../collections/componentSet';
 import type { DecompositionState, DecompositionStateValue } from '../convertContext/decompositionFinalizer';
 import { BaseMetadataTransformer } from './baseMetadataTransformer';
 
-type XmlObj = { [index: string]: { [XML_NS_KEY]: typeof XML_NS_URL } & JsonMap };
+export type XmlObj = { [index: string]: { [XML_NS_KEY]: typeof XML_NS_URL } & JsonMap };
 type StateSetter = (forComponent: MetadataComponent, props: Partial<Omit<DecompositionStateValue, 'origin'>>) => void;
 
 Messages.importMessagesDirectory(__dirname);
@@ -271,12 +271,6 @@ const getDefaultOutput = (component: MetadataComponent): SourcePath => {
 const tagToChildTypeId = ({ tagKey, type }: { tagKey: string; type: MetadataType }): string | undefined =>
   Object.values(type.children?.types ?? {}).find((c) => c.xmlElementName === tagKey)?.id ??
   type.children?.directories?.[tagKey];
-
-/** Ex: CustomObject: { '@_xmlns': 'http://soap.sforce.com/2006/04/metadata' } has no real values */
-const objectHasSomeRealValues =
-  (type: MetadataType) =>
-  (obj: XmlObj): boolean =>
-    Object.keys(obj[type.name] ?? {}).length > 1;
 
 const hasChildTypeId = (cm: ComposedMetadata): cm is Required<ComposedMetadata> => !!cm.childTypeId;
 

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -17,14 +17,13 @@ import type { MetadataComponent } from '../../resolve/types';
 import { DecompositionStrategy, type MetadataType } from '../../registry/types';
 import { SourceComponent } from '../../resolve/sourceComponent';
 import { JsToXml } from '../streams';
-import type { WriteInfo } from '../types';
+import type { WriteInfo, XmlObj } from '../types';
 import { META_XML_SUFFIX, XML_NS_KEY, XML_NS_URL } from '../../common/constants';
 import type { SourcePath } from '../../common/types';
 import { ComponentSet } from '../../collections/componentSet';
 import type { DecompositionState, DecompositionStateValue } from '../convertContext/decompositionFinalizer';
 import { BaseMetadataTransformer } from './baseMetadataTransformer';
 
-export type XmlObj = { [index: string]: { [XML_NS_KEY]: typeof XML_NS_URL } & JsonMap };
 type StateSetter = (forComponent: MetadataComponent, props: Partial<Omit<DecompositionStateValue, 'origin'>>) => void;
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/convert/types.ts
+++ b/src/convert/types.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Readable } from 'node:stream';
+import { JsonMap } from '@salesforce/ts-types';
+import { XML_NS_KEY, XML_NS_URL } from '../common/constants';
 import { FileResponseSuccess } from '../client/types';
 import { SourcePath } from '../common/types';
 import { MetadataComponent, SourceComponent } from '../resolve';
@@ -153,3 +155,4 @@ export type ReplacementEvent = {
   filename: string;
   replaced: string;
 };
+export type XmlObj = { [index: string]: { [XML_NS_KEY]: typeof XML_NS_URL } & JsonMap };

--- a/src/registry/presets/decomposeWorkflowBeta.json
+++ b/src/registry/presets/decomposeWorkflowBeta.json
@@ -39,17 +39,17 @@
           "workflowalert": {
             "directoryName": "workflowAlerts",
             "id": "workflowalert",
+            "isAddressable": false,
             "name": "WorkflowAlert",
             "suffix": "workflowAlert",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "alerts"
           },
           "workflowfieldupdate": {
             "directoryName": "workflowFieldUpdates",
             "id": "workflowfieldupdate",
+            "isAddressable": false,
             "name": "WorkflowFieldUpdate",
             "suffix": "workflowFieldUpdate",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "fieldUpdates"
           },
           "workflowknowledgepublish": {

--- a/src/registry/presets/decomposeWorkflowBeta.json
+++ b/src/registry/presets/decomposeWorkflowBeta.json
@@ -55,41 +55,41 @@
           "workflowknowledgepublish": {
             "directoryName": "workflowKnowledgePublishes",
             "id": "workflowknowledgepublish",
+            "isAddressable": false,
             "name": "WorkflowKnowledgePublish",
             "suffix": "workflowKnowledgePublish",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "knowledgePublishes"
           },
           "workflowoutboundmessage": {
             "directoryName": "workflowOutboundMessages",
             "id": "workflowoutboundmessage",
+            "isAddressable": false,
             "name": "WorkflowOutboundMessage",
             "suffix": "workflowOutboundMessage",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "outboundMessages"
           },
           "workflowrule": {
             "directoryName": "workflowRules",
             "id": "workflowrule",
+            "isAddressable": false,
             "name": "WorkflowRule",
             "suffix": "workflowRule",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "rules"
           },
           "workflowsend": {
             "directoryName": "workflowSends",
             "id": "workflowsend",
+            "isAddressable": false,
             "name": "WorkflowSend",
             "suffix": "workflowSend",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "send"
           },
           "workflowtask": {
             "directoryName": "workflowTasks",
             "id": "workflowtask",
+            "isAddressable": false,
             "name": "WorkflowTask",
             "suffix": "workflowTask",
-            "unaddressableWithoutParent": true,
             "xmlElementName": "tasks"
           }
         }

--- a/src/registry/presets/decomposeWorkflowBeta.json
+++ b/src/registry/presets/decomposeWorkflowBeta.json
@@ -41,6 +41,7 @@
             "id": "workflowalert",
             "name": "WorkflowAlert",
             "suffix": "workflowAlert",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "alerts"
           },
           "workflowfieldupdate": {
@@ -48,6 +49,7 @@
             "id": "workflowfieldupdate",
             "name": "WorkflowFieldUpdate",
             "suffix": "workflowFieldUpdate",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "fieldUpdates"
           },
           "workflowknowledgepublish": {
@@ -55,6 +57,7 @@
             "id": "workflowknowledgepublish",
             "name": "WorkflowKnowledgePublish",
             "suffix": "workflowKnowledgePublish",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "knowledgePublishes"
           },
           "workflowoutboundmessage": {
@@ -62,6 +65,7 @@
             "id": "workflowoutboundmessage",
             "name": "WorkflowOutboundMessage",
             "suffix": "workflowOutboundMessage",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "outboundMessages"
           },
           "workflowrule": {
@@ -69,6 +73,7 @@
             "id": "workflowrule",
             "name": "WorkflowRule",
             "suffix": "workflowRule",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "rules"
           },
           "workflowsend": {
@@ -76,6 +81,7 @@
             "id": "workflowsend",
             "name": "WorkflowSend",
             "suffix": "workflowSend",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "send"
           },
           "workflowtask": {
@@ -83,6 +89,7 @@
             "id": "workflowtask",
             "name": "WorkflowTask",
             "suffix": "workflowTask",
+            "unaddressableWithoutParent": true,
             "xmlElementName": "tasks"
           }
         }

--- a/src/utils/decomposed.ts
+++ b/src/utils/decomposed.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { JsonMap, getString } from '@salesforce/ts-types';
-import { XmlObj } from '../convert/transformers/decomposedMetadataTransformer';
+import { XmlObj } from '../convert/types';
 import { XML_NS_KEY } from '../common/constants';
 import { MetadataType } from '../registry/types';
 

--- a/src/utils/decomposed.ts
+++ b/src/utils/decomposed.ts
@@ -5,7 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { JsonMap, getString } from '@salesforce/ts-types';
+import { XmlObj } from '../convert/transformers/decomposedMetadataTransformer';
+import { XML_NS_KEY } from '../common/constants';
 import { MetadataType } from '../registry/types';
+
 /** handle wide-open reading of values from elements inside any metadata xml file...we don't know the type
  * Return the value of the matching element if supplied, or defaults `fullName` then `name`  */
 export const extractUniqueElementValue = (xml: JsonMap, uniqueId?: string): string | undefined =>
@@ -16,3 +19,25 @@ const getStandardElements = (xml: JsonMap): string | undefined =>
 
 /** @returns xmlElementName if specified, otherwise returns the directoryName */
 export const getXmlElement = (mdType: MetadataType): string => mdType.xmlElementName ?? mdType.directoryName;
+/** composed function, exported from module for test */
+
+export const unwrapAndOmitNS =
+  (outerType: string) =>
+  (xml: JsonMap): JsonMap =>
+    omitNsKey(unwrapXml(outerType)(xml));
+
+/** Remove the namespace key from the json object.  Only the parent needs one */
+const omitNsKey = (obj: JsonMap): JsonMap =>
+  Object.fromEntries(Object.entries(obj).filter(([key]) => key !== XML_NS_KEY)) as JsonMap;
+
+const unwrapXml =
+  (outerType: string) =>
+  (xml: JsonMap): JsonMap =>
+    // assert that the outerType is also a metadata type name (ex: CustomObject)
+    (xml[outerType] as JsonMap) ?? xml;
+
+/** Ex: CustomObject: { '@_xmlns': 'http://soap.sforce.com/2006/04/metadata' } has no real values */
+export const objectHasSomeRealValues =
+  (type: MetadataType) =>
+  (obj: XmlObj): boolean =>
+    Object.keys(obj[type.name] ?? {}).length > 1;

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -11,6 +11,11 @@ import { assert, expect } from 'chai';
 import { SinonStub } from 'sinon';
 import { AuthInfo, ConfigAggregator, Connection, Lifecycle, Messages, SfProject } from '@salesforce/core';
 import {
+  DECOMPOSED_CHILD_COMPONENT_1_EMPTY,
+  DECOMPOSED_CHILD_COMPONENT_2_EMPTY,
+  DECOMPOSED_COMPONENT_EMPTY,
+} from '../mock/type-constants/customObjectConstantEmptyObjectMeta';
+import {
   ComponentSet,
   ComponentSetBuilder,
   ConnectionResolver,
@@ -972,6 +977,26 @@ describe('ComponentSet', () => {
         {
           name: 'CustomField',
           members: ['MyParent__c.Child__c'],
+        },
+      ]);
+    });
+
+    it('omits empty parents from the package manifest', async () => {
+      const set = new ComponentSet([
+        DECOMPOSED_CHILD_COMPONENT_1_EMPTY,
+        DECOMPOSED_CHILD_COMPONENT_2_EMPTY,
+        DECOMPOSED_COMPONENT_EMPTY,
+      ]);
+      const types = (await set.getObject()).Package.types;
+      expect(types.map((type) => type.name)).to.not.include(DECOMPOSED_COMPONENT_EMPTY.type.name);
+      expect((await set.getObject()).Package.types).to.deep.equal([
+        {
+          name: DECOMPOSED_CHILD_COMPONENT_1_EMPTY.type.name,
+          members: [DECOMPOSED_CHILD_COMPONENT_1_EMPTY.fullName],
+        },
+        {
+          name: DECOMPOSED_CHILD_COMPONENT_2_EMPTY.type.name,
+          members: [DECOMPOSED_CHILD_COMPONENT_2_EMPTY.fullName],
         },
       ]);
     });

--- a/test/convert/convertContext/recomposition.test.ts
+++ b/test/convert/convertContext/recomposition.test.ts
@@ -7,7 +7,7 @@
 import { join } from 'node:path';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
-import { unwrapAndOmitNS } from '../../../src/convert/convertContext/recompositionFinalizer';
+import { unwrapAndOmitNS } from '../../../src/utils/decomposed';
 import { decomposed, nonDecomposed } from '../../mock';
 import { ConvertContext } from '../../../src/convert/convertContext/convertContext';
 import { ComponentSet } from '../../../src/collections/componentSet';

--- a/test/convert/transformers/decomposedMetadataTransformer.test.ts
+++ b/test/convert/transformers/decomposedMetadataTransformer.test.ts
@@ -454,7 +454,7 @@ describe('DecomposedMetadataTransformer', () => {
     describe('Merging Components', () => {
       it('should merge output with merge component that only has children', async () => {
         assert(registry.types.customobject.children?.types.customfield.name);
-        const mergeComponentChild = component.getChildren()[0];
+        const mergeComponentChild = component.getChildren()[1];
         assert(mergeComponentChild.parent);
         const componentToConvert = SourceComponent.createVirtualComponent(
           {

--- a/test/mock/type-constants/customObjectConstantEmptyObjectMeta.ts
+++ b/test/mock/type-constants/customObjectConstantEmptyObjectMeta.ts
@@ -4,11 +4,23 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { join } from 'node:path';
 import { assert } from 'chai';
 import { baseName } from '../../../src/utils';
 import { registry, SourceComponent, VirtualDirectory } from '../../../src';
 import { XML_NS_URL } from '../../../src/common';
+import {
+  DECOMPOSED_CHILD_DIR_1_PATH,
+  DECOMPOSED_CHILD_DIR,
+  DECOMPOSED_CHILD_DIR_1,
+  DECOMPOSED_CHILD_DIR_PATH,
+  DECOMPOSED_CHILD_XML_NAME_2,
+  DECOMPOSED_PATH,
+  DECOMPOSED_XML_PATH,
+  DECOMPOSED_CHILD_XML_PATH_1,
+  DECOMPOSED_XML_NAME,
+  DECOMPOSED_CHILD_XML_PATH_2,
+  DECOMPOSED_CHILD_XML_NAME_1,
+} from './customObjectConstant';
 
 // Constants for a decomposed type
 const type = registry.types.customobject;
@@ -16,29 +28,13 @@ const type = registry.types.customobject;
 assert(type.children?.types.validationrule);
 assert(type.children.types.customfield);
 
-export const DECOMPOSEDS_PATH = join('path', 'to', 'objects');
-export const DECOMPOSED_PATH = join(DECOMPOSEDS_PATH, 'customObject__c');
-export const DECOMPOSED_XML_NAME = 'customObject__c.object-meta.xml';
-export const DECOMPOSED_XML_PATH = join(DECOMPOSED_PATH, DECOMPOSED_XML_NAME);
-
-export const DECOMPOSED_CHILD_DIR = 'validationRules';
-export const DECOMPOSED_CHILD_DIR_1 = 'fields';
-
-export const DECOMPOSED_CHILD_DIR_PATH = join(DECOMPOSED_PATH, DECOMPOSED_CHILD_DIR);
-export const DECOMPOSED_CHILD_DIR_1_PATH = join(DECOMPOSED_PATH, DECOMPOSED_CHILD_DIR_1);
-
-export const DECOMPOSED_CHILD_XML_NAME_2 = 'myValidationRule.validationRule-meta.xml';
-export const DECOMPOSED_CHILD_XML_PATH_2 = join(DECOMPOSED_CHILD_DIR_PATH, DECOMPOSED_CHILD_XML_NAME_2);
-
-export const DECOMPOSED_CHILD_XML_NAME_1 = 'Fields__c.field-meta.xml';
-export const DECOMPOSED_CHILD_XML_PATH_1 = join(DECOMPOSED_CHILD_DIR_1_PATH, DECOMPOSED_CHILD_XML_NAME_1);
-export const DECOMPOSED_VIRTUAL_FS: VirtualDirectory[] = [
+export const DECOMPOSED_VIRTUAL_FS_EMPTY: VirtualDirectory[] = [
   {
     dirPath: DECOMPOSED_PATH,
     children: [
       {
         name: DECOMPOSED_XML_NAME,
-        data: Buffer.from(`<CustomObject xmlns="${XML_NS_URL}"><fullName>customObject__c</fullName></CustomObject>`),
+        data: Buffer.from(`<CustomObject xmlns="${XML_NS_URL}"></CustomObject>`),
       },
 
       DECOMPOSED_CHILD_DIR,
@@ -64,31 +60,32 @@ export const DECOMPOSED_VIRTUAL_FS: VirtualDirectory[] = [
     ],
   },
 ];
-export const DECOMPOSED_COMPONENT = SourceComponent.createVirtualComponent(
+export const DECOMPOSED_COMPONENT_EMPTY = SourceComponent.createVirtualComponent(
   {
     name: baseName(DECOMPOSED_XML_PATH),
     type,
     xml: DECOMPOSED_XML_PATH,
     content: DECOMPOSED_PATH,
   },
-  DECOMPOSED_VIRTUAL_FS
+  DECOMPOSED_VIRTUAL_FS_EMPTY
 );
 
-export const DECOMPOSED_CHILD_COMPONENT_1 = SourceComponent.createVirtualComponent(
+export const DECOMPOSED_CHILD_COMPONENT_1_EMPTY = SourceComponent.createVirtualComponent(
   {
     name: baseName(DECOMPOSED_CHILD_XML_NAME_1),
     type: type.children.types.customfield,
     xml: DECOMPOSED_CHILD_XML_PATH_1,
-    parent: DECOMPOSED_COMPONENT,
+    parent: DECOMPOSED_COMPONENT_EMPTY,
   },
-  DECOMPOSED_VIRTUAL_FS
+  DECOMPOSED_VIRTUAL_FS_EMPTY
 );
-export const DECOMPOSED_CHILD_COMPONENT_2 = SourceComponent.createVirtualComponent(
+
+export const DECOMPOSED_CHILD_COMPONENT_2_EMPTY = SourceComponent.createVirtualComponent(
   {
     name: baseName(DECOMPOSED_CHILD_XML_NAME_2),
     type: type.children.types.validationrule,
     xml: DECOMPOSED_CHILD_XML_PATH_2,
-    parent: DECOMPOSED_COMPONENT,
+    parent: DECOMPOSED_COMPONENT_EMPTY,
   },
-  DECOMPOSED_VIRTUAL_FS
+  DECOMPOSED_VIRTUAL_FS_EMPTY
 );

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -370,7 +370,9 @@ describe('SourceComponent', () => {
     );
 
     it('should return child components for a component', () => {
-      expect(decomposed.DECOMPOSED_COMPONENT.getChildren()).to.deep.equal([expectedChild, expectedChild2]);
+      const children = decomposed.DECOMPOSED_COMPONENT.getChildren();
+      expect(children).to.deep.include(expectedChild);
+      expect(children).to.deep.include(expectedChild2);
     });
 
     it('should not include children that are forceignored', () => {

--- a/test/snapshot/sampleProjects/preset-workflow-mpd/__snapshots__/verify-md-files.expected/package.xml
+++ b/test/snapshot/sampleProjects/preset-workflow-mpd/__snapshots__/verify-md-files.expected/package.xml
@@ -4,11 +4,5 @@
         <members>Case</members>
         <name>Workflow</name>
     </types>
-    <types>
-        <members>Case.ChangePriorityToHigh</members>
-        <members>Case.ChangePriorityToLow</members>
-        <members>Case.ChangePriorityToMedium</members>
-        <name>WorkflowFieldUpdate</name>
-    </types>
     <version>60.0</version>
 </Package>

--- a/test/snapshot/sampleProjects/preset-workflow/__snapshots__/verify-md-files.expected/package.xml
+++ b/test/snapshot/sampleProjects/preset-workflow/__snapshots__/verify-md-files.expected/package.xml
@@ -8,21 +8,5 @@
         <members>Account</members>
         <name>Workflow</name>
     </types>
-    <types>
-        <members>Account.emailalert1</members>
-        <name>WorkflowAlert</name>
-    </types>
-    <types>
-        <members>Account.fieldupdate1</members>
-        <name>WorkflowFieldUpdate</name>
-    </types>
-    <types>
-        <members>Account.outboundmsg1</members>
-        <name>WorkflowOutboundMessage</name>
-    </types>
-    <types>
-        <members>Account.task_1</members>
-        <name>WorkflowTask</name>
-    </types>
     <version>60.0</version>
 </Package>

--- a/test/snapshot/sampleProjects/variant-workflow/__snapshots__/verify-md-files.expected/package.xml
+++ b/test/snapshot/sampleProjects/variant-workflow/__snapshots__/verify-md-files.expected/package.xml
@@ -8,21 +8,5 @@
         <members>Account</members>
         <name>Workflow</name>
     </types>
-    <types>
-        <members>Account.emailalert1</members>
-        <name>WorkflowAlert</name>
-    </types>
-    <types>
-        <members>Account.fieldupdate1</members>
-        <name>WorkflowFieldUpdate</name>
-    </types>
-    <types>
-        <members>Account.outboundmsg1</members>
-        <name>WorkflowOutboundMessage</name>
-    </types>
-    <types>
-        <members>Account.task_1</members>
-        <name>WorkflowTask</name>
-    </types>
     <version>60.0</version>
 </Package>

--- a/test/snapshot/sampleProjects/variant-workflow/sfdx-project.json
+++ b/test/snapshot/sampleProjects/variant-workflow/sfdx-project.json
@@ -47,6 +47,7 @@
               "id": "workflowalert",
               "name": "WorkflowAlert",
               "suffix": "workflowAlert",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "alerts"
             },
             "workflowfieldupdate": {
@@ -54,6 +55,7 @@
               "id": "workflowfieldupdate",
               "name": "WorkflowFieldUpdate",
               "suffix": "workflowFieldUpdate",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "fieldUpdates"
             },
             "workflowknowledgepublish": {
@@ -61,6 +63,7 @@
               "id": "workflowknowledgepublish",
               "name": "WorkflowKnowledgePublish",
               "suffix": "workflowKnowledgePublish",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "knowledgePublishes"
             },
             "workflowoutboundmessage": {
@@ -68,6 +71,7 @@
               "id": "workflowoutboundmessage",
               "name": "WorkflowOutboundMessage",
               "suffix": "workflowOutboundMessage",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "outboundMessages"
             },
             "workflowrule": {
@@ -75,6 +79,7 @@
               "id": "workflowrule",
               "name": "WorkflowRule",
               "suffix": "workflowRule",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "rules"
             },
             "workflowsend": {
@@ -82,6 +87,7 @@
               "id": "workflowsend",
               "name": "WorkflowSend",
               "suffix": "workflowSend",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "send"
             },
             "workflowtask": {
@@ -89,6 +95,7 @@
               "id": "workflowtask",
               "name": "WorkflowTask",
               "suffix": "workflowTask",
+              "unaddressableWithoutParent": true,
               "xmlElementName": "tasks"
             }
           }

--- a/test/snapshot/sampleProjects/variant-workflow/sfdx-project.json
+++ b/test/snapshot/sampleProjects/variant-workflow/sfdx-project.json
@@ -20,6 +20,9 @@
     "strictDirectoryNames": {
       "workflows": "workflow"
     },
+    "suffixes": {
+      "workflow": "workflow"
+    },
     "types": {
       "workflow": {
         "children": {
@@ -45,57 +48,57 @@
             "workflowalert": {
               "directoryName": "workflowAlerts",
               "id": "workflowalert",
+              "isAddressable": false,
               "name": "WorkflowAlert",
               "suffix": "workflowAlert",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "alerts"
             },
             "workflowfieldupdate": {
               "directoryName": "workflowFieldUpdates",
               "id": "workflowfieldupdate",
+              "isAddressable": false,
               "name": "WorkflowFieldUpdate",
               "suffix": "workflowFieldUpdate",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "fieldUpdates"
             },
             "workflowknowledgepublish": {
               "directoryName": "workflowKnowledgePublishes",
               "id": "workflowknowledgepublish",
+              "isAddressable": false,
               "name": "WorkflowKnowledgePublish",
               "suffix": "workflowKnowledgePublish",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "knowledgePublishes"
             },
             "workflowoutboundmessage": {
               "directoryName": "workflowOutboundMessages",
               "id": "workflowoutboundmessage",
+              "isAddressable": false,
               "name": "WorkflowOutboundMessage",
               "suffix": "workflowOutboundMessage",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "outboundMessages"
             },
             "workflowrule": {
               "directoryName": "workflowRules",
               "id": "workflowrule",
+              "isAddressable": false,
               "name": "WorkflowRule",
               "suffix": "workflowRule",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "rules"
             },
             "workflowsend": {
               "directoryName": "workflowSends",
               "id": "workflowsend",
+              "isAddressable": false,
               "name": "WorkflowSend",
               "suffix": "workflowSend",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "send"
             },
             "workflowtask": {
               "directoryName": "workflowTasks",
               "id": "workflowtask",
+              "isAddressable": false,
               "name": "WorkflowTask",
               "suffix": "workflowTask",
-              "unaddressableWithoutParent": true,
               "xmlElementName": "tasks"
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,25 @@
     strip-ansi "^6.0.0"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.3.1.tgz#e6a3a6e892a0067e0afbb4f19b50f459efbf96a0"
+  integrity sha512-wLIQhU3X+ltZFItdQ8XMr2kqB70S2q4ukSELneCDQkDXlzRIqhQ7rZP4jcmcdT0r6Tc/8lvlw2s2paPxossRBA==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    "@types/node" "^18.15.3"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.4.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    https-proxy-agent "^5.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    strip-ansi "^6.0.0"
+    xml2js "^0.6.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -548,12 +567,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/cli-plugins-testkit@^5.3.18":
-  version "5.3.18"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.18.tgz#f36ae6ed8573b18396668a4d38b4effe0bd1a2bf"
-  integrity sha512-9+Yvmw5idIQryJcXVKZ2HASLKj2RUJizDuDFPq5ut9X+8y8MTWAkO0hO6OSj3IPkV+LTo8QF7QOCl16R2PWpMw==
+"@salesforce/cli-plugins-testkit@^5.3.19":
+  version "5.3.19"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.19.tgz#495e7516a6046c42fc7cf60b11894d8922dd01aa"
+  integrity sha512-4mRlszh1q6bPw7dF4EHbYJ2IFxAanzKBbauZ5pSUHt+++otASmANoPc3TZ4CzNDG3rbt+5qFLnhhaQWMli0Nqw==
   dependencies:
-    "@salesforce/core" "^8.1.1"
+    "@salesforce/core" "^8.2.1"
     "@salesforce/kit" "^3.1.6"
     "@salesforce/ts-types" "^2.0.10"
     "@types/shelljs" "^0.8.15"
@@ -564,12 +583,36 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.1.1", "@salesforce/core@^8.2.1":
+"@salesforce/core@^8.2.1":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.2.1.tgz#16b383886ec02ee9a99f815d5ce4a9f5a492295e"
   integrity sha512-juLxb4t12vZD9ozkhKhGtbZzOiYkEcUWdw+gAtgzuSrTFTwvoXlbKtzdGbdYPLTHLGYQCVW6cRdMswfwbE5BnQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.3"
+    "@salesforce/kit" "^3.1.6"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.2.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.2.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.2"
+    ts-retry-promise "^0.8.1"
+
+"@salesforce/core@^8.2.3":
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.2.3.tgz#4714e5ca046c6fcdcffb91aad151affa9e7a0e88"
+  integrity sha512-epkV2ZU+WQFgxb6q98+9vAp9Qo1bUnCOyk1VyVr2XycJk6BkC0fBE188KpvH0/nqB2+0p2K4Cd3x1/+oC7HYvQ==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.2.4"
     "@salesforce/kit" "^3.1.6"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.10"
@@ -5032,16 +5075,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5100,14 +5134,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5601,7 +5628,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5614,15 +5641,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?

deploy -d of an entire folder including a blank CustomObject file causes the Object to be in the manifest.

Case 1: If the Object is in the manifest, the mdapi will validate that the Object metadata contains all the required fields.

Case 2: If the Object is not in the manifest (only one or more of its child types are) then the validation doesn't happen (only the child types are validated)

SDR, when generating the manifest, needs to ask if the top-level (ex: object.meta.xml) is effectively empty.  If so, that type should be omitted from the manifest (to get Case 2 behavior from the API)

### other changes
update some tests that were based on an invalid mock
update the workflow preset to make all children of workflow unaddressable

### What issues does this PR fix or reference?
@W-16273581@ (see inv)

