### PR TITLE
@W-19292248@ Fix CatalogedApiArtifactVersionInfo in metadata registry

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -798,5 +798,5 @@ v65 introduces the following new types.  Here's their current level of support
 - DgtAssetMgmtPrvdLghtCpnt
 - CatalogedApi
 - CatalogedApiVersion
-- CatalogedApiArtfctVerInfo
+- CatalogedApiArtifactVersionInfo
 - RuleLibraryDefinition

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -166,7 +166,7 @@
     "careSystemFieldMapping": "caresystemfieldmapping",
     "catalogedApi": "catalogedapi",
     "catalogedApiVersion": "catalogedapiversion",
-    "catalogedApiArtfctVerInfo": "catalogedapiartfctverinfo",
+    "catalogedApiArtifactVersionInfo": "catalogedapiartifactversioninfo",
     "catalogFilterCondition": "svccatalogfiltercondition",
     "catalogFilterCriteria": "svccatalogfiltercriteria",
     "catalogItem": "svccatalogitemdef",
@@ -4908,11 +4908,11 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-    "catalogedapiartfctverinfo": {
-      "id": "catalogedapiartfctverinfo",
-      "name": "CatalogedApiArtfctVerInfo",
-      "suffix": "catalogedApiArtfctVerInfo",
-      "directoryName": "catalogedApiArtfctsVerInfo",
+    "catalogedapiartifactversioninfo": {
+      "id": "catalogedapiartifactversioninfo",
+      "name": "CatalogedApiArtifactVersionInfo",
+      "suffix": "catalogedApiArtifactVersionInfo",
+      "directoryName": "catalogedApiArtifactsVersionInfo",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?

* Updates the Salesforce metadata registry to fix the `CatalogedApiArtifactVersionInfo` entry.  
* After a review, it was requested to rename `artfcsver` to `artifactsversion`; accordingly, this PR updates the name, directory, and suffix to match the new convention.

### What issues does this PR fix or reference?

@W-19292248@
GUS Work Item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002JqX0mYAF/view

### Functionality Before

The metadata registry entry for `CatalogedApiArtifactVersionInfo` used the outdated identifier `artfcsver`, along with the old directory and suffix.

### Functionality After

The registry entry now uses the corrected identifier `artifactsversion` with updated directory and suffix, ensuring consistency with the revised naming standard.
