### PR TITLE
fix: add call center in wildcard and name support

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -1135,7 +1135,8 @@
       "inFolder": false,
       "name": "CallCenter",
       "strictDirectoryName": false,
-      "suffix": "callCenter"
+      "suffix": "callCenter",
+      "supportsWildcardAndName": true
     },
     "callcenterroutingmap": {
       "directoryName": "callCenterRoutingMaps",


### PR DESCRIPTION
### What does this PR do?

Change a configuration in the metadata registry to allow retrieve of call center metadata using wildcard in conjunction with named meta.

Given a `package.xml`

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Package xmlns="http://soap.force.com/2006/04/metadata">
    <types>
        <members>*</members>
        <members>ManagedCTI</members>
        <name>CallCenter</name>
    </types>
</Package>
```

This will successfully retrieve `ManagedCTI` from Metadata API.

### Functionality Before

Using `sf project retrieve start -x package.xml` command it will only retrieve manually created config.

### Functionality After

Using `sf project retrieve start -x package.xml` command it will retrieve manually created config and also given one which can be a managed package crafted one (already supported by workbench).
