### PR TITLE
fix(resolver): ignore non-component XML files in project

### DIFF
--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -152,7 +152,7 @@ export class ComponentSetBuilder {
       if (resolvedComponents.forceIgnoredPaths) {
         // if useFsForceIgnore = true, then we won't be able to resolve a forceignored path,
         // which we need to do to get the ignored source component
-        const resolver = new MetadataResolver(registry, undefined, true);
+        const resolver = new MetadataResolver(registry, undefined, false);
 
         for (const ignoredPath of resolvedComponents.forceIgnoredPaths ?? []) {
           resolver.getComponentsFromPath(ignoredPath).map((ignored) => {

--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -152,7 +152,7 @@ export class ComponentSetBuilder {
       if (resolvedComponents.forceIgnoredPaths) {
         // if useFsForceIgnore = true, then we won't be able to resolve a forceignored path,
         // which we need to do to get the ignored source component
-        const resolver = new MetadataResolver(registry, undefined, false);
+        const resolver = new MetadataResolver(registry, undefined, true);
 
         for (const ignoredPath of resolvedComponents.forceIgnoredPaths ?? []) {
           resolver.getComponentsFromPath(ignoredPath).map((ignored) => {

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -373,7 +373,16 @@ const parseAsContentMetadataXml =
     const suffixType = registry.getTypeBySuffix(extName(fsPath));
     if (!suffixType) return false;
 
-    return fsPath.split(sep).includes(suffixType.directoryName);
+    const matchesSuffixType = fsPath.split(sep).includes(suffixType.directoryName);
+    if (matchesSuffixType) return matchesSuffixType;
+
+    // it might be a type that requires strict parent folder name.
+    const strictFolderSuffixType = registry
+      .getStrictFolderTypes()
+      .find((l) => l.suffix === suffixType.suffix && l.directoryName && l.name !== suffixType.name);
+    if (!strictFolderSuffixType) return false;
+
+    return fsPath.split(sep).includes(strictFolderSuffixType.directoryName);
   };
 
 /**

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -369,8 +369,12 @@ const resolveType =
  */
 const parseAsContentMetadataXml =
   (registry: RegistryAccess) =>
-  (fsPath: string): boolean =>
-    Boolean(registry.getTypeBySuffix(extName(fsPath)));
+  (fsPath: string): boolean => {
+    const suffixType = registry.getTypeBySuffix(extName(fsPath));
+    if (!suffixType) return false;
+
+    return fsPath.split(sep).includes(suffixType.directoryName);
+  };
 
 /**
  * If this file should be considered as a metadata file then return the metadata type

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -458,6 +458,24 @@ describe('MetadataResolver', () => {
         expect(access.getComponentsFromPath(path).length).to.equal(0);
       });
 
+      it('Should not throw TypeInferenceError for a non-metadata file that is not part of an inclusive filter', () => {
+        const emailservicesPath = join('unpackaged', 'emailservices', 'MyEmailServices.xml');
+        const nonMetadataDirPath = join('unpackaged', 'datasets');
+        const nonMetadataFilePath = join(nonMetadataDirPath, 'myDS.xml');
+        const emailservicesComponent = new SourceComponent(
+          {
+            name: 'MyEmailServices',
+            type: registry.types.emailservicesfunction,
+            xml: emailservicesPath,
+          },
+          VirtualTreeContainer.fromFilePaths([emailservicesPath])
+        );
+        const filter = new ComponentSet([emailservicesComponent]);
+        const treeContainer = VirtualTreeContainer.fromFilePaths([emailservicesPath, nonMetadataFilePath]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer, false);
+        expect(mdResolver.getComponentsFromPath(nonMetadataDirPath, filter)).to.deep.equal([]);
+      });
+
       it('Should not return a component if path to folder metadata xml is forceignored', () => {
         const path = xmlInFolder.FOLDER_XML_PATH;
         const access = testUtil.createMetadataResolver([


### PR DESCRIPTION
### What does this PR do?

Updates the metadata resolver to ignore XML files in a project that aren't part of a source component.

A customer had datapacks with an XML file that isn't part of the metadata inside `force_app`, when SDR built the component to deploy a specific metadata it would try to resolve the XML file as `emailservicesfunction` because the helpers to detect if a filepath was a metadata type were checking if the file suffix matched one in the registry (`emailservicesfunction.suffix === 'xml'`).

This PR updates `isMetadata` to first try to find the type based on the suffix, if it there's not then it will check for `strictDirectoryNames` type ones **and** their `directoryName`.

Repro:

1. create an invalid file in the project dir (force-app/main/default/lala/hehe.xml)
2. update forceignore to ignore the file (**/lala/**)
3. confirm it shows up when running `sf project list ignored`
4. try deploying something via --metadata: `sf project deploy start -m ApexClass` 
5. see error about SDR trying to resolve an it as `emailservicesfunction`
6. rename the file extension from file created in step one to something else other than `xml`, then step 4 works b/c it doesn't try to resolve it as a component.

### What issues does this PR fix or reference?

@W-17113942@

