### PR TITLE
@W-17803621 Add LifeSciConfigCategory and LifeSciConfigRecord

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -533,7 +533,9 @@
     "aiEvaluationDefinition": "aievaluationdefinition",
     "uaviz": "analyticsvisualization",
     "uawork": "analyticsworkspace",
-    "annotationextensionset": "annotationextensionset"
+    "annotationextensionset": "annotationextensionset",
+    "lifeSciConfigCategory": "lifesciconfigcategory",
+    "lifeSciConfigRecord": "lifesciconfigrecord"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4746,6 +4748,22 @@
       "name": "AnnotationExtensionSet",
       "suffix": "annotationextensionset",
       "directoryName": "annotationextensionsets",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lifesciconfigcategory": {
+      "id": "lifesciconfigcategory",
+      "name": "LifeSciConfigCategory",
+      "suffix": "lifeSciConfigCategory",
+      "directoryName": "lifeSciConfigCategories",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "lifesciconfigrecord": {
+      "id": "lifesciconfigrecord",
+      "name": "LifeSciConfigRecord",
+      "suffix": "lifeSciConfigRecord",
+      "directoryName": "lifeSciConfigRecords",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?
Adds LifeSciConfigCategory and LifeSciConfigRecord entities to the SDR registry so that records can be deployed and retrieved through the SF CLI

### What issues does this PR fix or reference?
[W-17803621](https://gus.lightning.force.com/a07EE000029d3IVYAY)

### Functionality Before
Could not deploy or retrieve LifeSciConfigCategory or LifeSciConfigRecord records

### Functionality After
Can now deploy and retrieve LifeSciConfigCategory and LifeSciConfigRecord records
