### PR TITLE
Only check md file for changes

### DIFF
--- a/.github/workflows/supportedMetadataUpdate.yml
+++ b/.github/workflows/supportedMetadataUpdate.yml
@@ -28,7 +28,7 @@ jobs:
       - run: yarn build
       - run: yarn update-supported-metadata
       - run: |
-          if [[ -n $(git status --short) ]]; then
+          if [[ -n $(git status --short METADATA_SUPPORT.md) ]]; then
             git add METADATA_SUPPORT.md
             git commit -m "chore: auto-update metadata coverage in METADATA_SUPPORT.md [no ci]" --no-verify
             git push --no-verify


### PR DESCRIPTION
We had a few GHA failures because of a newline in the `LICENSE.md` file. This change only checks for changes in the `METADATA_SUPPORT.md` file before attempting to commit

Example failure:
https://github.com/forcedotcom/source-deploy-retrieve/actions/runs/12589411545/job/35089181629#step:9:17