### PR TITLE
W-18012955 - fix: add checkDeployStatus for REST

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.8.5",
+    "@salesforce/core": "^8.8.7",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/types": "^1.3.0",
@@ -42,7 +42,7 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
-    "@jsforce/jsforce-node": "^3.6.6",
+    "@jsforce/jsforce-node": "^3.7.0",
     "@salesforce/cli-plugins-testkit": "^5.3.39",
     "@salesforce/dev-scripts": "^10.2.12",
     "@types/deep-equal-in-any-order": "^1.0.1",

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -152,7 +152,7 @@ export class MetadataApiDeploy extends MetadataTransfer<
     }
     const connection = await this.getConnection();
     // Recasting to use the project's version of the type
-    return connection.metadata.checkDeployStatus(this.id, true) as unknown as MetadataApiDeployStatus;
+    return connection.metadata.checkDeployStatus(this.id, true, this.isRestDeploy) as unknown as MetadataApiDeployStatus;
   }
 
   /**

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -11,6 +11,7 @@ import { AnyJson, ensureString, getString } from '@salesforce/ts-types';
 import { envVars, Lifecycle, Messages, PollingClient, StatusResult } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
+import * as sinon from 'sinon';
 import {
   ComponentSet,
   ComponentStatus,
@@ -323,7 +324,7 @@ describe('MetadataApiDeploy', () => {
         id: MOCK_ASYNC_RESULT.id,
         apiOptions: { rest: true },
         components: new ComponentSet(),
-      }
+      };
       const { operation, checkStatusStub } = await stubMetadataDeploy($$, testOrg, options);
       await operation.checkStatus();
       expect(checkStatusStub.calledOnce).to.be.true;
@@ -336,7 +337,7 @@ describe('MetadataApiDeploy', () => {
       const options = {
         id: MOCK_ASYNC_RESULT.id,
         components: new ComponentSet(),
-      }
+      };
       const { operation, checkStatusStub } = await stubMetadataDeploy($$, testOrg, options);
       await operation.checkStatus();
       expect(checkStatusStub.calledOnce).to.be.true;

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -317,6 +317,33 @@ describe('MetadataApiDeploy', () => {
         expect(e.message).to.equal(expectedError.message);
       }
     });
+
+    it('should pass isRestDeploy=true to checkDeployStatus', async () => {
+      const options = {
+        id: MOCK_ASYNC_RESULT.id,
+        apiOptions: { rest: true },
+        components: new ComponentSet(),
+      }
+      const { operation, checkStatusStub } = await stubMetadataDeploy($$, testOrg, options);
+      await operation.checkStatus();
+      expect(checkStatusStub.calledOnce).to.be.true;
+      expect(checkStatusStub.firstCall.firstArg).to.equal(MOCK_ASYNC_RESULT.id);
+      expect(checkStatusStub.firstCall.args[1]).to.equal(true);
+      expect(checkStatusStub.firstCall.args[2]).to.equal(true);
+    });
+
+    it('should pass isRestDeploy=false to checkDeployStatus', async () => {
+      const options = {
+        id: MOCK_ASYNC_RESULT.id,
+        components: new ComponentSet(),
+      }
+      const { operation, checkStatusStub } = await stubMetadataDeploy($$, testOrg, options);
+      await operation.checkStatus();
+      expect(checkStatusStub.calledOnce).to.be.true;
+      expect(checkStatusStub.firstCall.firstArg).to.equal(MOCK_ASYNC_RESULT.id);
+      expect(checkStatusStub.firstCall.args[1]).to.equal(true);
+      expect(checkStatusStub.firstCall.args[2]).to.equal(false);
+    });
   });
 
   describe('deployRecentValidation', () => {

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -118,7 +118,7 @@ export async function stubMetadataDeploy(
   status.done = true;
   const checkStatusStub = sandbox.stub(connection.metadata, 'checkDeployStatus');
   // @ts-ignore
-  checkStatusStub.withArgs(MOCK_ASYNC_RESULT.id, true).resolves(status);
+  checkStatusStub.withArgs(MOCK_ASYNC_RESULT.id, true, sinon.match.any).resolves(status);
 
   // @ts-ignore
   const invokeStub = sandbox.stub(connection.metadata, '_invoke');

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -13,6 +13,7 @@ import { PollingClient } from '@salesforce/core';
 import { match, SinonSpy, SinonStub } from 'sinon';
 import type { AsyncResult } from '@jsforce/jsforce-node/lib/api/metadata';
 import { ensureString } from '@salesforce/ts-types';
+import * as sinon from 'sinon';
 import {
   ComponentSet,
   ConvertOutputConfig,
@@ -141,6 +142,9 @@ export async function stubMetadataDeploy(
       usernameOrConnection: connection,
       components: options.components,
       id: options.id,
+      apiOptions: {
+        rest: options.apiOptions?.rest,
+      },
     }),
     response: status as MetadataApiDeployStatus,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,10 +588,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.6.5", "@jsforce/jsforce-node@^3.6.6":
-  version "3.6.6"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.6.6.tgz#26fe2fc9f4f3671ca8bfb0c98a728cb8a0219265"
-  integrity sha512-WdIo2lLbrz6nkfiaz2UynyaNiM8o+fEjaRev7zA4KKSaQYB1MJ66xHubeI5Iheq8WgkY9XGwWKAwPDhuV+GROQ==
+"@jsforce/jsforce-node@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.7.0.tgz#aaa317eef3207489db90498f79e96c5bd9f53469"
+  integrity sha512-v9pc3lPM5RMuB81Gasz5/NKcjktE1LLEACRFopB9LiXRafb4K9bStSMl3nLEHq7+OFdtxfQB3Sx2rYXJGG4DKw==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"
@@ -646,12 +646,12 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.8.0", "@salesforce/core@^8.8.3", "@salesforce/core@^8.8.5":
-  version "8.8.5"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.8.5.tgz#4004e22523e4e45b42631733d06dc8aec9fdc23d"
-  integrity sha512-eCiiO4NptvKkz04A4ivBVLzEBy/6IIFmaXoZ4tnF1FcD5MESvC+Xuc+0RFSRiYmPi5oloKNl6njrfVCKAho2zQ==
+"@salesforce/core@^8.8.0", "@salesforce/core@^8.8.3", "@salesforce/core@^8.8.7":
+  version "8.8.7"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.8.7.tgz#ac307e8f10934affa7bcf33ccb65993669cd8f12"
+  integrity sha512-AuPSmb/GZ7F8eV5GO6NcfFq3YSOVnPL4sssEQEvKduOSJMs8RTJ92kEefrId/tgFBYfw4b7UzndjFtdgrGGeoA==
   dependencies:
-    "@jsforce/jsforce-node" "^3.6.5"
+    "@jsforce/jsforce-node" "^3.7.0"
     "@salesforce/kit" "^3.2.2"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.10"


### PR DESCRIPTION
### What does this PR do?
Modifies the call to jsForce's metadata.checkDeployStatus() to pass `isRestDeploy` to use the REST endpoint.

NOTE: This PR requires [this jsForce PR](https://github.com/jsforce/jsforce/pull/1670) to be merged and published.  Then the `@salesforce/core` library needs to be updated with the jsForce version that contains that PR.  Then this PR needs to bump to that version of `@salesforce/core`, and bump the dev-dep version of jsforce-node.  Then PDR needs to bump library versions to get all the changes.

### What issues does this PR fix or reference?
@W-18012955@
