### PR TITLE
fix: add logger to detect hidden dir- W-18715150

### DIFF
--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -309,8 +309,9 @@ const existsOrDoesntMatchIgnored =
   (writeInfo: WriteInfo): boolean => {
     const result = existsSync(writeInfo.output) || forceignore.accepts(writeInfo.output);
 
+    // Detect if file was ignored by .forceignore patterns
     if (!result) {
-      logger.debug(`File ${writeInfo.output} was ignored by .forceignore patterns`);
+      logger.debug(`File ${writeInfo.output} was ignored or not exists`);
     }
     return result;
   };

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -141,13 +141,14 @@ export class StandardWriter extends ComponentWriter {
     if (chunk.writeInfos.length !== 0) {
       try {
         const toResolve = new Set<string>();
+
         // it is a reasonable expectation that when a conversion call exits, the files of
         // every component has been written to the destination. This await ensures the microtask
         // queue is empty when that call exits and overall less memory is consumed.
         await Promise.all(
           chunk.writeInfos
             .map(makeWriteInfoAbsolute(this.rootDestination))
-            .filter(existsOrDoesntMatchIgnored(this.forceignore))
+            .filter(existsOrDoesntMatchIgnored(this.forceignore)) // Skip files matched by default ignore
             .map((info) => {
               if (info.shouldDelete) {
                 this.deleted.push({
@@ -304,6 +305,13 @@ const makeWriteInfoAbsolute =
   });
 
 const existsOrDoesntMatchIgnored =
-  (forceignore: ForceIgnore) =>
-  (writeInfo: WriteInfo): boolean =>
-    existsSync(writeInfo.output) || forceignore.accepts(writeInfo.output);
+  (forceignore: ForceIgnore, logger?: Logger) =>
+  (writeInfo: WriteInfo): boolean => {
+    const result = existsSync(writeInfo.output) || forceignore.accepts(writeInfo.output);
+
+    // For hidden path detection
+    if (writeInfo.output.includes('/.')) {
+      logger?.debug(`Found file in hidden directory: ${writeInfo.output}`);
+    }
+    return result;
+  };

--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -148,7 +148,7 @@ export class StandardWriter extends ComponentWriter {
         await Promise.all(
           chunk.writeInfos
             .map(makeWriteInfoAbsolute(this.rootDestination))
-            .filter(existsOrDoesntMatchIgnored(this.forceignore)) // Skip files matched by default ignore
+            .filter(existsOrDoesntMatchIgnored(this.forceignore, this.logger)) // Skip files matched by default ignore
             .map((info) => {
               if (info.shouldDelete) {
                 this.deleted.push({
@@ -305,13 +305,12 @@ const makeWriteInfoAbsolute =
   });
 
 const existsOrDoesntMatchIgnored =
-  (forceignore: ForceIgnore, logger?: Logger) =>
+  (forceignore: ForceIgnore, logger: Logger) =>
   (writeInfo: WriteInfo): boolean => {
     const result = existsSync(writeInfo.output) || forceignore.accepts(writeInfo.output);
 
-    // For hidden path detection
-    if (writeInfo.output.includes('/.')) {
-      logger?.debug(`Found file in hidden directory: ${writeInfo.output}`);
+    if (!result) {
+      logger.debug(`File ${writeInfo.output} was ignored by .forceignore patterns`);
     }
     return result;
   };


### PR DESCRIPTION
### What does this PR do?
Add debug logger to detect hidden directories early
### What issues does this PR fix or reference?

Github issue link: https://github.com/forcedotcom/cli/issues/3310, @W-18715150@
### Functionality Before
Hidden directory get processed normally
No early warning, no visibility

### Functionality After

Catches all hidden directory usage and early detecting before writing
