### PR TITLE
@W-18141734: feat: add ApiNamedQuery to metadataRegistry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -546,7 +546,8 @@
     "fieldServiceMobileConfig": "fieldservicemobileconfig",
     "dgtAssetMgmtProvider": "dgtassetmgmtprovider",
     "dgtAssetMgmtPrvdLghtCpnt": "dgtassetmgmtprvdlghtcpnt",
-    "ecaCanvas": "extlclntappcanvasstngs"
+    "ecaCanvas": "extlclntappcanvasstngs",
+    "apiNamedQuery": "apinamedquery"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4867,6 +4868,14 @@
       "name": "ExtlClntAppCanvasStngs",
       "suffix": "ecaCanvas",
       "directoryName": "extlClntAppCanvasStngs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "apinamedquery": {
+      "id": "apinamedquery",
+      "name": "ApiNamedQuery",
+      "suffix": "apiNamedQuery",
+      "directoryName": "apiNamedQueries",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?
This PR added ApiNamedQuery to metadataRegistry so that SF CLI could work with NamedQuery API features

### What issues does this PR fix or reference?
This PR added ApiNamedQuery to metadataRegistry so that SF CLI could work with NamedQuery API features

#<Insert GitHub Issue>, @W-18141734@

### Functionality Before

SF CLI doesn't current support NamedQuery API features. An attempt to retrieve metadata type ApiNamedQuery will result in error "Error (RegistryError): Missing metadata type definition in registry for id 'apinamedquery'."

### Functionality After

SF CLI supports interaction with ApiNamedQuery
