### PR TITLE
feat: add support for rootTypesWithDependencies to RetrieveRequest - W-17238293

### DIFF
--- a/src/client/metadataApiRetrieve.ts
+++ b/src/client/metadataApiRetrieve.ts
@@ -245,6 +245,7 @@ export class MetadataApiRetrieve extends MetadataTransfer<
       apiVersion: this.components?.sourceApiVersion ?? (await connection.retrieveMaxApiVersion()),
       ...(manifestData ? { unpackaged: manifestData } : {}),
       ...(this.options.singlePackage ? { singlePackage: this.options.singlePackage } : {}),
+      ...(this.options.rootTypesWithDependencies ? { rootTypesWithDependencies: this.options.rootTypesWithDependencies } : {}),
       // if we're retrieving with packageNames add it
       // otherwise don't - it causes errors if undefined or an empty array
       ...(packageNames.length ? { packageNames } : {}),

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -216,6 +216,7 @@ export type DeployMessage = {
 export type RetrieveRequest = {
   apiVersion: string;
   packageNames?: string[];
+  rootTypesWithDependencies?: string[];
   singlePackage?: boolean;
   specificFiles?: string[];
   unpackaged?: {
@@ -313,6 +314,11 @@ export type RetrieveOptions = {
    * A list of package names to retrieve, or package names and their retrieval locations.
    */
   packageOptions?: PackageOptions;
+  /**
+   * An array of metadata type names for which related, dependent metadata
+   * will be retrieved. At this time only `Bot` is supported.
+   */
+  rootTypesWithDependencies?: string[];
   /**
    * The file format desired for the retrieved files.
    */

--- a/test/client/metadataApiRetrieve.test.ts
+++ b/test/client/metadataApiRetrieve.test.ts
@@ -163,6 +163,25 @@ describe('MetadataApiRetrieve', () => {
         });
       });
 
+      it('should call retrieve with rootTypesWithDependencies', async () => {
+        const toRetrieve = new ComponentSet([COMPONENT]);
+        const options = {
+          toRetrieve,
+          rootTypesWithDependencies: [ 'Bot' ],
+          merge: true,
+          successes: toRetrieve,
+        };
+        const { operation, retrieveStub } = await stubMetadataRetrieve($$, testOrg, options);
+        await operation.start();
+
+        expect(retrieveStub.calledOnce).to.be.true;
+        expect(retrieveStub.firstCall.args[0]).to.deep.equal({
+          apiVersion: (await testOrg.getConnection()).getApiVersion(),
+          rootTypesWithDependencies: options.rootTypesWithDependencies,
+          unpackaged: (await toRetrieve.getObject()).Package,
+        });
+      });
+
       it('should return an AsyncResult', async () => {
         const toRetrieve = new ComponentSet([COMPONENT]);
         const options = {

--- a/test/mock/client/transferOperations.ts
+++ b/test/mock/client/transferOperations.ts
@@ -156,6 +156,7 @@ type RetrieveStubOptions = {
   toRetrieve?: ComponentSet;
   messages?: Partial<RetrieveMessage> | Array<Partial<RetrieveMessage>>;
   successes?: ComponentSet;
+  rootTypesWithDependencies?: string[];
 };
 
 type RetrieveOperationLifecycle = {
@@ -321,6 +322,7 @@ export async function stubMetadataRetrieve(
       packageOptions: options.packageOptions,
       usernameOrConnection: connection,
       components: retrievedComponents,
+      rootTypesWithDependencies: options.rootTypesWithDependencies,
       output: MOCK_DEFAULT_OUTPUT,
       registry: undefined,
       merge: options.merge,


### PR DESCRIPTION
### What does this PR do?
Adds support for the new, optional parameter on RetrieveRequest; `rootTypesWithDependencies`.  Using this parameter with an allowlisted metadata type (`Bot` is only supported as of today) will cause the response to include all dependent metadata for all requested metadata of that type.  It will also include a dependencies json file in a format similar to deploy/retrieve manifest xml files of the dependencies.

### What issues does this PR fix or reference?
 @W-17238293@

