### PR TITLE
fix: include parent in manifest when retrieving - W-18650723

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.11.0",
+    "@salesforce/core": "^8.11.1",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/types": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.11.1",
+    "@salesforce/core": "^8.11.4",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/types": "^1.3.0",

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -980,7 +980,7 @@ describe('ComponentSet', () => {
       ]);
     });
 
-    it('omits empty parents from the package manifest', async () => {
+    it('omits empty parents from the package manifest when not a retrieve', async () => {
       const set = new ComponentSet([
         DECOMPOSED_CHILD_COMPONENT_1_EMPTY,
         DECOMPOSED_CHILD_COMPONENT_2_EMPTY,
@@ -992,6 +992,30 @@ describe('ComponentSet', () => {
         {
           name: DECOMPOSED_CHILD_COMPONENT_1_EMPTY.type.name,
           members: [DECOMPOSED_CHILD_COMPONENT_1_EMPTY.fullName],
+        },
+        {
+          name: DECOMPOSED_CHILD_COMPONENT_2_EMPTY.type.name,
+          members: [DECOMPOSED_CHILD_COMPONENT_2_EMPTY.fullName],
+        },
+      ]);
+    });
+
+    it('does not omit empty parents from the package manifest for retrieves', async () => {
+      const set = new ComponentSet([
+        DECOMPOSED_CHILD_COMPONENT_1_EMPTY,
+        DECOMPOSED_CHILD_COMPONENT_2_EMPTY,
+        DECOMPOSED_COMPONENT_EMPTY,
+      ]);
+      // @ts-expect-error modifying private property
+      set.forRetrieve = true;
+      expect((await set.getObject()).Package.types).to.deep.equal([
+        {
+          name: DECOMPOSED_CHILD_COMPONENT_1_EMPTY.type.name,
+          members: [DECOMPOSED_CHILD_COMPONENT_1_EMPTY.fullName],
+        },
+        {
+          name: DECOMPOSED_COMPONENT_EMPTY.type.name,
+          members: [DECOMPOSED_COMPONENT_EMPTY.fullName],
         },
         {
           name: DECOMPOSED_CHILD_COMPONENT_2_EMPTY.type.name,

--- a/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-deploy.expected/deployOutput/mdapi/objects/Broker__c.object
+++ b/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-deploy.expected/deployOutput/mdapi/objects/Broker__c.object
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>Title__c</fullName>
+        <externalId>false</externalId>
+        <label>Title</label>
+        <length>30</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-deploy.expected/deployOutput/mdapi/package.xml
+++ b/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-deploy.expected/deployOutput/mdapi/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Broker__c.Title__c</members>
+        <name>CustomField</name>
+    </types>
+    <version>59.0</version>
+</Package>

--- a/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-retrieve.expected/retrieveOutput/mdapi/objects/Broker__c.object
+++ b/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-retrieve.expected/retrieveOutput/mdapi/objects/Broker__c.object
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>Title__c</fullName>
+        <externalId>false</externalId>
+        <label>Title</label>
+        <length>30</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-retrieve.expected/retrieveOutput/mdapi/package.xml
+++ b/test/snapshot/sampleProjects/customObjects-and-children/__snapshots__/verify-md-files-retrieve.expected/retrieveOutput/mdapi/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Broker__c.Title__c</members>
+        <name>CustomField</name>
+    </types>
+    <types>
+        <members>Broker__c</members>
+        <name>CustomObject</name>
+    </types>
+    <version>59.0</version>
+</Package>

--- a/test/snapshot/sampleProjects/customObjects-and-children/originalMdapi2/objects/Broker__c.object
+++ b/test/snapshot/sampleProjects/customObjects-and-children/originalMdapi2/objects/Broker__c.object
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>Title__c</fullName>
+        <externalId>false</externalId>
+        <label>Title</label>
+        <length>30</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/test/snapshot/sampleProjects/customObjects-and-children/originalMdapi2/package.xml
+++ b/test/snapshot/sampleProjects/customObjects-and-children/originalMdapi2/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Broker__c.Title__c</members>
+        <name>CustomField</name>
+    </types>
+    <version>63.0</version>
+</Package>

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,7 +686,7 @@
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.11.1":
+"@salesforce/core@^8.11.4":
   version "8.11.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.11.4.tgz#e4f049351540a46e12bb5c1b6574232fd4d1288b"
   integrity sha512-6jrACrCmpic7mrnp4XQ6tiyx5FvHs101dQ2v+m8+aHF97036bul+GeeYuSjVp3ASh0sjR5CotYf7R65chd4H+A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,6 +604,22 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.8.2.tgz#68b903f6733ae479086ab02ea4a2de87a7f208eb"
+  integrity sha512-ewaRr9JnZRW6I28C/TzUnv5p70zMrWsKCq2ovRW6X557/ikdfvA24F9k4cQXZnTG2lZLEfVn+WwdBGEtY7pPnQ==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.4.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    https-proxy-agent "^5.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    xml2js "^0.6.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -670,12 +686,12 @@
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.11.0":
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.11.0.tgz#23d5ddcc318008230258ab449e70a26f671123c2"
-  integrity sha512-S4UgHKUy1hykRQVaoYm+LSktQgRhI3ltAUoLGI25/Q8gYokERTa2E7MpPMb+X/kTpjJJvDlnQqelB/sQJs/AKA==
+"@salesforce/core@^8.11.1":
+  version "8.11.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.11.4.tgz#e4f049351540a46e12bb5c1b6574232fd4d1288b"
+  integrity sha512-6jrACrCmpic7mrnp4XQ6tiyx5FvHs101dQ2v+m8+aHF97036bul+GeeYuSjVp3ASh0sjR5CotYf7R65chd4H+A==
   dependencies:
-    "@jsforce/jsforce-node" "^3.8.1"
+    "@jsforce/jsforce-node" "^3.8.2"
     "@salesforce/kit" "^3.2.2"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.10"
@@ -687,9 +703,9 @@
     js2xmlparser "^4.0.1"
     jsonwebtoken "9.0.2"
     jszip "3.10.1"
-    pino "^9.4.0"
+    pino "^9.7.0"
     pino-abstract-transport "^1.2.0"
-    pino-pretty "^11.2.2"
+    pino-pretty "^11.3.0"
     proper-lockfile "^4.1.2"
     semver "^7.6.3"
     ts-retry-promise "^0.8.1"
@@ -4589,6 +4605,13 @@ pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.2.0:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
+pino-abstract-transport@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
+  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
+  dependencies:
+    split2 "^4.0.0"
+
 pino-pretty@^11.2.2:
   version "11.2.2"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.2.2.tgz#5e8ec69b31e90eb187715af07b1d29a544e60d39"
@@ -4603,6 +4626,26 @@ pino-pretty@^11.2.2:
     minimist "^1.2.6"
     on-exit-leak-free "^2.1.0"
     pino-abstract-transport "^1.0.0"
+    pump "^3.0.0"
+    readable-stream "^4.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^4.0.1"
+    strip-json-comments "^3.1.1"
+
+pino-pretty@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.3.0.tgz#390b3be044cf3d2e9192c7d19d44f6b690468f2e"
+  integrity sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.2"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
     pump "^3.0.0"
     readable-stream "^4.0.0"
     secure-json-parse "^2.4.0"
@@ -4625,6 +4668,23 @@ pino@^9.4.0:
     pino-abstract-transport "^1.2.0"
     pino-std-serializers "^7.0.0"
     process-warning "^4.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^3.0.0"
+
+pino@^9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-9.7.0.tgz#ff7cd86eb3103ee620204dbd5ca6ffda8b53f645"
+  integrity sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^2.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^5.0.0"
     quick-format-unescaped "^4.0.3"
     real-require "^0.2.0"
     safe-stable-stringify "^2.3.1"
@@ -4682,6 +4742,11 @@ process-warning@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-4.0.0.tgz#581e3a7a1fb456c5f4fd239f76bce75897682d5a"
   integrity sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==
+
+process-warning@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-5.0.0.tgz#566e0bf79d1dff30a72d8bbbe9e8ecefe8d378d7"
+  integrity sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==
 
 process@^0.11.10:
   version "0.11.10"


### PR DESCRIPTION
### What does this PR do?
When retrieving a `CustomObject` that has an empty object-meta.xml file, include the CustomObject in the manifest entry and not just custom fields or other children.  This does not affect deploying or converting since different behavior is required for those operation.  I.e., including a CustomObject in the manifest without the object-meta data would fail deployment validation.  See https://github.com/forcedotcom/source-deploy-retrieve/pull/1375

### What issues does this PR fix or reference?
#3300, @W-18650723@

### Functionality Before
`sf project retrieve start -m CustomObject:TestObject__c` with an empty object-meta.xml file would result in a manifest like this:
```
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>TestObject__c.TestField__c</members>
        <name>CustomField</name>
    </types>
    <version>63.0</version>
</Package>
```

### Functionality After

```
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>TestObject__c.TestField__c</members>
        <name>CustomField</name>
    </types>
    <types>
        <members>TestObject__c</members>
        <name>CustomObject</name>
    </types>
    <version>63.0</version>
</Package>
```
