### PR TITLE
W-17669669: add pseudo-type support to ComponentSetBuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.8.0",
-    "@salesforce/kit": "^3.2.2",
+    "@salesforce/core": "^8.8.2",
+    "@salesforce/kit": "^3.2.3",
     "@salesforce/ts-types": "^2.0.12",
     "fast-levenshtein": "^3.0.0",
     "fast-xml-parser": "^4.5.1",

--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -78,7 +78,7 @@ const getLogger = (): Logger => {
   return logger;
 };
 
-const PSEUDO_TYPES = ['Agent'];
+const PSEUDO_TYPES = { AGENT: 'Agent' };
 
 export class ComponentSetBuilder {
   /**
@@ -387,11 +387,11 @@ const buildMapFromMetadata = (mdOption: MetadataOption, registry: RegistryAccess
 // Replace pseudo types with actual types.
 const replacePseudoTypes = async (mdEntries: string[], connection: Connection): Promise<string[]> => {
   const pseudoEntries: string[][] = [];
-  const replacedEntries: string[] = [];
+  let replacedEntries: string[] = [];
 
   mdEntries.map((rawEntry) => {
     const [typeName, ...name] = rawEntry.split(':');
-    if (PSEUDO_TYPES.includes(typeName)) {
+    if (Object.values(PSEUDO_TYPES).includes(typeName)) {
       pseudoEntries.push([typeName, name.join(':').trim()]);
     } else {
       replacedEntries.push(rawEntry);
@@ -404,9 +404,9 @@ const replacePseudoTypes = async (mdEntries: string[], connection: Connection): 
         const pseudoType = pseudoEntry[0];
         const pseudoName = pseudoEntry[1] || '*';
         getLogger().debug(`Converting pseudo-type ${pseudoType}:${pseudoName}`);
-        if (pseudoType === 'Agent') {
+        if (pseudoType === PSEUDO_TYPES.AGENT) {
           const agentMdEntries = await buildAgentMdEntries(pseudoName, connection);
-          agentMdEntries.map((e) => replacedEntries.push(e));
+          replacedEntries = [...replacedEntries, ...agentMdEntries];
         }
       })
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,6 +670,30 @@
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
 
+"@salesforce/core@^8.8.2":
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.8.2.tgz#0fc1632cc183b8c62e333f1f884bf3ee0f4aee6e"
+  integrity sha512-EOH75R2Nr2tg7b3gbyzRNwZPfZ/dZOpmMKmFHKL9oCtUI59+N4IkVljg6dpKYypVKuJJTzjI7T2ibnA8/cluZg==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.6.1"
+    "@salesforce/kit" "^3.2.2"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.10"
+    ajv "^8.17.1"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^9.4.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.2.2"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.3"
+    ts-retry-promise "^0.8.1"
+
 "@salesforce/dev-config@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.3.1.tgz#4dac8245df79d675258b50e1d24e8c636eaa5e10"


### PR DESCRIPTION
### What does this PR do?
Allows ComponentSetBuilder to handle "pseudo-types", which are types that can be translated to one or more different metadata types.  At the moment, it can interpret "Agent" as a type.
Adds unit tests for the feature.

### What issues does this PR fix or reference?
@W-17669669@
