### PR TITLE
Wr/sccache

### DIFF
--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -53,7 +53,7 @@ export class SourceComponent implements MetadataComponent {
   private readonly forceIgnore: ForceIgnore;
   private markedForDelete = false;
   private destructiveChangesType?: DestructiveChangesType;
-  private pathContentMap = new Map<string, string>();
+  private fileContent?: string;
 
   public constructor(
     props: ComponentProperties,
@@ -188,8 +188,8 @@ export class SourceComponent implements MetadataComponent {
   public async parseXml<T extends JsonMap>(xmlFilePath?: string): Promise<T> {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.pathContentMap.get(xml) ?? (await this.tree.readFile(xml)).toString();
-      this.pathContentMap.set(xml, contents);
+      const contents = this.fileContent ?? (await this.tree.readFile(xml)).toString();
+      this.fileContent = contents;
       const replacements = this.replacements?.[xml] ?? this.parent?.replacements?.[xml];
       return this.parseAndValidateXML<T>(
         replacements ? await replacementIterations(contents, replacements) : contents,
@@ -202,8 +202,8 @@ export class SourceComponent implements MetadataComponent {
   public parseXmlSync<T extends JsonMap>(xmlFilePath?: string): T {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.pathContentMap.get(xml) ?? this.tree.readFileSync(xml).toString();
-      this.pathContentMap.set(xml, contents);
+      const contents = this.fileContent ?? this.tree.readFileSync(xml).toString();
+      this.fileContent = contents;
       return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -53,7 +53,7 @@ export class SourceComponent implements MetadataComponent {
   private readonly forceIgnore: ForceIgnore;
   private markedForDelete = false;
   private destructiveChangesType?: DestructiveChangesType;
-  private fileContent?: string;
+  private pathContentMap = new Map<string, string>();
 
   public constructor(
     props: ComponentProperties,
@@ -188,8 +188,8 @@ export class SourceComponent implements MetadataComponent {
   public async parseXml<T extends JsonMap>(xmlFilePath?: string): Promise<T> {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.fileContent ?? (await this.tree.readFile(xml)).toString();
-      this.fileContent = contents;
+      const contents = this.pathContentMap.get(xml) ?? (await this.tree.readFile(xml)).toString();
+      this.pathContentMap.set(xml, contents);
       const replacements = this.replacements?.[xml] ?? this.parent?.replacements?.[xml];
       return this.parseAndValidateXML<T>(
         replacements ? await replacementIterations(contents, replacements) : contents,
@@ -202,8 +202,8 @@ export class SourceComponent implements MetadataComponent {
   public parseXmlSync<T extends JsonMap>(xmlFilePath?: string): T {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.fileContent ?? this.tree.readFileSync(xml).toString();
-      this.fileContent = contents;
+      const contents = this.pathContentMap.get(xml) ?? this.tree.readFileSync(xml).toString();
+      this.pathContentMap.set(xml, contents);
       return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -188,8 +188,14 @@ export class SourceComponent implements MetadataComponent {
   public async parseXml<T extends JsonMap>(xmlFilePath?: string): Promise<T> {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.pathContentMap.get(xml) ?? (await this.tree.readFile(xml)).toString();
-      this.pathContentMap.set(xml, contents);
+      let contents: string;
+      if (this.pathContentMap.has(xml)) {
+        contents = this.pathContentMap.get(xml) as string;
+      } else {
+        contents = (await this.tree.readFile(xml)).toString();
+        this.pathContentMap.set(xml, contents);
+      }
+
       const replacements = this.replacements?.[xml] ?? this.parent?.replacements?.[xml];
       return this.parseAndValidateXML<T>(
         replacements ? await replacementIterations(contents, replacements) : contents,
@@ -202,8 +208,14 @@ export class SourceComponent implements MetadataComponent {
   public parseXmlSync<T extends JsonMap>(xmlFilePath?: string): T {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.pathContentMap.get(xml) ?? this.tree.readFileSync(xml).toString();
-      this.pathContentMap.set(xml, contents);
+      let contents: string;
+      if (this.pathContentMap.has(xml)) {
+        contents = this.pathContentMap.get(xml) as string;
+      } else {
+        contents = this.tree.readFileSync(xml).toString();
+        this.pathContentMap.set(xml, contents);
+      }
+
       return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -53,6 +53,7 @@ export class SourceComponent implements MetadataComponent {
   private readonly forceIgnore: ForceIgnore;
   private markedForDelete = false;
   private destructiveChangesType?: DestructiveChangesType;
+  private pathContentMap = new Map<string, string>();
 
   public constructor(
     props: ComponentProperties,
@@ -187,7 +188,8 @@ export class SourceComponent implements MetadataComponent {
   public async parseXml<T extends JsonMap>(xmlFilePath?: string): Promise<T> {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = (await this.tree.readFile(xml)).toString();
+      const contents = this.pathContentMap.get(xml) ?? (await this.tree.readFile(xml)).toString();
+      this.pathContentMap.set(xml, contents);
       const replacements = this.replacements?.[xml] ?? this.parent?.replacements?.[xml];
       return this.parseAndValidateXML<T>(
         replacements ? await replacementIterations(contents, replacements) : contents,
@@ -200,7 +202,8 @@ export class SourceComponent implements MetadataComponent {
   public parseXmlSync<T extends JsonMap>(xmlFilePath?: string): T {
     const xml = xmlFilePath ?? this.xml;
     if (xml) {
-      const contents = this.tree.readFileSync(xml).toString();
+      const contents = this.pathContentMap.get(xml) ?? this.tree.readFileSync(xml).toString();
+      this.pathContentMap.set(xml, contents);
       return this.parseAndValidateXML(contents, xml);
     }
     return {} as T;

--- a/test/convert/convertContext/nonDecomposition.test.ts
+++ b/test/convert/convertContext/nonDecomposition.test.ts
@@ -22,6 +22,7 @@ import {
   VIRTUAL_DIR,
   WORKING_DIR,
 } from '../../mock/type-constants/customlabelsConstant';
+import { SourceComponent } from '../../../src';
 
 describe('NonDecomposition', () => {
   const env = createSandbox();
@@ -40,7 +41,7 @@ describe('NonDecomposition', () => {
     } as unknown as SfProject);
   });
   it('should return WriterFormats for claimed children', async () => {
-    const component = nonDecomposed.COMPONENT_1;
+    const component = new SourceComponent(nonDecomposed.COMPONENT_1, TREE);
     const context = new ConvertContext();
     const writeInfos = [
       {
@@ -61,7 +62,7 @@ describe('NonDecomposition', () => {
   });
 
   it('should return WriterFormats when no local files exist', async () => {
-    const component = nonDecomposed.COMPONENT_1;
+    const component = new SourceComponent(nonDecomposed.COMPONENT_1);
     const context = new ConvertContext();
     const [baseName] = component.fullName.split('.');
     const output = join(
@@ -94,7 +95,7 @@ describe('NonDecomposition', () => {
   });
 
   it('should merge unclaimed children to default parent component', async () => {
-    const component = nonDecomposed.COMPONENT_1;
+    const component = new SourceComponent(nonDecomposed.COMPONENT_1);
     const type = component.type;
     const context = new ConvertContext();
 
@@ -120,7 +121,7 @@ describe('NonDecomposition', () => {
   });
 
   it('should merge 1 updated file', async () => {
-    const component = nonDecomposed.COMPONENT_1;
+    const component = new SourceComponent(nonDecomposed.COMPONENT_1, TREE);
     const context = new ConvertContext();
     const type = component.type;
 
@@ -163,7 +164,7 @@ describe('NonDecomposition', () => {
         },
       ],
     } as unknown as SfProject);
-    const component = nonDecomposed.COMPONENT_2;
+    const component = new SourceComponent(nonDecomposed.COMPONENT_2);
     const context = new ConvertContext();
     const type = component.type;
 

--- a/test/convert/convertContext/nonDecomposition.test.ts
+++ b/test/convert/convertContext/nonDecomposition.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../mock/type-constants/customlabelsConstant';
 import { SourceComponent } from '../../../src';
 
-describe('NonDecomposition', () => {
+describe.skip('NonDecomposition', () => {
   const env = createSandbox();
   afterEach(() => env.restore());
 

--- a/test/convert/convertContext/nonDecomposition.test.ts
+++ b/test/convert/convertContext/nonDecomposition.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../../mock/type-constants/customlabelsConstant';
 import { SourceComponent } from '../../../src';
 
-describe.skip('NonDecomposition', () => {
+describe('NonDecomposition', () => {
   const env = createSandbox();
   afterEach(() => env.restore());
 
@@ -41,7 +41,7 @@ describe.skip('NonDecomposition', () => {
     } as unknown as SfProject);
   });
   it('should return WriterFormats for claimed children', async () => {
-    const component = new SourceComponent(nonDecomposed.COMPONENT_1, TREE);
+    const component = nonDecomposed.COMPONENT_1;
     const context = new ConvertContext();
     const writeInfos = [
       {
@@ -58,6 +58,8 @@ describe.skip('NonDecomposition', () => {
     };
 
     const result = await context.nonDecomposition.finalize(nonDecomposed.DEFAULT_DIR, TREE);
+    // @ts-ignore - because the resulting component will have cache info, and the initial one won't
+    result[0].component.pathContentMap = new Map();
     expect(result).to.deep.equal([{ component, writeInfos }]);
   });
 
@@ -95,7 +97,7 @@ describe.skip('NonDecomposition', () => {
   });
 
   it('should merge unclaimed children to default parent component', async () => {
-    const component = new SourceComponent(nonDecomposed.COMPONENT_1);
+    const component = nonDecomposed.COMPONENT_1;
     const type = component.type;
     const context = new ConvertContext();
 
@@ -116,7 +118,8 @@ describe.skip('NonDecomposition', () => {
     };
 
     const result = await context.nonDecomposition.finalize(nonDecomposed.DEFAULT_DIR, TREE);
-
+    // @ts-ignore - because the resulting component will have cache info, and the initial one won't
+    result[0].component.pathContentMap = new Map();
     expect(result).to.deep.equal([{ component, writeInfos }]);
   });
 
@@ -145,6 +148,8 @@ describe.skip('NonDecomposition', () => {
     };
 
     const result = await context.nonDecomposition.finalize(nonDecomposed.DEFAULT_DIR, TREE);
+    // @ts-ignore - because the resulting component will have cache info, and the initial one won't
+    result[0].component.pathContentMap = new Map();
     expect(result).to.deep.equal([{ component, writeInfos }]);
   });
 
@@ -164,7 +169,7 @@ describe.skip('NonDecomposition', () => {
         },
       ],
     } as unknown as SfProject);
-    const component = new SourceComponent(nonDecomposed.COMPONENT_2);
+    const component = nonDecomposed.COMPONENT_2;
     const context = new ConvertContext();
     const type = component.type;
 
@@ -188,6 +193,8 @@ describe.skip('NonDecomposition', () => {
     };
 
     const result = await context.nonDecomposition.finalize(nonDecomposed.DEFAULT_DIR, TREE);
+    // @ts-ignore - because the resulting component will have cache info, and the initial one won't
+    result[0].component.pathContentMap = new Map();
     expect(result).to.deep.equal([{ component, writeInfos }]);
   });
 });

--- a/test/convert/convertContext/recomposition.test.ts
+++ b/test/convert/convertContext/recomposition.test.ts
@@ -151,7 +151,7 @@ describe('Recomposition', () => {
         },
       ]);
 
-      expect(readFileSpy.callCount, JSON.stringify(readFileSpy.getCalls(), undefined, 2)).to.equal(1);
+      expect(readFileSpy.callCount, JSON.stringify(readFileSpy.getCalls(), undefined, 2)).to.equal(0);
     });
 
     describe('should only read unique child xml files once per parent for non-decomposed components', () => {
@@ -224,7 +224,7 @@ describe('Recomposition', () => {
 
         await context.recomposition.finalize();
 
-        expect(readFileSpy.callCount, 'readFile() should only be called twice').to.equal(2);
+        expect(readFileSpy.callCount, 'readFile() should only be called twice').to.equal(0);
       });
     });
   });

--- a/test/resolve/adapters/decomposedSourceAdapter.test.ts
+++ b/test/resolve/adapters/decomposedSourceAdapter.test.ts
@@ -12,7 +12,7 @@ import { registry, RegistryAccess, SourceComponent, VirtualTreeContainer } from 
 import { RegistryTestUtil } from '../registryTestUtil';
 import { META_XML_SUFFIX } from '../../../src/common';
 
-describe('DecomposedSourceAdapter', () => {
+describe.skip('DecomposedSourceAdapter', () => {
   const registryAccess = new RegistryAccess();
   const type = registry.types.customobject;
   const tree = new VirtualTreeContainer(decomposed.DECOMPOSED_VIRTUAL_FS);

--- a/test/resolve/adapters/decomposedSourceAdapter.test.ts
+++ b/test/resolve/adapters/decomposedSourceAdapter.test.ts
@@ -12,7 +12,7 @@ import { registry, RegistryAccess, SourceComponent, VirtualTreeContainer } from 
 import { RegistryTestUtil } from '../registryTestUtil';
 import { META_XML_SUFFIX } from '../../../src/common';
 
-describe.skip('DecomposedSourceAdapter', () => {
+describe('DecomposedSourceAdapter', () => {
   const registryAccess = new RegistryAccess();
   const type = registry.types.customobject;
   const tree = new VirtualTreeContainer(decomposed.DECOMPOSED_VIRTUAL_FS);
@@ -80,6 +80,8 @@ describe.skip('DecomposedSourceAdapter', () => {
     assert(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
     const result = adapter.getComponent(decomposed.DECOMPOSED_CHILD_COMPONENT_1.xml);
 
+    // @ts-ignore - this only failed when running 'yarn test' - parent has cache info the result won't
+    component.parent.pathContentMap = new Map();
     expect(result).to.deep.equal(component);
   });
 

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -46,7 +46,7 @@ const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sd
 
 const env = createSandbox();
 
-describe('SourceComponent', () => {
+describe.skip('SourceComponent', () => {
   it('should return correct fullName for components without a parent', () => {
     expect(DECOMPOSED_COMPONENT.fullName).to.equal(DECOMPOSED_COMPONENT.name);
   });

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'node:path';
-import { assert, expect } from 'chai';
+import { assert, config, expect } from 'chai';
 import { createSandbox } from 'sinon';
 import { Messages, SfError } from '@salesforce/core';
 import { decomposed, matchingContentFile, mixedContentDirectory, xmlInFolder } from '../mock';
@@ -41,12 +41,14 @@ import { DE_METAFILE } from '../mock/type-constants/digitalExperienceBundleConst
 import { XML_NS_KEY, XML_NS_URL } from '../../src/common';
 import { RegistryTestUtil } from './registryTestUtil';
 
+config.truncateThreshold = 0;
+
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sdr');
 
 const env = createSandbox();
 
-describe.skip('SourceComponent', () => {
+describe('SourceComponent', () => {
   it('should return correct fullName for components without a parent', () => {
     expect(DECOMPOSED_COMPONENT.fullName).to.equal(DECOMPOSED_COMPONENT.name);
   });

--- a/test/resolve/sourceComponent.test.ts
+++ b/test/resolve/sourceComponent.test.ts
@@ -244,7 +244,7 @@ describe('SourceComponent', () => {
     });
 
     it('should preserve leading zeroes in node values', async () => {
-      const component = COMPONENT;
+      const component = new SourceComponent(COMPONENT);
       env
         .stub(component.tree, 'readFile')
         .resolves(Buffer.from('<MatchingContentFile><test>001</test></MatchingContentFile>'));
@@ -260,7 +260,7 @@ describe('SourceComponent', () => {
     });
 
     it('should parse cdata node values', async () => {
-      const component = COMPONENT;
+      const component = new SourceComponent(COMPONENT);
       env
         .stub(component.tree, 'readFile')
         .resolves(Buffer.from('<MatchingContentFile><test><![CDATA[<p>Hello</p>]]></test></MatchingContentFile>'));
@@ -276,7 +276,7 @@ describe('SourceComponent', () => {
     });
 
     it('should parse attributes of nodes', async () => {
-      const component = COMPONENT;
+      const component = new SourceComponent(COMPONENT);
       env
         .stub(component.tree, 'readFile')
         .resolves(Buffer.from('<MatchingContentFile a="test"><test>something</test></MatchingContentFile>'));


### PR DESCRIPTION
@W-16383577@

keeps a map of path=>content on the source component to avoid re-reading any files and referencing information we've already gathered.
