### PR TITLE
W-17980476: add functionality to exclude md types from connection resolver

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -321,7 +321,12 @@ export class ComponentSet extends LazyCollection<MetadataComponent> {
       }
     }
 
-    const connectionResolver = new ConnectionResolver(usernameOrConnection, options.registry, options.metadataTypes);
+    const connectionResolver = new ConnectionResolver(
+      usernameOrConnection,
+      options.registry,
+      options.metadataTypes,
+      options.excludedTypes
+    );
     const manifest = await connectionResolver.resolve(options.componentFilter);
     const result = new ComponentSet([], options.registry);
     result.apiVersion = manifest.apiVersion;

--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -260,6 +260,7 @@ export class ComponentSetBuilder {
       usernameOrConnection: connection,
       componentFilter: getOrgComponentFilter(org, mdMap, metadata),
       metadataTypes: mdMap.size ? Array.from(mdMap.keys()) : undefined,
+      excludedTypes: metadata?.excludedEntries?.length ? metadata.excludedEntries : undefined,
       registry,
     });
   }

--- a/src/collections/types.ts
+++ b/src/collections/types.ts
@@ -94,4 +94,8 @@ export type FromConnectionOptions = {
    * array of metadata type names to use for `connection.metadata.list()`
    */
   metadataTypes?: string[];
+  /**
+   * array of metadata type names to exclude
+   */
+  excludedTypes?: string[];
 } & OptionalTreeRegistryOptions;


### PR DESCRIPTION
### What does this PR do?
- Adds new optional parameter to connectionResolver class. This parameter is used to exclude specific types from the result.
 - Update CSB to pass the list of excluded types to CS. This fixes a bug where components in folders where included in the resulting CB even if they where not included in the list md types to be retrieved.

### What issues does this PR fix or reference?

[@W-17980476@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002AjRNfYAN/view)
https://github.com/forcedotcom/cli/issues/3232

### Functionality Before

Calling `sf project generate manifest --from-org my-org --name package --excluded-metadata Dashboard --excluded-metadata Report` doesn't exclude Dashboard and Report components from the resulting manifest. 

### Functionality After

Calling `sf project generate manifest --from-org my-org --name package --excluded-metadata Dashboard --excluded-metadata Report` excludes Dashboard and Report components from the resulting manifest. 
