### PR TITLE
fix: force new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/source-deploy-retrieve",
-  "version": "12.8.1",
+  "version": "12.9.0",
   "description": "JavaScript library to run Salesforce metadata deploys and retrieves",
   "main": "lib/src/index.js",
   "author": "Salesforce",


### PR DESCRIPTION
### What does this PR do?
Force a new release. The `package.json` version got out of sync with the branch protection issues we had this week

[skip-validate-pr]