### PR TITLE
W-18734168 : Add new ExtlClntAppCanvasStngs to metadata registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -543,7 +543,8 @@
     "invocableactionextension": "invocableactionextension",
     "fieldServiceMobileConfig": "fieldservicemobileconfig",
     "dgtAssetMgmtProvider": "dgtassetmgmtprovider",
-    "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt"
+    "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt",
+    "ecaCanvas": "extlclntappcanvasstngs"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4841,6 +4842,14 @@
       "name": "DgtAssetMgmtPrvdLghtCpnt",
       "suffix": "dgtAssetMgmtPrvdLghtCpnt",
       "directoryName": "dgtAssetMgmtPrvdLghtCpnts",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "extlclntappcanvasstngs": {
+      "id": "extlclntappcanvasstngs",
+      "name": "ExtlClntAppCanvasStngs",
+      "suffix": "ecaCanvas",
+      "directoryName": "extlClntAppCanvasStngs",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?
Adds ExtlClntAppCanvasStngs metadata type to the registry.

### What issues does this PR fix or reference?
[@W-18734168@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FqonVYAR/view)

### Functionality Before

N/A

### Functionality After
ExtlClntAppCanvasStngs metadata type is exposed in registry.
