### PR TITLE
fix: populate manifestComponents consistently

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -511,6 +511,21 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       this.components.set(key, new DecodeableMap<string, SourceComponent>());
     }
 
+    if (!deletionType && typeof component.type !== 'string') {
+      // this component is meant to be added to manifestComponents, even if it's not a fully validated source component,
+      // this ensures when getObject is called, we created consistent manifests  whether using this.components, or this.manifestComponents
+      // when no destructive changes are present, we use this.components (not fully validated as source components, so typos end up in the generated manifest)
+      // when destructive changes are used, we use this.manifestComponents (fully validated, would not match this.components)
+      // this ensures this.components manifest === this.manifestComponents manifest
+      const sc = new SourceComponent({ type: component.type, name: component.fullName });
+      const srcKey = sourceKey(sc);
+
+      if (!this.manifestComponents.has(key)) {
+        this.manifestComponents.set(key, new DecodeableMap<string, SourceComponent>());
+      }
+      this.manifestComponents.get(key)?.set(srcKey, sc);
+    }
+
     if (!(component instanceof SourceComponent)) {
       return;
     }

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -1251,7 +1251,7 @@ describe('ComponentSet', () => {
 
     it('should keep manifestComponents/components in sync', async () => {
       const set = new ComponentSet(undefined, registryAccess);
-      const jerryComponent = new SourceComponent({ name: 'Jerry', type: registry.types.staticresource });
+      const jerryComponent = { fullName: 'Jerry', type: registry.types.staticresource };
       const billComponent = new SourceComponent({ name: 'Bill', type: registry.types.staticresource });
       const philComponent = new SourceComponent({ name: 'Phil', type: registry.types.staticresource });
 

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -31,12 +31,11 @@ import {
   SourceComponent,
   ZipTreeContainer,
 } from '../../src';
-import { decomposedtoplevel, matchingContentFile, mixedContentSingleFile, digitalExperienceBundle } from '../mock';
+import { decomposedtoplevel, digitalExperienceBundle, matchingContentFile, mixedContentSingleFile } from '../mock';
 import { MATCHING_RULES_COMPONENT } from '../mock/type-constants/customlabelsConstant';
 import * as manifestFiles from '../mock/manifestConstants';
-import { testApiVersionAsString } from '../mock/manifestConstants';
+import { testApiVersion, testApiVersionAsString } from '../mock/manifestConstants';
 import * as coverage from '../../src/registry/coverage';
-import { testApiVersion } from '../mock/manifestConstants';
 
 const registryAccess = new RegistryAccess();
 
@@ -1248,6 +1247,32 @@ describe('ComponentSet', () => {
       set.add(component);
 
       expect(Array.from(set)).to.deep.equal([component]);
+    });
+
+    it('should keep manifestComponents/components in sync', async () => {
+      const set = new ComponentSet(undefined, registryAccess);
+      const jerryComponent = new SourceComponent({ name: 'Jerry', type: registry.types.staticresource });
+      const billComponent = new SourceComponent({ name: 'Bill', type: registry.types.staticresource });
+      const philComponent = new SourceComponent({ name: 'Phil', type: registry.types.staticresource });
+
+      expect(set.size).to.equal(0);
+
+      set.add(jerryComponent);
+
+      expect(set.size).to.equal(1); // @ts-ignore - private
+      expect(set.manifestComponents.size).to.equal(1); // @ts-ignore - private
+      expect(set.components.size).to.equal(1);
+      const allToDeployObject = await set.getObject();
+
+      set.add(philComponent, DestructiveChangesType.PRE); // @ts-ignore - private
+      expect(set.manifestComponents.size).to.equal(1); // @ts-ignore - private
+      expect(set.components.size).to.equal(2);
+
+      set.add(billComponent, DestructiveChangesType.POST); // @ts-ignore - private
+      expect(set.manifestComponents.size).to.equal(1); // @ts-ignore - private
+      expect(set.components.size).to.equal(3);
+
+      expect(await set.getObject()).to.deep.equal(allToDeployObject);
     });
 
     it('should add metadata component marked for delete to package components', () => {


### PR DESCRIPTION
### What does this PR do?

ensures the generated manifests are the same, when using `--post/pre` destructive changes or not

### What issues does this PR fix or reference?
 @W-17425220@

### Functionality Before

would NOT error when using `--post/pre` when a constructive manifest had a typo
would parse out typo (as it wasn't found locally) from the manifest sent to the server, and deployment would succeed

### Functionality After

will send typo to server, and allow it to error there