### PR TITLE
W-17909761 - fix: resolve plugins from planner for agent pseudo type resolution

### DIFF
--- a/src/resolve/pseudoTypes/agentResolver.ts
+++ b/src/resolve/pseudoTypes/agentResolver.ts
@@ -115,11 +115,10 @@ const resolveAgentFromConnection = async (connection: Connection, botName: strin
         );
         // read the planner metadata from the org
         // @ts-expect-error jsForce types don't know about GenAiPlanner yet
-        const genAiPlannerMd = ensureArray(
-          await connection.metadata.read<GenAiPlanner>('GenAiPlanner', botName)
-        ) as GenAiPlanner[];
-        if (genAiPlannerMd?.length && genAiPlannerMd[0]?.genAiPlugins.length) {
-          genAiPlannerMd[0].genAiPlugins.map((plugin) => {
+        const genAiPlannerMd = await connection.metadata.read<GenAiPlanner>('GenAiPlanner', botName);
+        const genAiPlannerMdArr = ensureArray(genAiPlannerMd) as unknown as GenAiPlanner[];
+        if (genAiPlannerMdArr?.length && genAiPlannerMdArr[0]?.genAiPlugins.length) {
+          genAiPlannerMdArr[0].genAiPlugins.map((plugin) => {
             if (plugin.genAiPluginName?.length) {
               mdEntries.push(`GenAiPlugin:${plugin.genAiPluginName}`);
             }

--- a/src/resolve/pseudoTypes/agentResolver.ts
+++ b/src/resolve/pseudoTypes/agentResolver.ts
@@ -110,7 +110,23 @@ const resolveAgentFromConnection = async (connection: Connection, botName: strin
       if (genAiPluginNames.length) {
         genAiPluginNames.map((r) => mdEntries.push(`GenAiPlugin:${r.DeveloperName}`));
       } else {
-        getLogger().debug(`No GenAiPlugin metadata matches for plannerId: ${plannerId15}`);
+        getLogger().debug(
+          `No GenAiPlugin metadata matches for plannerId: ${plannerId15}. Reading the planner metadata for plugins...`
+        );
+        // read the planner metadata from the org
+        // @ts-expect-error jsForce types don't know about GenAiPlanner yet
+        const genAiPlannerMd = ensureArray(
+          await connection.metadata.read<GenAiPlanner>('GenAiPlanner', botName)
+        ) as GenAiPlanner[];
+        if (genAiPlannerMd?.length && genAiPlannerMd[0]?.genAiPlugins.length) {
+          genAiPlannerMd[0].genAiPlugins.map((plugin) => {
+            if (plugin.genAiPluginName?.length) {
+              mdEntries.push(`GenAiPlugin:${plugin.genAiPluginName}`);
+            }
+          });
+        } else {
+          getLogger().debug(`No GenAiPlugin metadata found in planner file for API name: ${botName}`);
+        }
       }
     } else {
       getLogger().debug(`No GenAiPlanner metadata matches for Bot: ${botName}`);


### PR DESCRIPTION
### What does this PR do?
When plugins have API names that don't match the planner ID naming pattern, read the planner file to get the plugins.

### What issues does this PR fix or reference?
@W-17909761@

