### PR TITLE
fix: add DAM metadata types

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -541,7 +541,9 @@
     "lifeSciConfigCategory": "lifesciconfigcategory",
     "lifeSciConfigRecord": "lifesciconfigrecord",
     "invocableactionextension": "invocableactionextension",
-    "fieldServiceMobileConfig": "fieldservicemobileconfig"
+    "fieldServiceMobileConfig": "fieldservicemobileconfig",
+    "dgtAssetMgmtProvider": "dgtassetmgmtprovider",
+    "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4823,6 +4825,22 @@
       "name": "FieldServiceMobileConfig",
       "suffix": "fieldServiceMobileConfig",
       "directoryName": "fieldServiceMobileConfigs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprovider": {
+      "id": "dgtassetmgmtprovider",
+      "name": "DgtAssetMgmtProvider",
+      "suffix": "dgtAssetMgmtProvider",
+      "directoryName": "dgtAssetMgmtProviders",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "dgtassetmgmtprvdlghtcpnt": {
+      "id": "dgtassetmgmtprvdlghtcpnt",
+      "name": "DgtAssetMgmtPrvdLghtCpnt",
+      "suffix": "dgtAssetMgmtPrvdLghtCpnt",
+      "directoryName": "dgtAssetMgmtPrvdLghtCpnts",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3277
@W-18422782@

### Functionality Before

Internal users couldn't retrieve `DgtAssetMgmtPrvdLghtCpnt` and `DgtAssetMgmtProvider` (to be included in next Salesforce release)

### Functionality After

![Screenshot 2025-05-08 at 14 11 17](https://github.com/user-attachments/assets/a964be6b-8022-490a-a892-3efb5719f2fa)

<insert gif and/or summary>
