### PR TITLE
Jon freed/perf ziptreecont match

### DIFF
--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* eslint-disable class-methods-use-this */
-import { join, dirname, basename, normalize, sep, posix } from 'node:path';
+import { join, dirname, basename, sep, posix } from 'node:path';
 import { Readable } from 'node:stream';
 import { statSync, existsSync, readdirSync, createReadStream, readFileSync } from 'graceful-fs';
 import JSZip from 'jszip';

--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* eslint-disable class-methods-use-this */
-import { join, dirname, basename, normalize, sep } from 'node:path';
+import { join, dirname, basename, normalize, sep, posix } from 'node:path';
 import { Readable } from 'node:stream';
 import { statSync, existsSync, readdirSync, createReadStream, readFileSync } from 'graceful-fs';
 import JSZip from 'jszip';
@@ -191,23 +191,18 @@ export class ZipTreeContainer extends TreeContainer {
     throw new SfError(messages.getMessage('error_expected_file_path', [fsPath]), 'LibraryError');
   }
 
-  // Finds a matching entry in the zip by first comparing basenames, then dirnames.
-  // Note that zip files always use forward slash separators, so paths within the
-  // zip files are normalized for the OS file system before comparing.
+  // Finds a matching entry in the zip.
+  // Note that zip files always use forward slash separators, so the provided path
+  // is converted to use posix forward slash separators before comparing.
   private match(fsPath: string): string | undefined {
     // "dot" has a special meaning as a directory name and always matches. Just return it.
     if (fsPath === '.') {
       return fsPath;
     }
-
-    const fsPathBasename = basename(fsPath);
-    const fsPathDirname = dirname(fsPath);
-    return Object.keys(this.zip.files).find((filePath) => {
-      const normFilePath = normalize(filePath);
-      if (basename(normFilePath) === fsPathBasename) {
-        return dirname(normFilePath) === fsPathDirname;
-      }
-    });
+    const posixPath = posix.normalize(fsPath);
+    return Object.prototype.hasOwnProperty.call(this.zip.files, posixPath) 
+      ? posixPath 
+      : undefined;
   }
 
   private ensureDirectory(dirPath: string): boolean {


### PR DESCRIPTION
### What does this PR do?

Improves performance of the `ZipTreeContainer.match()` function, which can be called many thousands of times during metadata operations.

The match() code being replaced does a linear search (Array.find()) while doing the same string manipulation for each array entry it evaluates (normalize, basename, dirname).  All of that work adds up.  

The new match() code just does one string manipulation (posix.normalize) on the incoming string parameter and then does a simple and fast direct key lookup.  This works because JSZip keys are always in forward-slash (POSIX normalized) format.

The match() function inputs and outputs remain the same.

In performance tests with full-org retrievals, this change reduced `match()` CPU self time by 5–12%, shaving over a minute from overall execution time due to the high volume of calls.

### What issues does this PR fix or reference?

n/a

### Functionality Before

match() returned the path to the file within the zip file if found, otherwise undefined.

### Functionality After

same