### PR TITLE
feat(mdTypes): Update TUA Visualization Metadata Types

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -532,7 +532,6 @@
     "PublicKeyCertificateSet": "publickeycertificateset",
     "aiEvaluationDefinition": "aievaluationdefinition",
     "uaviz": "analyticsvisualization",
-    "uavizview": "analyticsvizviewdef",
     "uawork": "analyticsworkspace",
     "annotationextensionset": "annotationextensionset"
   },
@@ -4718,15 +4717,7 @@
       "id": "analyticsvisualization",
       "name": "AnalyticsVisualization",
       "suffix": "uaviz",
-      "directoryName": "unified-analytics",
-      "inFolder": false,
-      "strictDirectoryName": false
-    },
-    "analyticsvizviewdef": {
-      "id": "analyticsvizviewdef",
-      "name": "AnalyticsVizViewDef",
-      "suffix": "uavizview",
-      "directoryName": "unified-analytics",
+      "directoryName": "unified-analytics-visualization",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?
This PR updates the directory name for the _AnalyticsVisualization_ metadata type to `unified-analytics-visualization` and removes the _AnalyticsVizViewDef_ type from the registry.

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029W2yzYAC/view

@W-17791453@