### PR TITLE
fix: @W-17936678 - Rename AnnotationExtensionSet metadata type to InvocableActionExtension

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -535,9 +535,9 @@
     "uadash": "analyticsdashboard",
     "uaviz": "analyticsvisualization",
     "uawork": "analyticsworkspace",
-    "annotationextensionset": "annotationextensionset",
     "lifeSciConfigCategory": "lifesciconfigcategory",
-    "lifeSciConfigRecord": "lifesciconfigrecord"
+    "lifeSciConfigRecord": "lifesciconfigrecord",
+    "invocableactionextension": "invocableactionextension"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4765,14 +4765,6 @@
       },
       "supportsPartialDelete": true
     },
-    "annotationextensionset": {
-      "id": "annotationextensionset",
-      "name": "AnnotationExtensionSet",
-      "suffix": "annotationextensionset",
-      "directoryName": "annotationextensionsets",
-      "inFolder": false,
-      "strictDirectoryName": false
-    },
     "lifesciconfigcategory": {
       "id": "lifesciconfigcategory",
       "name": "LifeSciConfigCategory",
@@ -4786,6 +4778,14 @@
       "name": "LifeSciConfigRecord",
       "suffix": "lifeSciConfigRecord",
       "directoryName": "lifeSciConfigRecords",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "invocableactionextension": {
+      "id": "invocableactionextension",
+      "name": "InvocableActionExtension",
+      "suffix": "invocableactionextension",
+      "directoryName": "invocableactionextensions",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?
Rename AnnotationExtensionSet metadata type to InvocableActionExtension

### What issues does this PR fix or reference?
Rename AnnotationExtensionSet metadata type to InvocableActionExtension after reviewing the entities with Data modeling team

#<Insert GitHub Issue>, @W-17936678@

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
