### PR TITLE
fix: track string replacements W-18794860

### DIFF
--- a/src/convert/replacements.ts
+++ b/src/convert/replacements.ts
@@ -42,7 +42,7 @@ export const getReplacementStreamForReadable = (
  * A stream for replacing the contents of a single SourceComponent.
  * Tracks which replacements were found across all chunks and emits warnings only at the end.
  */
-class ReplacementStream extends Transform {
+export class ReplacementStream extends Transform {
   private readonly foundReplacements = new Set<string>();
   private readonly allReplacements: MarkedReplacement[];
   private readonly lifecycleInstance = Lifecycle.getInstance();

--- a/src/resolve/sourceComponent.ts
+++ b/src/resolve/sourceComponent.ts
@@ -198,7 +198,7 @@ export class SourceComponent implements MetadataComponent {
 
       const replacements = this.replacements?.[xml] ?? this.parent?.replacements?.[xml];
       return this.parseAndValidateXML<T>(
-        replacements ? await replacementIterations(contents, replacements) : contents,
+        replacements ? (await replacementIterations(contents, replacements)).output : contents,
         xml
       );
     }

--- a/test/convert/replacements.test.ts
+++ b/test/convert/replacements.test.ts
@@ -316,48 +316,60 @@ describe('executes replacements on a string', () => {
   describe('string', () => {
     it('basic replacement', async () => {
       expect(
-        await replacementIterations('ThisIsATest', [
-          { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That', singleFile: true },
-        ])
+        (
+          await replacementIterations('ThisIsATest', [
+            { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That', singleFile: true },
+          ])
+        ).output
       ).to.equal('ThatIsATest');
     });
     it('same replacement occuring multiple times', async () => {
       expect(
-        await replacementIterations('ThisIsATestWithThisAndThis', [
-          { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That', singleFile: true },
-        ])
+        (
+          await replacementIterations('ThisIsATestWithThisAndThis', [
+            { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That', singleFile: true },
+          ])
+        ).output
       ).to.equal('ThatIsATestWithThatAndThat');
     });
     it('multiple replacements', async () => {
       expect(
-        await replacementIterations('ThisIsATestWithThisAndThis', [
-          { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That' },
-          { matchedFilename, toReplace: stringToRegex('ATest'), replaceWith: 'AnAwesomeTest' },
-        ])
+        (
+          await replacementIterations('ThisIsATestWithThisAndThis', [
+            { matchedFilename, toReplace: stringToRegex('This'), replaceWith: 'That' },
+            { matchedFilename, toReplace: stringToRegex('ATest'), replaceWith: 'AnAwesomeTest' },
+          ])
+        ).output
       ).to.equal('ThatIsAnAwesomeTestWithThatAndThat');
     });
   });
   describe('regex', () => {
     it('basic replacement', async () => {
       expect(
-        await replacementIterations('ThisIsATest', [
-          { toReplace: /Is/g, replaceWith: 'IsNot', singleFile: true, matchedFilename },
-        ])
+        (
+          await replacementIterations('ThisIsATest', [
+            { toReplace: /Is/g, replaceWith: 'IsNot', singleFile: true, matchedFilename },
+          ])
+        ).output
       ).to.equal('ThisIsNotATest');
     });
     it('same replacement occuring multiple times', async () => {
       expect(
-        await replacementIterations('ThisIsATestWithThisAndThis', [
-          { toReplace: /s/g, replaceWith: 'S', singleFile: true, matchedFilename },
-        ])
+        (
+          await replacementIterations('ThisIsATestWithThisAndThis', [
+            { toReplace: /s/g, replaceWith: 'S', singleFile: true, matchedFilename },
+          ])
+        ).output
       ).to.equal('ThiSISATeStWithThiSAndThiS');
     });
     it('multiple replacements', async () => {
       expect(
-        await replacementIterations('This Is A Test With This And This', [
-          { toReplace: /^T.{2}s/, replaceWith: 'That', singleFile: false, matchedFilename },
-          { toReplace: /T.{2}s$/, replaceWith: 'Stuff', singleFile: false, matchedFilename },
-        ])
+        (
+          await replacementIterations('This Is A Test With This And This', [
+            { toReplace: /^T.{2}s/, replaceWith: 'That', singleFile: false, matchedFilename },
+            { toReplace: /T.{2}s$/, replaceWith: 'Stuff', singleFile: false, matchedFilename },
+          ])
+        ).output
       ).to.equal('That Is A Test With This And Stuff');
     });
   });
@@ -376,24 +388,28 @@ describe('executes replacements on a string', () => {
       emitSpy.restore();
     });
     it('emits warning only when no change', async () => {
-      await replacementIterations('ThisIsATest', [
+      // Warnings are now emitted in the stream, not in replacementIterations
+      const result = await replacementIterations('ThisIsATest', [
         { toReplace: stringToRegex('Nope'), replaceWith: 'Nah', singleFile: true, matchedFilename },
       ]);
-      expect(warnSpy.callCount).to.equal(1);
-      expect(emitSpy.callCount).to.equal(1);
+      expect(result.output).to.equal('ThisIsATest');
+      // No warning should be emitted here
+      expect(warnSpy.callCount).to.equal(0);
+      expect(emitSpy.callCount).to.equal(0);
     });
     it('no warning when string is replaced', async () => {
-      await replacementIterations('ThisIsATest', [
+      const result = await replacementIterations('ThisIsATest', [
         { toReplace: stringToRegex('Test'), replaceWith: 'SpyTest', singleFile: true, matchedFilename },
       ]);
+      expect(result.output).to.equal('ThisIsASpyTest');
       expect(warnSpy.callCount).to.equal(0);
-      // because it emits the replacement event
       expect(emitSpy.callCount).to.equal(1);
     });
     it('no warning when no replacement but not a single file (ex: glob)', async () => {
-      await replacementIterations('ThisIsATest', [
+      const result = await replacementIterations('ThisIsATest', [
         { toReplace: stringToRegex('Nope'), replaceWith: 'Nah', singleFile: false, matchedFilename },
       ]);
+      expect(result.output).to.equal('ThisIsATest');
       expect(warnSpy.callCount).to.equal(0);
       expect(emitSpy.callCount).to.equal(0);
     });


### PR DESCRIPTION
### What does this PR do?

Updates the `ReplacementStream` transform stream to keep track of replacements applied to a file.

In the conversion pipeline we have this transformer perform [string replacements](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_string_replace.htm) on each file.
Bigger files get split into chunks and could get into a false-positive about missing replacement when:

1. project specifies 2 or more string replacements in `sfdx-project.json`
2. big file is split in 2 or more chunks
3. 1st chunk contains 1 string to replace but the other one is in the next chunk

This is a false-positive warning because all chunks go through the transform step in the pipeline.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3318
[@W-18794860@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002GFo90YAD/view)

### Functionality Before

![Screenshot 2025-06-16 at 15 27 07](https://github.com/user-attachments/assets/7bf3e8b8-cac3-4ed3-a710-92297552967f)


### Functionality After

![Screenshot 2025-06-16 at 15 27 31](https://github.com/user-attachments/assets/306dc149-90dd-488f-a906-859cb5afd2d7)

### Testing instructions

project:
1. clone dreamhouse
2. use this sfdx-project.json:
```json
{
    "packageDirectories": [
        {
            "path": "force-app",
            "default": true
        }
    ],
    "namespace": "",
    "sourceApiVersion": "63.0",
    "replacements": [
        {
            "filename": "force-app/main/default/sites/E_Bikes.site-meta.xml",
            "stringToReplace": "replaceMe",
            "replaceWithEnv": "ADMIN"
        },
          {
            "filename": "force-app/main/default/sites/E_Bikes.site-meta.xml",
            "stringToReplace": "ownerReplaceMe",
            "replaceWithEnv": "OWNER"
        }
    ]
}
```
3. update `force-app/main/default/sites/E_Bikes.site-meta.xml` to have 2 xml nodes with strings to replace, put any on the top and repeat the same line few thousand times, same with the other node so you ensure the first and last chunks are missing one of the replacements. ~7K lines worked for me.

Suggestion:
add `console.count('chunk')` right here:
https://github.com/forcedotcom/source-deploy-retrieve/blob/83f4aba6b797bd135fca212707fe5cde66d00aa6/src/convert/replacements.ts#L60

to see how many chunks were passed across the pipeline.

CLI
1. checkout this PR, build and link it into plugin-deploy-retrieve
2. run this command, see no warnings:
```
rm -rf ./gen && OWNER=doe ADMIN=jon SF_APPLY_REPLACEMENTS_ON_CONVERT=true sf project convert source -p force-app/main/default/sites/E_Bikes.site-meta.xml -d gen --json
```

then verify the replacements happened 😄 

(if you unlink this branch you will see the warnings as mentioned in the GH issue).


-------------------------------

🪄 fixed by copilot agent using gpt-4.1.
prompt:
```
replacementIterations is used in a writable stream pipeline where it gets chunks of a file and performs a string replacement, or warns if a string replacement option was defined but not found in the string.

There's a bug where if a file is big enough to be split in chunks, one chunk might not have a replacement done even thought the replacement happened in a separate one, giving a false-positive warning.

Think of plan to fix this code
```