### PR TITLE
chore: fix forceignore warnings on commented lines

### DIFF
--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -6,6 +6,7 @@
  */
 
 import { dirname, join, relative } from 'node:path';
+import * as os from 'node:os';
 import ignore, { Ignore } from 'ignore/index';
 import { readFileSync } from 'graceful-fs';
 import { Lifecycle } from '@salesforce/core';
@@ -24,8 +25,8 @@ export class ForceIgnore {
       const contents = readFileSync(forceIgnorePath, 'utf-8');
       // check if file `.forceignore` exists
       if (contents !== undefined) {
-        // check for windows style separators (\) and warn
-        if (contents.includes('\\')) {
+        // check for windows style separators (\) and warn, that aren't comments
+        if (contents.split(os.EOL).find((c) => c.includes('\\') && !c.startsWith('#'))) {
           // void because you cannot await a method in a constructor
           void Lifecycle.getInstance().emitWarning(
             'Your .forceignore file incorrectly uses the backslash ("\\") as a folder separator; it should use the slash ("/") instead. The ignore rules will not work as expected until you fix this.'

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { join } from 'node:path';
+import * as os from 'node:os';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import fs from 'graceful-fs';
@@ -44,6 +45,19 @@ describe('ForceIgnore', () => {
     const forceIgnore = new ForceIgnore();
 
     expect(forceIgnore.accepts(pathToClass)).to.be.true;
+    expect(lifecycleStub.callCount).to.equal(1);
+  });
+
+  it('will not warn for \\ on commented lines', () => {
+    const lifecycleStub = env.stub(Lifecycle.prototype, 'emitWarning');
+    const forceIgnoreEntry = `# force-app\\main\\default\\classes\\myApex.* ${os.EOL} force-app\\main\\default\\classes\\myApex.*`;
+    const pathToClass = join('force-app', 'main', 'default', 'classes', 'myApex.cls');
+    env.stub(fs, 'readFileSync').returns(forceIgnoreEntry);
+
+    const forceIgnore = new ForceIgnore();
+
+    expect(forceIgnore.accepts(pathToClass)).to.be.true;
+    // once, second line is uncommented, but uses \
     expect(lifecycleStub.callCount).to.equal(1);
   });
 


### PR DESCRIPTION
### What does this PR do?

changes forceignore warnings to ignore commented lines

### What issues does this PR fix or reference?
[skip-validate-pr]

https://github.com/forcedotcom/cli/issues/3127
### Functionality Before

would warn on 
`# force-app\main`

### Functionality After
will not warn on example above
