### PR TITLE
fix: filter out empty dirs when resolving components from path

### DIFF
--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -88,6 +88,11 @@ export class MetadataResolver {
 
       if (this.tree.isDirectory(fsPath)) {
         if (resolveDirectoryAsComponent(this.registry)(this.tree)(fsPath)) {
+          // Filter out empty directories to prevent deployment issues
+          if (this.tree.readDirectory(fsPath).length === 0) {
+            continue;
+          }
+
           const component = this.resolveComponent(fsPath, true);
           if (component && (!inclusiveFilter || inclusiveFilter.has(component))) {
             components.push(component);

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -220,7 +220,7 @@ describe('ComponentSet', () => {
 
         let preAndPostRetrieveEventCount = 0;
         lifecycleEmitStub.args.forEach((event) => {
-          if (event[0] === ('scopedPreRetrieve' || 'scopedPostRetrieve')) {
+          if (event[0] === 'scopedPreRetrieve' || event[0] === 'scopedPostRetrieve') {
             preAndPostRetrieveEventCount = preAndPostRetrieveEventCount + 1;
           }
         });

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -979,5 +979,47 @@ describe('MetadataResolver', () => {
         expect(result).to.deep.equal([]);
       });
     });
+
+    it('should filter out empty directories when resolving components', () => {
+      const resolver = testUtil.createMetadataResolver([
+        {
+          dirPath: 'lwc',
+          children: ['myComponent', 'emptyComponent'],
+        },
+        {
+          dirPath: 'lwc/myComponent',
+          children: ['myComponent.js', 'myComponent.js-meta.xml'],
+        },
+        {
+          dirPath: 'lwc/emptyComponent',
+          children: [], // Empty directory
+        },
+      ]);
+
+      const expectedComponent = new SourceComponent({
+        name: 'myComponent',
+        type: registry.types.lightningcomponentbundle,
+        content: 'lwc/myComponent',
+        xml: 'lwc/myComponent/myComponent.js-meta.xml',
+      });
+
+      testUtil.stubAdapters([
+        {
+          type: registry.types.lightningcomponentbundle,
+          componentMappings: [
+            {
+              path: 'lwc/myComponent',
+              component: expectedComponent,
+            },
+          ],
+        },
+      ]);
+
+      const components = resolver.getComponentsFromPath('lwc');
+
+      // Should only return the non-empty component
+      expect(components).to.have.length(1);
+      expect(components[0].name).to.equal('myComponent');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a fix to ensure empty directories are excluded when resolving components and includes a test update to validate this behavior. Additionally, it corrects a logical error in a test condition. Below are the most important changes grouped by theme:

### Metadata resolution improvements:
* [`src/resolve/metadataResolver.ts`](diffhunk://#diff-203e6a2753d1d337462f07b575a5458e494bc231005c0554e3e2a996b49509d0R91-R95): Added a check to filter out empty directories in the `MetadataResolver` class to prevent deployment issues when resolving components.

### Test updates:
* [`test/resolve/metadataResolver.test.ts`](diffhunk://#diff-05cdc30e060c3fb02a75e0fe625781e7ca6f9c6f79b034c2d5334053bd982492R982-R1023): Added a new test case to verify that empty directories are correctly excluded when resolving components.
* [`test/collections/componentSet.test.ts`](diffhunk://#diff-3666a9944f11ccd9b477431ab6eb0ae138b5be8de1c5e9c82956cb42c0558a3dL223-R223): Fixed a logical error in a test condition by correcting the syntax for checking event types (`scopedPreRetrieve` and `scopedPostRetrieve`).

### What issues does this PR fix or reference?
@W-18991079@