### PR TITLE
fix: resolve strict dirs before suffixes for potential metadata files

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -370,19 +370,15 @@ const resolveType =
 const parseAsContentMetadataXml =
   (registry: RegistryAccess) =>
   (fsPath: string): boolean => {
+    // just like resolveType() above, check strict folders first so we don't
+    // have false positive matches for duplicate suffixes like "rule" or "site"
+    const strictFolderType = resolveTypeFromStrictFolder(registry)(fsPath);
+    if (strictFolderType) return true;
+
     const suffixType = registry.getTypeBySuffix(extName(fsPath));
     if (!suffixType) return false;
 
-    const matchesSuffixType = fsPath.split(sep).includes(suffixType.directoryName);
-    if (matchesSuffixType) return matchesSuffixType;
-
-    // it might be a type that requires strict parent folder name.
-    const strictFolderSuffixType = registry
-      .getStrictFolderTypes()
-      .find((l) => l.suffix === suffixType.suffix && l.directoryName && l.name !== suffixType.name);
-    if (!strictFolderSuffixType) return false;
-
-    return fsPath.split(sep).includes(strictFolderSuffixType.directoryName);
+    return fsPath.split(sep).includes(suffixType.directoryName);
   };
 
 /**

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -370,15 +370,14 @@ const resolveType =
 const parseAsContentMetadataXml =
   (registry: RegistryAccess) =>
   (fsPath: string): boolean => {
-    // just like resolveType() above, check strict folders first so we don't
-    // have false positive matches for duplicate suffixes like "rule" or "site"
-    const strictFolderType = resolveTypeFromStrictFolder(registry)(fsPath);
-    if (strictFolderType) return true;
-
     const suffixType = registry.getTypeBySuffix(extName(fsPath));
     if (!suffixType) return false;
 
-    return fsPath.split(sep).includes(suffixType.directoryName);
+    const matchesSuffixType = fsPath.split(sep).includes(suffixType.directoryName);
+    if (matchesSuffixType) return matchesSuffixType;
+
+    // at this point, the suffixType is not a match, so check for strict folder types
+    return !!resolveTypeFromStrictFolder(registry)(fsPath);
   };
 
 /**

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -476,6 +476,29 @@ describe('MetadataResolver', () => {
         expect(mdResolver.getComponentsFromPath(nonMetadataDirPath, filter)).to.deep.equal([]);
       });
 
+      it('Should resolve RestrictionRules metadata in mdapi format', () => {
+        const unpackagedPath = 'unpackaged';
+        const packageXmlPath = join(unpackagedPath, 'package.xml');
+        const restrictionRulesPath = join('unpackaged', 'restrictionRules');
+        const restrictionRulePath = join(restrictionRulesPath, 'Foo.rule');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([
+          unpackagedPath,
+          packageXmlPath,
+          restrictionRulesPath,
+          restrictionRulePath,
+        ]);
+        const restrictionRuleComponent = new SourceComponent(
+          {
+            name: 'Foo',
+            type: registry.types.restrictionrule,
+            xml: restrictionRulePath,
+          },
+          treeContainer
+        );
+        const mdResolver = new MetadataResolver(undefined, treeContainer, false);
+        expect(mdResolver.getComponentsFromPath(unpackagedPath)).to.deep.equal([restrictionRuleComponent]);
+      });
+
       it('Should not return a component if path to folder metadata xml is forceignored', () => {
         const path = xmlInFolder.FOLDER_XML_PATH;
         const access = testUtil.createMetadataResolver([


### PR DESCRIPTION
### What does this PR do?
Modifies the code when resolving potential metadata files to not reuse the suffixType when that type doesn't match with the provided file path.  Added a test to ensure this doesn't regress.

See the GitHub issue for a repro.  Certain metadata types have non-unique file suffixes like "rule" or "site".  These would not resolve correctly in certain code paths, such as when retrieving `RestrictionRule` metadata.

### What issues does this PR fix or reference?
#3168
@W-17555689@
