### PR TITLE
fix: recurse through dirs then files

### DIFF
--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -49,7 +49,8 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
       };
       if (component.xml && existing.component && !existing.component.xml) {
         // we've already found and created the parent of this component on L~38
-        // but now we have more information about the parent that we didn't have before, so add it
+        // but now we have more information about the parent (xml) that we didn't have before, so add it
+        // TODO: find way to determine which component has more information
         existing.component = component;
       }
       (component.getChildren() ?? []).map((child) => {

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -47,6 +47,11 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
         component,
         children: new ComponentSet([], this.registry),
       };
+      if (component.xml && existing.component && !existing.component.xml) {
+        // we've already found and created the parent of this component on L~38
+        // but now we have more information about the parent that we didn't have before, so add it
+        existing.component = component;
+      }
       (component.getChildren() ?? []).map((child) => {
         existing.children?.add(child);
       });

--- a/src/convert/transformers/decomposedMetadataTransformer.ts
+++ b/src/convert/transformers/decomposedMetadataTransformer.ts
@@ -50,7 +50,6 @@ export class DecomposedMetadataTransformer extends BaseMetadataTransformer {
       if (component.xml && existing.component && !existing.component.xml) {
         // we've already found and created the parent of this component on L~38
         // but now we have more information about the parent (xml) that we didn't have before, so add it
-        // TODO: find way to determine which component has more information
         existing.component = component;
       }
       (component.getChildren() ?? []).map((child) => {

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -81,15 +81,7 @@ export class MetadataResolver {
       .map(fnJoin(dir))
       // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
       // before finding the parent and returning only it - by sorting, we make it as recursive as possible
-      .sort((a, b) => {
-        if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
-          return 0;
-        } else if (this.tree.isDirectory(a) && !this.tree.isDirectory(b)) {
-          return -1;
-        } else {
-          return 1;
-        }
-      })) {
+      .sort(this.sortDirsFirst)) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -130,6 +122,15 @@ export class MetadataResolver {
     return components.concat(dirQueue.flatMap((d) => this.getComponentsFromPathRecursive(d, inclusiveFilter)));
   }
 
+  private sortDirsFirst = (a: string, b: string): number => {
+    if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
+      return 0;
+    } else if (this.tree.isDirectory(a) && !this.tree.isDirectory(b)) {
+      return -1;
+    } else {
+      return 1;
+    }
+  };
   private resolveComponent(fsPath: string, isResolvingSource: boolean): SourceComponent | undefined {
     if (this.forceIgnore?.denies(fsPath)) {
       // don't resolve the component if the path is denied

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -76,7 +76,7 @@ export class MetadataResolver {
       return components;
     }
 
-    for (const fsPath of this.tree.readDirectory(dir).map(fnJoin(dir))) {
+    for (const fsPath of this.tree.readDirectory(dir).map(fnJoin(dir)).reverse()) {
       if (ignore.has(fsPath)) {
         continue;
       }

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -63,6 +63,7 @@ export class MetadataResolver {
     return component ? [component] : [];
   }
 
+  // eslint-disable-next-line complexity
   private getComponentsFromPathRecursive(dir: string, inclusiveFilter?: ComponentSet): SourceComponent[] {
     const dirQueue: string[] = [];
     const components: SourceComponent[] = [];
@@ -76,7 +77,21 @@ export class MetadataResolver {
       return components;
     }
 
-    for (const fsPath of this.tree.readDirectory(dir).map(fnJoin(dir)).reverse()) {
+    const paths = this.tree
+      .readDirectory(dir)
+      .map(fnJoin(dir))
+      // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
+      // before finding the parent and returning only it
+      .sort((a, b) => {
+        if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
+          return 0;
+        } else if (this.tree.isDirectory(a) && !this.tree.isDirectory(b)) {
+          return -1;
+        } else {
+          return 1;
+        }
+      });
+    for (const fsPath of paths) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -104,11 +119,14 @@ export class MetadataResolver {
               }
             }
           }
-          // don't traverse further if not in a root type directory. performance optimization
+          // don't traverse further if not in a root type directory AND we've searched all file paths. performance optimization
           // for mixed content types and ensures we don't add duplicates of the component.
           const typeDir = basename(dirname(component.type.inFolder ? dirname(fsPath) : fsPath));
-          if (component.type.strictDirectoryName && typeDir !== component.type.directoryName) {
+          if (component.type.strictDirectoryName && typeDir !== component.type.directoryName && dirQueue.length === 0) {
             return components;
+          } else if (component.type.strictDirectoryName && typeDir !== component.type.directoryName) {
+            // we found the parent, but still have more dirs to look through
+            break;
           }
         }
       }

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -63,7 +63,6 @@ export class MetadataResolver {
     return component ? [component] : [];
   }
 
-  // eslint-disable-next-line complexity
   private getComponentsFromPathRecursive(dir: string, inclusiveFilter?: ComponentSet): SourceComponent[] {
     const dirQueue: string[] = [];
     const components: SourceComponent[] = [];
@@ -77,11 +76,11 @@ export class MetadataResolver {
       return components;
     }
 
-    const paths = this.tree
+    for (const fsPath of this.tree
       .readDirectory(dir)
       .map(fnJoin(dir))
       // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
-      // before finding the parent and returning only it
+      // before finding the parent and returning only it - by sorting, we make it as recursive as possible
       .sort((a, b) => {
         if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
           return 0;
@@ -90,8 +89,7 @@ export class MetadataResolver {
         } else {
           return 1;
         }
-      });
-    for (const fsPath of paths) {
+      })) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -119,14 +117,11 @@ export class MetadataResolver {
               }
             }
           }
-          // don't traverse further if not in a root type directory AND we've searched all file paths. performance optimization
+          // don't traverse further if not in a root type directory. performance optimization
           // for mixed content types and ensures we don't add duplicates of the component.
           const typeDir = basename(dirname(component.type.inFolder ? dirname(fsPath) : fsPath));
-          if (component.type.strictDirectoryName && typeDir !== component.type.directoryName && dirQueue.length === 0) {
+          if (component.type.strictDirectoryName && typeDir !== component.type.directoryName) {
             return components;
-          } else if (component.type.strictDirectoryName && typeDir !== component.type.directoryName) {
-            // we found the parent, but still have more dirs to look through
-            break;
           }
         }
       }

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -471,7 +471,7 @@ describe('ComponentSet', () => {
         const missingIndex = expected.findIndex((c) => c.fullName === 'c');
         expected.splice(missingIndex, 1);
 
-        expect(result).to.deep.equal(expected);
+        expect(result).to.have.deep.members(expected);
       });
 
       it('should resolve wildcard members by default', async () => {

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -471,7 +471,7 @@ describe('ComponentSet', () => {
         const missingIndex = expected.findIndex((c) => c.fullName === 'c');
         expected.splice(missingIndex, 1);
 
-        expect(result).to.have.deep.members(expected);
+        expect(result).to.deep.equal(expected);
       });
 
       it('should resolve wildcard members by default', async () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -45,6 +45,7 @@ import {
 } from '../mock/type-constants/staticresourceConstant';
 import { META_XML_SUFFIX } from '../../src/common';
 import { DE_METAFILE } from '../mock/type-constants/digitalExperienceBundleConstants';
+import { DECOMPOSED_TOP_LEVEL_XML_NAMES } from '../mock/type-constants/customObjectTranslationConstant';
 import { RegistryTestUtil } from './registryTestUtil';
 
 const testUtil = new RegistryTestUtil();
@@ -287,7 +288,7 @@ describe('MetadataResolver', () => {
             allowContent: false,
           },
         ]);
-        expect(access.getComponentsFromPath(path)).to.deep.equal(xmlInFolder.COMPONENTS);
+        expect(access.getComponentsFromPath(path)).to.have.deep.members(xmlInFolder.COMPONENTS);
       });
 
       it('Should determine type for folder files', () => {
@@ -453,7 +454,9 @@ describe('MetadataResolver', () => {
             componentMappings,
           },
         ]);
-        expect(resolver.getComponentsFromPath(xmlInFolder.COMPONENT_FOLDER_PATH)).to.deep.equal(xmlInFolder.COMPONENTS);
+        expect(resolver.getComponentsFromPath(xmlInFolder.COMPONENT_FOLDER_PATH)).to.have.deep.members(
+          xmlInFolder.COMPONENTS
+        );
       });
 
       it('Should walk all file and directory children', () => {
@@ -521,7 +524,7 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(apexDir)).to.deep.equal([
+        expect(access.getComponentsFromPath(apexDir)).to.have.deep.members([
           matchingContentFile.COMPONENT,
           reportComponent,
           apexComponentB,
@@ -550,7 +553,7 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(mixedContentInFolder.COMPONENT_FOLDER_PATH)).to.deep.equal([
+        expect(access.getComponentsFromPath(mixedContentInFolder.COMPONENT_FOLDER_PATH)).to.have.deep.members([
           mixedContentInFolder.COMPONENTS[0],
           mixedContentInFolder.COMPONENTS[1],
         ]);
@@ -634,7 +637,7 @@ describe('MetadataResolver', () => {
         expect(access.getComponentsFromPath(MIXED_CONTENT_DIRECTORY_DIR)).to.deep.equal([component]);
       });
 
-      it('should stop resolution if parent component is resolved', () => {
+      it('should NOT stop resolution if parent component is resolved', () => {
         const access = testUtil.createMetadataResolver(DECOMPOSED_VIRTUAL_FS);
         testUtil.stubAdapters([
           {
@@ -645,7 +648,10 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(DECOMPOSED_PATH)).to.deep.equal([DECOMPOSED_COMPONENT]);
+        expect(access.getComponentsFromPath(DECOMPOSED_PATH)).to.deep.equal([
+          DECOMPOSED_CHILD_COMPONENT_1,
+          DECOMPOSED_COMPONENT,
+        ]);
       });
 
       it('should return expected child SourceComponent when given a subdirectory of a folderPerType component', () => {
@@ -782,7 +788,7 @@ describe('MetadataResolver', () => {
         expect(result).to.deep.equal([xmlInFolder.COMPONENTS[0]]);
       });
 
-      it('should resolve child components when present in filter', () => {
+      it.skip('should resolve child components when present in filter', () => {
         const resolver = testUtil.createMetadataResolver(decomposedtoplevel.DECOMPOSED_VIRTUAL_FS);
         const children = decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT.getChildren();
         const componentMappings = children.map((c: SourceComponent) => ({
@@ -813,7 +819,7 @@ describe('MetadataResolver', () => {
 
         const result = resolver.getComponentsFromPath(decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT_PATH, filter);
 
-        expect(result).to.deep.equal(children);
+        expect(result).to.have.deep.members([DECOMPOSED_TOP_LEVEL_XML_NAMES[0], ...children]);
       });
 
       it('should resolve directory component if in filter', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -784,7 +784,7 @@ describe('MetadataResolver', () => {
         expect(result).to.deep.equal([xmlInFolder.COMPONENTS[0]]);
       });
 
-      it.skip('should resolve child components when present in filter', () => {
+      it('should resolve child components when present in filter', () => {
         const resolver = testUtil.createMetadataResolver(decomposedtoplevel.DECOMPOSED_VIRTUAL_FS);
         const children = decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT.getChildren();
         const componentMappings = children.map((c: SourceComponent) => ({

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -45,7 +45,6 @@ import {
 } from '../mock/type-constants/staticresourceConstant';
 import { META_XML_SUFFIX } from '../../src/common';
 import { DE_METAFILE } from '../mock/type-constants/digitalExperienceBundleConstants';
-import { DECOMPOSED_TOP_LEVEL_XML_NAMES } from '../mock/type-constants/customObjectTranslationConstant';
 import { RegistryTestUtil } from './registryTestUtil';
 
 const testUtil = new RegistryTestUtil();
@@ -637,7 +636,7 @@ describe('MetadataResolver', () => {
         expect(access.getComponentsFromPath(MIXED_CONTENT_DIRECTORY_DIR)).to.deep.equal([component]);
       });
 
-      it('should NOT stop resolution if parent component is resolved', () => {
+      it('should stop resolution if parent component is resolved', () => {
         const access = testUtil.createMetadataResolver(DECOMPOSED_VIRTUAL_FS);
         testUtil.stubAdapters([
           {
@@ -819,7 +818,7 @@ describe('MetadataResolver', () => {
 
         const result = resolver.getComponentsFromPath(decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT_PATH, filter);
 
-        expect(result).to.have.deep.members([DECOMPOSED_TOP_LEVEL_XML_NAMES[0], ...children]);
+        expect(result).to.have.deep.members(children);
       });
 
       it('should resolve directory component if in filter', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -647,10 +647,7 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(DECOMPOSED_PATH)).to.deep.equal([
-          DECOMPOSED_CHILD_COMPONENT_1,
-          DECOMPOSED_COMPONENT,
-        ]);
+        expect(access.getComponentsFromPath(DECOMPOSED_PATH)).to.deep.equal([DECOMPOSED_COMPONENT]);
       });
 
       it('should return expected child SourceComponent when given a subdirectory of a folderPerType component', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -287,7 +287,7 @@ describe('MetadataResolver', () => {
             allowContent: false,
           },
         ]);
-        expect(access.getComponentsFromPath(path)).to.have.deep.members(xmlInFolder.COMPONENTS);
+        expect(access.getComponentsFromPath(path)).to.deep.equal(xmlInFolder.COMPONENTS);
       });
 
       it('Should determine type for folder files', () => {
@@ -453,9 +453,7 @@ describe('MetadataResolver', () => {
             componentMappings,
           },
         ]);
-        expect(resolver.getComponentsFromPath(xmlInFolder.COMPONENT_FOLDER_PATH)).to.have.deep.members(
-          xmlInFolder.COMPONENTS
-        );
+        expect(resolver.getComponentsFromPath(xmlInFolder.COMPONENT_FOLDER_PATH)).to.deep.equal(xmlInFolder.COMPONENTS);
       });
 
       it('Should walk all file and directory children', () => {
@@ -523,7 +521,7 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(apexDir)).to.have.deep.members([
+        expect(access.getComponentsFromPath(apexDir)).to.deep.equal([
           matchingContentFile.COMPONENT,
           reportComponent,
           apexComponentB,
@@ -552,7 +550,7 @@ describe('MetadataResolver', () => {
             ],
           },
         ]);
-        expect(access.getComponentsFromPath(mixedContentInFolder.COMPONENT_FOLDER_PATH)).to.have.deep.members([
+        expect(access.getComponentsFromPath(mixedContentInFolder.COMPONENT_FOLDER_PATH)).to.deep.equal([
           mixedContentInFolder.COMPONENTS[0],
           mixedContentInFolder.COMPONENTS[1],
         ]);
@@ -815,7 +813,7 @@ describe('MetadataResolver', () => {
 
         const result = resolver.getComponentsFromPath(decomposedtoplevel.DECOMPOSED_TOP_LEVEL_COMPONENT_PATH, filter);
 
-        expect(result).to.have.deep.members(children);
+        expect(result).to.deep.equal(children);
       });
 
       it('should resolve directory component if in filter', () => {


### PR DESCRIPTION
### What does this PR do?

sorts files/folders to folders first then files when searching for components so that we find everything
updates the cache when a parent with more information is found

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2230, @W-13629588@

### Functionality Before

would have to order modules alphabetically to get deploy to work

### Functionality After

 order doesn't matter