### PR TITLE
@W-17203557: feat: Update metadata registry with RuleLibraryDefinition

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -552,7 +552,7 @@
     "ecaCanvas": "extlclntappcanvasstngs",
     "apiNamedQuery": "apinamedquery",
     "ExternalStoragePrvdConfigSet": "externalstorageprvdconfig",
-    "ruleLibraryDefinition":  "rulelibrarydefinition"
+    "ruleLibraryDefinition": "rulelibrarydefinition"
   },
   "types": {
     "accesscontrolpolicy": {


### PR DESCRIPTION
to address this: https://github.com/forcedotcom/cli/issues/3099

What does this PR do?
This PR added RuleLibraryDefinition to metadataRegistry so that SF CLI could work with this RCA type

What issues does this PR fix or reference?
This PR added RuleLibraryDefinition to metadataRegistry so that SF CLI could work with this RCA type

#, @W-17203557@

Functionality Before
SF CLI doesn't current support RuleLibraryDefinition API features. An attempt to retrieve metadata type RuleLibraryDefinition will result in error "Error (RegistryError): Missing metadata type definition in registry for id 'rulelibrarydefinition'."

Functionality After
SF CLI supports interaction with RuleLibraryDefinition