### PR TITLE
fix: windows can not deploy folder with "/"

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -739,7 +739,7 @@ const constructFullName = (registry: RegistryAccess, type: MetadataType, fullNam
   // ReportFolders are deployed/retrieved as Reports. If a ReportFolder is being added append
   // a "/" so the metadata API can identify it as a folder.
   ['DashboardFolder', 'ReportFolder', 'EmailTemplateFolder'].includes(type.name) && !fullName.endsWith('/')
-    ? `${fullName}/`
+    ? `${fullName}`
     : registry.getParentType(type.name)?.strategies?.recomposition === 'startEmpty' && fullName.includes('.')
     ? // they're reassembled like CustomLabels.MyLabel
       fullName.split('.')[1]

--- a/test/resolve/manifestResolver.test.ts
+++ b/test/resolve/manifestResolver.test.ts
@@ -204,8 +204,8 @@ describe('ManifestResolver', () => {
         data: Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
       <Package xmlns="http://soap.sforce.com/2006/04/metadata">
         <types>
-          <members>foo/</members>
-          <members>foo/subfoo/</members>
+          <members>foo</members>
+          <members>foo/subfoo</members>
           <members>foo/subfoo/MySubFooReport1</members>
           <members>foo/subfoo/MySubFooReport2</members>
           <members>bar/MyBarReport1</members>

--- a/test/snapshot/sampleProjects/nestedFolders/__snapshots__/verify-md-files.expected/package.xml
+++ b/test/snapshot/sampleProjects/nestedFolders/__snapshots__/verify-md-files.expected/package.xml
@@ -7,8 +7,8 @@
         <name>EmailTemplate</name>
     </types>
     <types>
-        <members>TopFolder/</members>
-        <members>TopFolder/ChildFolder/</members>
+        <members>TopFolder</members>
+        <members>TopFolder/ChildFolder</members>
         <members>TopFolder/ChildFolder/Report_in_Child_Folder_qz4</members>
         <members>TopFolder/Copy_of_Top_level_report_DOj</members>
         <members>unfiled$public/Top_level_report_cZJ</members>


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

I can not deploy ReportFolder/DashBoard with "/" on windows , but work on linux or macos.
It works on windows/linux/macos without "/".

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>foo/</members>
        <members>foo/FooReport1</members>
        <members>foo/FooReport2</members>
        <name>Report</name>
    </types>
    <version>60.0</version>
</Package>
```

### Functionality Before

![image](https://github.com/user-attachments/assets/2fa4925f-fdaf-4f0b-a75d-aaa45004c3b9)


### Functionality After

