### PR TITLE
fix: @W-16815182 - Add support for type AnnotationExtensionSet

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -533,7 +533,8 @@
     "aiEvaluationDefinition": "aievaluationdefinition",
     "uaviz": "analyticsvisualization",
     "uavizview": "analyticsvizviewdef",
-    "uawork": "analyticsworkspace"
+    "uawork": "analyticsworkspace",
+    "annotationextensionset": "annotationextensionset"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4748,6 +4749,14 @@
         "adapter": "bundle"
       },
       "supportsPartialDelete": true
+    },
+    "annotationextensionset": {
+      "id": "annotationextensionset",
+      "name": "AnnotationExtensionSet",
+      "suffix": "annotationextensionset",
+      "directoryName": "annotationextensionsets",
+      "inFolder": false,
+      "strictDirectoryName": false
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds CLI metadata type support for AnnotationExtensionSet

### What issues does this PR fix or reference?

@W-16815182@

### Functionality Before

Did not support .annotationextensionset and AnnotationExtensionSet metadata type

### Functionality After

Support .annotationextensionset and AnnotationExtensionSet metadata type
