### PR TITLE
fix: add support for CustomFieldDisplay

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -553,7 +553,8 @@
     "ecaCanvas": "extlclntappcanvasstngs",
     "apiNamedQuery": "apinamedquery",
     "ExternalStoragePrvdConfigSet": "externalstorageprvdconfig",
-    "ruleLibraryDefinition": "rulelibrarydefinition"
+    "ruleLibraryDefinition": "rulelibrarydefinition",
+    "customFieldDisplay": "customfielddisplay"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4929,6 +4930,14 @@
       "name": "RuleLibraryDefinition",
       "suffix": "ruleLibraryDefinition",
       "directoryName": "ruleLibraryDefinition",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "customfielddisplay": {
+      "id": "customfielddisplay",
+      "name": "CustomFieldDisplay",
+      "suffix": "customFieldDisplay",
+      "directoryName": "customFieldDisplays",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?

Add support for the `CustomFieldDisplay` metadata type.

### What issues does this PR fix or reference?

N/A

### Functionality Before

`CustomFieldDisplay` was not supported.

### Functionality After

`CustomFieldDisplay` is now supported.
