### PR TITLE
feat(mdTypes): Update TUA assets MD Types directory names

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -4717,7 +4717,7 @@
       "id": "analyticsvisualization",
       "name": "AnalyticsVisualization",
       "suffix": "uaviz",
-      "directoryName": "unified-analytics-visualization",
+      "directoryName": "analyticsVisualizations",
       "inFolder": false,
       "strictDirectoryName": false
     },
@@ -4725,7 +4725,7 @@
       "id": "analyticsworkspace",
       "name": "AnalyticsWorkspace",
       "suffix": "uawork",
-      "directoryName": "unified-analytics-workspace",
+      "directoryName": "analyticsWorkspaces",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?
This PR updates the directory names for the _AnalyticsVisualization_ and _AnalyticsWorkspace_ metadata types to align with the [recommendations](https://confluence.internal.salesforce.com/pages/viewpage.action?spaceKey=METADATA&title=Create+a+POJO+or+Java-Backed+Metadata+Type#:~:text=The%20standard%20is%20to%20use%20an%20init%2Dlower%2Dcased%2C%20plural%20version%20of%20the%20type%20name%2C%20which%20is%20why%20the%20Example%20type%20above%20specifies%20%22examples%22.) in the Metadata and Tooling API documentation.

Note: Since the TUA MDAPIs are not yet GA-released, this change will not impact any existing customers.

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029giuWYAQ/view

@W-17810143@