### PR TITLE
W-18115496 Regestring FieldServiceMobileConfig Metadata to SDR

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -538,7 +538,8 @@
     "uawork": "analyticsworkspace",
     "lifeSciConfigCategory": "lifesciconfigcategory",
     "lifeSciConfigRecord": "lifesciconfigrecord",
-    "invocableactionextension": "invocableactionextension"
+    "invocableactionextension": "invocableactionextension",
+    "fieldServiceMobileConfig": "fieldservicemobileconfig"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4795,6 +4796,14 @@
       "name": "InvocableActionExtension",
       "suffix": "invocableactionextension",
       "directoryName": "invocableactionextensions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "fieldservicemobileconfig": {
+      "id": "fieldservicemobileconfig",
+      "name": "FieldServiceMobileConfig",
+      "suffix": "fieldServiceMobileConfig",
+      "directoryName": "fieldServiceMobileConfigs",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?
It registers FieldServiceMobileConfig metadata type to SDR.

### What issues does this PR fix or reference?

FieldServiceMobileConfig is GA in 256 and we also need to expose FieldServiceMobileConfig for DevOps center (API v64), For that we need to register our FieldServiceMobileConfig Metadata type to SDR

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before
FieldServiceMobileConfig was not registered in SDR

<insert gif and/or summary>

### Functionality After
FieldServiceMobileConfig will be registered in SDR

<insert gif and/or summary>
