### PR TITLE
@W-19405722 Fix Cataloged Artifact Version directory

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -4949,7 +4949,7 @@
       "id": "catalogedapiartifactversioninfo",
       "name": "CatalogedApiArtifactVersionInfo",
       "suffix": "catalogedApiArtifactVersionInfo",
-      "directoryName": "catalogedApiArtifactsVersionInfo",
+      "directoryName": "catalogedApiArtifactVersionInfos",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
### What does this PR do?

* Fixes the `directoryName` for the **CatalogedApiArtifactVersionInfo** metadata type.  
  * Updated from `catalogedApiArtifactVersionInfo` → `catalogedApiArtifactVersionInfos`  
  * Ensures consistency with the expected directory naming convention.

### What issues does this PR fix or reference?

Fixes #<GitHub Issue>  
[GUS Ticket](https://gus.lightning.force.com/lightning/r/a07EE00002KZqGvYAL/view)

### Functionality Before

The metadata type **CatalogedApiArtifactVersionInfo** had an incorrect `directoryName` that did not follow the required naming convention, potentially causing issues during retrieve/deploy operations.  

### Functionality After

The metadata type now uses the correct `directoryName` (`catalogedApiArtifactVersionInfos`), ensuring compatibility and alignment with Salesforce metadata standards.  
