### PR TITLE
W-17980476: exclude folder when folder content is excluded from org connection

### DIFF
--- a/src/collections/componentSetBuilder.ts
+++ b/src/collections/componentSetBuilder.ts
@@ -392,6 +392,9 @@ const buildMapFromMetadata = (mdOption: MetadataOption, registry: RegistryAccess
       if (cmp.metadataName === '*') {
         excludedTypes.push(cmp.type.name);
       }
+      if (cmp.type.folderType) {
+        excludedTypes.push(registry.getTypeByName(cmp.type.folderType).name);
+      }
     });
     if (mdMap.size === 0) {
       // we are excluding specific metadata types from all supported types


### PR DESCRIPTION
### What does this PR do?

Updates CSB build() method for when an Org and excluded types are passed in. It will check if the excluded type is a folder content and if so, it will also exclude the folder from the resulting CS. 
E.g. if Report type is excluded, it will also exclude ReportFolder.

[#3232](https://github.com/forcedotcom/cli/issues/3232), [@W-17980476@ >](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002AjRNfYAN/view)
