### PR TITLE
fix: add workflow flow actions to decomposed workflow preset and allow isAddressable

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -29,6 +29,7 @@
     "weblink": "customobject",
     "workflowalert": "workflow",
     "workflowfieldupdate": "workflow",
+    "workflowflowaction": "workflow",
     "workflowknowledgepublish": "workflow",
     "workflowoutboundmessage": "workflow",
     "workflowrule": "workflow",
@@ -513,6 +514,7 @@
     "workflow": "workflow",
     "workflowAlert": "workflowalert",
     "workflowFieldUpdate": "workflowfieldupdate",
+    "workflowFlowAction": "workflowflowaction",
     "workflowKnowledgePublish": "workflowknowledgepublish",
     "workflowOutboundMessage": "workflowoutboundmessage",
     "workflowRule": "workflowrule",
@@ -4517,6 +4519,7 @@
         "directories": {
           "workflowAlerts": "workflowalert",
           "workflowFieldUpdates": "workflowfieldupdate",
+          "workflowFlowActions": "workflowflowaction",
           "workflowKnowledgePublishs": "workflowknowledgepublish",
           "workflowOutboundMessages": "workflowoutboundmessage",
           "workflowRules": "workflowrule",
@@ -4526,6 +4529,7 @@
         "suffixes": {
           "workflowAlert": "workflowalert",
           "workflowFieldUpdate": "workflowfieldupdate",
+          "workflowFlowAction": "workflowflowaction",
           "workflowKnowledgePublish": "workflowknowledgepublish",
           "workflowOutboundMessage": "workflowoutboundmessage",
           "workflowRule": "workflowrule",
@@ -4548,6 +4552,14 @@
             "suffix": "workflowFieldUpdate",
             "uniqueIdElement": "fullName",
             "xmlElementName": "fieldUpdates"
+          },
+          "workflowflowaction": {
+            "directoryName": "workflowFlowActions",
+            "id": "workflowflowaction",
+            "name": "WorkflowFlowAction",
+            "suffix": "workflowFlowAction",
+            "uniqueIdElement": "fullName",
+            "xmlElementName": "flowActions"
           },
           "workflowknowledgepublish": {
             "directoryName": "workflowKnowledgePublishs",

--- a/src/registry/presets/decomposeWorkflowBeta.json
+++ b/src/registry/presets/decomposeWorkflowBeta.json
@@ -2,6 +2,7 @@
   "childTypes": {
     "workflowalert": "workflow",
     "workflowfieldupdate": "workflow",
+    "workflowflowaction": "workflow",
     "workflowknowledgepublish": "workflow",
     "workflowoutboundmessage": "workflow",
     "workflowrule": "workflow",
@@ -20,6 +21,7 @@
         "directories": {
           "workflowAlerts": "workflowalert",
           "workflowFieldUpdates": "workflowfieldupdate",
+          "workflowFlowActions": "workflowflowaction",
           "workflowKnowledgePublishes": "workflowknowledgepublish",
           "workflowOutboundMessages": "workflowoutboundmessage",
           "workflowRules": "workflowrule",
@@ -29,6 +31,7 @@
         "suffixes": {
           "workflowAlert": "workflowalert",
           "workflowFieldUpdate": "workflowfieldupdate",
+          "workflowFlowAction": "workflowflowaction",
           "workflowKnowledgePublish": "workflowknowledgepublish",
           "workflowOutboundMessage": "workflowoutboundmessage",
           "workflowRule": "workflowrule",
@@ -39,7 +42,6 @@
           "workflowalert": {
             "directoryName": "workflowAlerts",
             "id": "workflowalert",
-            "isAddressable": false,
             "name": "WorkflowAlert",
             "suffix": "workflowAlert",
             "xmlElementName": "alerts"
@@ -47,15 +49,20 @@
           "workflowfieldupdate": {
             "directoryName": "workflowFieldUpdates",
             "id": "workflowfieldupdate",
-            "isAddressable": false,
             "name": "WorkflowFieldUpdate",
             "suffix": "workflowFieldUpdate",
             "xmlElementName": "fieldUpdates"
           },
+          "workflowflowaction": {
+            "directoryName": "workflowFlowActions",
+            "id": "workflowflowaction",
+            "name": "WorkflowFlowAction",
+            "suffix": "workflowFlowAction",
+            "xmlElementName": "flowActions"
+          },
           "workflowknowledgepublish": {
             "directoryName": "workflowKnowledgePublishes",
             "id": "workflowknowledgepublish",
-            "isAddressable": false,
             "name": "WorkflowKnowledgePublish",
             "suffix": "workflowKnowledgePublish",
             "xmlElementName": "knowledgePublishes"
@@ -63,7 +70,6 @@
           "workflowoutboundmessage": {
             "directoryName": "workflowOutboundMessages",
             "id": "workflowoutboundmessage",
-            "isAddressable": false,
             "name": "WorkflowOutboundMessage",
             "suffix": "workflowOutboundMessage",
             "xmlElementName": "outboundMessages"
@@ -71,7 +77,6 @@
           "workflowrule": {
             "directoryName": "workflowRules",
             "id": "workflowrule",
-            "isAddressable": false,
             "name": "WorkflowRule",
             "suffix": "workflowRule",
             "xmlElementName": "rules"
@@ -79,7 +84,6 @@
           "workflowsend": {
             "directoryName": "workflowSends",
             "id": "workflowsend",
-            "isAddressable": false,
             "name": "WorkflowSend",
             "suffix": "workflowSend",
             "xmlElementName": "send"
@@ -87,7 +91,6 @@
           "workflowtask": {
             "directoryName": "workflowTasks",
             "id": "workflowtask",
-            "isAddressable": false,
             "name": "WorkflowTask",
             "suffix": "workflowTask",
             "xmlElementName": "tasks"


### PR DESCRIPTION
### What does this PR do?

Updates the decomposed workflow preset to add the child type: Workflow Flow Actions

The overall metadata registry is also missing this child type so I'm adding it to that JSON as well.

In the current decomposed preset, Workflow Flow Actions are added to the `*.workflow-meta.xml` file instead of decomposed into their own directory and smaller files.

This is causing issues deploying decomposed workflow children, as Salesforce CLI appears to check the `*.workflow-meta.xml` file even when deploying just 1 decomposed workflow child like an email alert. Since the  `*.workflow-meta.xml`  isn't "empty", I'm unable to deploy just a decomposed WorkflowAlert for example.

Also, the "isAddressable: false" key in each supported decomposed workflow child is preventing each decomposed workflow child from being retrieved or deployed without the parent. 

After working with @shetzel via CLI Issue 2563, updating the preset to remove all `isAddressable: false` lines and manually add workflow flow actions to the preset fixes my issue retrieving and deploying decomposed workflow children. I've tested this out in my work's repo, which has tons of workflows with workflow flow actions.

Let me know if your team wants to make this a `beta2` instead of modfying an existing `beta`. Since I'm not changing the overall decomposed workflow structure, just adding a missing child and fixing the addressable feature, I think it makes sense to me to just update the `beta` preset.

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/2563

### Functionality Before

Decomposed workflow children besides Flow Actions are decomposed into their own sub-directories and files.

Flow actions are added directly to the `*.workflow-meta.xml` files.

Retrieves can work but deployments fail because it's seeing the Flow Action in the `*.workflow-meta.xml` file and `isAddressable` is false, so I can't deploy the child without the parent file.

### Functionality After

All decomposed workflow children including Flow Actions are decomposed into their own sub-directories and files.

The `*.workflow-meta.xml` file just contains the workflow header/footer.

Retrieving and deploying individual workflow children including Flow Actions works with Salesforce CLI.

[skip-validate-pr]