### PR TITLE
perf: cache ForceIgnore and speed up resolver and virtual tree - W-21986538

### DIFF
--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import * as os from 'node:os';
 import ignore, { Ignore } from 'ignore/index';
-import { readFileSync } from 'graceful-fs';
+import { readFileSync, statSync } from 'graceful-fs';
 import { Lifecycle } from '@salesforce/core/lifecycle';
 import { Logger } from '@salesforce/core/logger';
 import { SourcePath } from '../common/types';
 import { searchUp } from '../utils/fileSystemHandler';
+
+type IgnoreFileCacheEntry = { mtimeMs: number; size: number; instance: ForceIgnore };
+
+const ignoreFileByPath = new Map<string, IgnoreFileCacheEntry>();
+let emptyWhenNoIgnoreFile: ForceIgnore | undefined;
 
 export class ForceIgnore {
   public static readonly FILE_NAME = '.forceignore';
@@ -78,11 +83,41 @@ export class ForceIgnore {
    * `ForceIgnore` object based on the result. If there is no `.forceignore` file,
    * the returned `ForceIgnore` object will accept everything.
    *
+   * Parsed files are cached by absolute path and invalidated when `mtime` or `size` changes on disk.
+   *
    * @param seed Path to begin the `.forceignore` search from
    */
   public static findAndCreate(seed: SourcePath): ForceIgnore {
     const projectConfigPath = searchUp(seed, ForceIgnore.FILE_NAME);
-    return new ForceIgnore(projectConfigPath ? join(dirname(projectConfigPath), ForceIgnore.FILE_NAME) : '');
+    if (!projectConfigPath) {
+      emptyWhenNoIgnoreFile ??= new ForceIgnore('');
+      return emptyWhenNoIgnoreFile;
+    }
+
+    const absPath = normalize(projectConfigPath);
+    let mtimeMs: number;
+    let size: number;
+    try {
+      const st = statSync(absPath);
+      ({ mtimeMs, size } = st);
+    } catch {
+      return new ForceIgnore('');
+    }
+
+    const hit = ignoreFileByPath.get(absPath);
+    if (hit && hit.mtimeMs === mtimeMs && hit.size === size) {
+      return hit.instance;
+    }
+
+    const instance = new ForceIgnore(join(dirname(absPath), ForceIgnore.FILE_NAME));
+    ignoreFileByPath.set(absPath, { mtimeMs, size, instance });
+    return instance;
+  }
+
+  /** @internal clears module cache; for unit tests only */
+  public static clearCacheForTest(): void {
+    ignoreFileByPath.clear();
+    emptyWhenNoIgnoreFile = undefined;
   }
 
   public denies(fsPath: SourcePath): boolean {

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -88,12 +88,21 @@ export class MetadataResolver {
       return components;
     }
 
-    for (const fsPath of this.tree
-      .readDirectory(dir)
-      .map(fnJoin(dir))
-      // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
-      // before finding the parent and returning only it - by sorting, we make it as recursive as possible
-      .sort(this.sortDirsFirst)) {
+    const entries = this.tree.readDirectory(dir).map(fnJoin(dir));
+    const isDirByPath = new Map(entries.map((entry) => [entry, this.tree.isDirectory(entry)]));
+    // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
+    // before finding the parent and returning only it - by sorting, we make it as recursive as possible
+    for (const fsPath of entries.sort((a, b) => {
+      const aDir = isDirByPath.get(a)!;
+      const bDir = isDirByPath.get(b)!;
+      if (aDir && bDir) {
+        return 0;
+      } else if (aDir && !bDir) {
+        return -1;
+      } else {
+        return 1;
+      }
+    })) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -139,15 +148,6 @@ export class MetadataResolver {
     return components.concat(dirQueue.flatMap((d) => this.getComponentsFromPathRecursive(d, inclusiveFilter)));
   }
 
-  private sortDirsFirst = (a: string, b: string): number => {
-    if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
-      return 0;
-    } else if (this.tree.isDirectory(a) && !this.tree.isDirectory(b)) {
-      return -1;
-    } else {
-      return 1;
-    }
-  };
   private resolveComponent(fsPath: string, isResolvingSource: boolean): SourceComponent | undefined {
     if (this.forceIgnore?.denies(fsPath)) {
       // don't resolve the component if the path is denied

--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -266,24 +266,37 @@ export class VirtualTreeContainer extends TreeContainer {
    * @returns VirtualTreeContainer
    */
   public static fromFilePaths(paths: string[]): VirtualTreeContainer {
-    // a map to reduce array iterations
-    const virtualDirectoryByFullPath = new Map<string, VirtualDirectory>();
-    paths
-      // defending against undefined being passed in.  The metadata API sometimes responds missing fileName
-      .filter(isString)
-      .map((filename) => {
-        const splits = filename.split(sep);
-        for (let i = 0; i < splits.length - 1; i++) {
-          const fullPathSoFar = splits.slice(0, i + 1).join(sep);
-          const existing = virtualDirectoryByFullPath.get(fullPathSoFar);
-          virtualDirectoryByFullPath.set(fullPathSoFar, {
-            dirPath: fullPathSoFar,
-            // only add to children if we don't already have it
-            children: Array.from(new Set(existing?.children ?? []).add(splits[i + 1])),
-          });
+    const childrenByDir = new Map<string, Set<string>>();
+    for (const filename of paths) {
+      if (!isString(filename)) {
+        continue;
+      }
+      const splits = filename.split(sep);
+      if (splits.length <= 1) {
+        continue;
+      }
+
+      let currentDir = splits[0];
+      for (let i = 0; i < splits.length - 1; i++) {
+        const childName = splits[i + 1];
+        let childSet = childrenByDir.get(currentDir);
+        if (!childSet) {
+          childSet = new Set<string>();
+          childrenByDir.set(currentDir, childSet);
         }
-      });
-    return new VirtualTreeContainer(Array.from(virtualDirectoryByFullPath.values()));
+        childSet.add(childName);
+        if (i < splits.length - 2) {
+          currentDir = join(currentDir, childName);
+        }
+      }
+    }
+
+    const virtualFs: VirtualDirectory[] = Array.from(childrenByDir.entries()).map(([dirPath, set]) => ({
+      dirPath,
+      children: Array.from(set),
+    }));
+
+    return new VirtualTreeContainer(virtualFs);
   }
 
   public isDirectory(fsPath: string): boolean {

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import type { Stats } from 'node:fs';
 import { join } from 'node:path';
 import * as os from 'node:os';
 import { expect } from 'chai';
@@ -33,6 +35,7 @@ describe('ForceIgnore', () => {
   afterEach(() => {
     env.restore();
     Sinon.restore();
+    ForceIgnore.clearCacheForTest();
   });
 
   it('Should default to not ignoring a file if forceignore is not loaded', () => {
@@ -80,10 +83,46 @@ describe('ForceIgnore', () => {
   it('Should find a forceignore file from a given path', () => {
     const readStub = env.stub(fs, 'readFileSync');
     const searchStub = env.stub(fsUtil, 'searchUp');
+    env.stub(fs, 'statSync').returns({ mtimeMs: 99, size: 500 } as Stats);
     readStub.withArgs(forceIgnorePath).returns(testPattern);
     searchStub.withArgs(testPath, ForceIgnore.FILE_NAME).returns(forceIgnorePath);
     const forceIgnore = ForceIgnore.findAndCreate(testPath);
     expect(forceIgnore.accepts(testPath)).to.be.false;
+  });
+
+  describe('findAndCreate cache', () => {
+    it('reuses the same instance and reads .forceignore once when mtime/size unchanged', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      writeFileSync(fiPath, `${testPattern}\n`);
+      mkdirSync(join(tmp, 'pkg', 'classes'), { recursive: true });
+      const seedA = join(tmp, 'pkg', 'classes');
+      const seedB = join(tmp, 'pkg', 'classes', 'Foo.cls');
+      const readSpy = env.spy(fs, 'readFileSync');
+      const first = ForceIgnore.findAndCreate(seedA);
+      const second = ForceIgnore.findAndCreate(seedB);
+      expect(first).to.equal(second);
+      const readsForFi = readSpy
+        .getCalls()
+        .filter((c) => typeof c.args[0] === 'string' && c.args[0].endsWith(ForceIgnore.FILE_NAME));
+      expect(readsForFi.length).to.equal(1);
+    });
+
+    it('reloads when .forceignore mtime or size changes', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-inv-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      writeFileSync(fiPath, '**/old/**\n');
+      mkdirSync(join(tmp, 'force-app'), { recursive: true });
+      const seed = join(tmp, 'force-app');
+      const readSpy = env.spy(fs, 'readFileSync');
+      ForceIgnore.findAndCreate(seed);
+      writeFileSync(fiPath, '**/new/**\n');
+      ForceIgnore.findAndCreate(seed);
+      const readsForFi = readSpy
+        .getCalls()
+        .filter((c) => typeof c.args[0] === 'string' && c.args[0].endsWith(ForceIgnore.FILE_NAME));
+      expect(readsForFi.length).to.equal(2);
+    });
   });
 
   it('Should handle forward slashes on windows', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -354,17 +354,11 @@ describe('MetadataResolver', () => {
           },
         ]);
         access.getComponentsFromPath(path);
-        // isDirectory is called a few times during recursive parsing, after debugging
-        // we only need to verify calls made in succession are called with dirs, and then files
-        expect([isDirSpy.args[3][0], isDirSpy.args[4][0]]).to.deep.equal([path, join(path, 'parent.report-meta.xml')]);
-        expect([isDirSpy.args[7][0], isDirSpy.args[8][0]]).to.deep.equal([
-          join(path, 'dir1'),
-          join(path, 'parent.report-meta.xml'),
-        ]);
-        expect([isDirSpy.args[10][0], isDirSpy.args[11][0]]).to.deep.equal([
-          join(path, 'dir1'),
-          join(path, 'dir1', 'dir1.report-meta.xml'),
-        ]);
+        const dir1Path = join(path, 'dir1');
+        const parentXmlPath = join(path, 'parent.report-meta.xml');
+        const allArgs = isDirSpy.getCalls().map((c) => c.args[0]);
+        // Directory children are sorted before files; batch isDirectory uses readDirectory order (dir1 before parent)
+        expect(allArgs.indexOf(dir1Path)).to.be.lessThan(allArgs.indexOf(parentXmlPath));
       });
 
       it('Should determine type for folder files', () => {

--- a/test/resolve/treeContainers.test.ts
+++ b/test/resolve/treeContainers.test.ts
@@ -13,451 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable class-methods-use-this */
-
 import { join } from 'node:path';
-import { Readable } from 'node:stream';
-import { Messages, SfError } from '@salesforce/core';
-import { assert, expect } from 'chai';
-import { createSandbox } from 'sinon';
-import fs from 'graceful-fs';
-import JSZip from 'jszip';
-import {
-  MetadataResolver,
-  NodeFSTreeContainer,
-  TreeContainer,
-  VirtualDirectory,
-  VirtualTreeContainer,
-  ZipTreeContainer,
-} from '../../src';
+import { expect } from 'chai';
+import { VirtualTreeContainer } from '../../src/resolve/treeContainers';
 
-Messages.importMessagesDirectory(__dirname);
-const messages = Messages.loadMessages('@salesforce/source-deploy-retrieve', 'sdr');
-
-describe('Tree Containers', () => {
-  const readDirResults = ['a.q', 'a.x-meta.xml', 'b', 'b.x-meta.xml', 'c.z', 'c.x-meta.xml'];
-
-  const streamToString = async (stream: Readable) => {
-    stream.setEncoding('utf-8');
-    const chunks = [];
-
-    for await (const chunk of stream) {
-      chunks.push(chunk);
-    }
-
-    return chunks.join('');
-  };
-
-  describe('TreeContainer Base Class', () => {
-    class TestTreeContainer extends TreeContainer {
-      public readDirectory(): string[] {
-        return readDirResults;
-      }
-
-      public exists(): boolean {
-        return false;
-      }
-
-      public isDirectory(): boolean {
-        return false;
-      }
-
-      public readFile(): Promise<Buffer> {
-        return Promise.resolve(Buffer.from(''));
-      }
-
-      public readFileSync(): Buffer {
-        return Buffer.from('');
-      }
-
-      public stream(): Readable {
-        // @ts-expect-error it's a mock!
-        return;
-      }
-    }
-    const tree = new TestTreeContainer();
-
-    it('should find first matching metadata file', () => {
-      expect(tree.find('metadataXml', 'b', '')).to.equal('b.x-meta.xml');
+describe('VirtualTreeContainer', () => {
+  describe('fromFilePaths', () => {
+    it('builds parent directories for a single file path', () => {
+      const filePath = join('force-app', 'main', 'default', 'classes', 'Foo.cls');
+      const tree = VirtualTreeContainer.fromFilePaths([filePath]);
+      expect(tree.exists(filePath)).to.be.true;
+      expect(tree.isDirectory(join('force-app', 'main', 'default', 'classes'))).to.be.true;
+      expect(tree.readDirectory(join('force-app', 'main', 'default', 'classes'))).to.include.members(['Foo.cls']);
     });
 
-    it('should find first matching content file', () => {
-      expect(tree.find('content', 'c', '')).to.equal('c.z');
-    });
-  });
-
-  describe('NodeFSTreeContainer', () => {
-    const env = createSandbox();
-    const tree = new NodeFSTreeContainer();
-    const path = join('path', 'to', 'test');
-
-    afterEach(() => env.restore());
-
-    it('should use expected Node API for exists', () => {
-      const existsStub = env.stub(fs, 'existsSync');
-      existsStub.withArgs(path).returns(true);
-      expect(tree.exists(path)).to.be.true;
-      expect(existsStub.calledOnce).to.be.true;
+    it('merges overlapping paths into shared directory entries', () => {
+      const base = join('force-app', 'main', 'default');
+      const a = join(base, 'classes', 'A.cls');
+      const b = join(base, 'triggers', 'T.trigger');
+      const tree = VirtualTreeContainer.fromFilePaths([a, b]);
+      expect(tree.exists(a)).to.be.true;
+      expect(tree.exists(b)).to.be.true;
+      const rootChildren = tree.readDirectory(base);
+      expect(rootChildren).to.include.members(['classes', 'triggers']);
+      expect(tree.readDirectory(join(base, 'classes'))).to.deep.equal(['A.cls']);
+      expect(tree.readDirectory(join(base, 'triggers'))).to.deep.equal(['T.trigger']);
     });
 
-    it('should use expected Node API for isDirectory', () => {
-      const statStub = env.stub(fs, 'statSync');
-      // @ts-ignore lstat returns more than isDirectory function
-      statStub.withArgs(path).returns({ isDirectory: () => true });
-      expect(tree.isDirectory(path)).to.be.true;
-      expect(statStub.calledOnce).to.be.true;
+    it('deduplicates identical paths', () => {
+      const p = join('pkg', 'objects', 'Obj__c', 'Obj__c.object-meta.xml');
+      const tree = VirtualTreeContainer.fromFilePaths([p, p, p]);
+      expect(tree.exists(p)).to.be.true;
+      expect(tree.readDirectory(join('pkg', 'objects', 'Obj__c'))).to.deep.equal(['Obj__c.object-meta.xml']);
     });
 
-    it('should use expected Node API for readDirectory', () => {
-      const readdirStub = env.stub(fs, 'readdirSync');
-      // @ts-ignore wants Dirents but string[] works as well
-      readdirStub.withArgs(path).returns(readDirResults);
-      expect(tree.readDirectory(path)).to.deep.equal(readDirResults);
-      expect(readdirStub.calledOnce).to.be.true;
+    it('handles a deep path', () => {
+      const parts = ['a', 'b', 'c', 'd', 'e', 'deep.txt'];
+      const filePath = join(...parts);
+      const tree = VirtualTreeContainer.fromFilePaths([filePath]);
+      expect(tree.exists(filePath)).to.be.true;
+      expect(tree.isDirectory(join('a', 'b', 'c', 'd'))).to.be.true;
+      expect(tree.readDirectory(join('a', 'b', 'c', 'd'))).to.deep.equal(['e']);
     });
 
-    it('should use expected Node API for readFile', async () => {
-      const readFileStub = env.stub(fs, 'readFileSync');
-      // @ts-ignore wants Dirents but string[] works as well
-      readFileStub.withArgs(path).resolves(Buffer.from('test'));
-      const data = await tree.readFile(path);
-      expect(data.toString()).to.deep.equal('test');
-      expect(readFileStub.calledOnce).to.be.true;
+    it('ignores non-string entries like the previous implementation', () => {
+      const p = join('x', 'y.txt');
+      const tree = VirtualTreeContainer.fromFilePaths([p, undefined as unknown as string, null as unknown as string]);
+      expect(tree.exists(p)).to.be.true;
     });
 
-    it('should use expected Node API for readFileSync', () => {
-      const readFileStub = env.stub(fs, 'readFileSync');
-      // @ts-ignore wants Dirents but string[] works as well
-      readFileStub.withArgs(path).returns(Buffer.from('test'));
-      const data = tree.readFileSync(path);
-      expect(data.toString()).to.deep.equal('test');
-      expect(readFileStub.calledOnce).to.be.true;
-    });
-
-    it('should use expected Node API for stream', () => {
-      const readable = new Readable();
-      // @ts-ignore wants ReadStream but Readable works for testing
-      env.stub(fs, 'createReadStream').returns(readable);
-      env.stub(fs, 'existsSync').returns(true);
-      expect(tree.stream(path)).to.deep.equal(readable);
-    });
-
-    describe('with projectPath/cwd', () => {
-      let projectPath: string;
-      // mocking fs will defeat the goal of these tests, so we'll use the real one and clean it up
-      before(async () => {
-        projectPath = join('path', 'to', 'project');
-        await fs.promises.mkdir(projectPath, { recursive: true });
-        await fs.promises.writeFile(join(projectPath, 'test.txt'), 'test');
-      });
-
-      after(async () => {
-        await fs.promises.rm(projectPath, { recursive: true });
-      });
-
-      it('should return the path as is if it is already relative to the project path', () => {
-        const tree = new NodeFSTreeContainer(projectPath);
-        const path = join(projectPath, 'test.txt');
-        expect(tree.exists(path)).to.be.true;
-        expect(tree.readDirectory(projectPath)).to.deep.equal(['test.txt']);
-      });
-
-      it('should add the project path to the path if it is not already relative to the project path', () => {
-        const tree = new NodeFSTreeContainer(projectPath);
-        const path = 'test.txt';
-        expect(tree.exists(path)).to.be.true;
-        expect(tree.readDirectory(projectPath)).to.deep.equal(['test.txt']);
-      });
-    });
-  });
-
-  describe('ZipTreeContainer', () => {
-    let tree: ZipTreeContainer;
-    let zipBuffer: Buffer;
-
-    //
-    // NOTE: All files in zips use a forward slash as a file separator, so we build
-    //       the zip using paths with hard-coded forward slashes, not OS specific seps.
-    //
-
-    const filesRoot = 'main/default';
-    const moreFiles = `${filesRoot}/morefiles`;
-
-    before(async () => {
-      const zip = new JSZip();
-      zip
-        ?.file(`${filesRoot}/test.txt`, 'test text')
-        ?.file(`${filesRoot}/test2.txt`, 'test text 2')
-        ?.file(`${moreFiles}/test3.txt`, 'test text 3');
-
-      zipBuffer = await zip.generateAsync({
-        type: 'nodebuffer',
-        compression: 'DEFLATE',
-        compressionOptions: { level: 3 },
-      });
-
-      tree = await ZipTreeContainer.create(zipBuffer);
-    });
-
-    describe('exists', () => {
-      it('should return true for file that exists', () => {
-        const path = join(filesRoot, 'test.txt');
-        expect(tree.exists(path)).to.be.true;
-      });
-
-      it('should return true for directory that exists', () => {
-        const path = join(filesRoot, 'morefiles');
-        expect(tree.exists(path)).to.be.true;
-      });
-
-      it('should return false for file that does not exist', () => {
-        const path = join(filesRoot, 'test4.txt');
-        expect(tree.exists(path)).to.be.false;
-      });
-
-      it('should return false for directory that does not exist', () => {
-        const path = join('.', 'dne');
-        expect(tree.exists(path)).to.be.false;
-      });
-    });
-
-    describe('isDirectory', () => {
-      it('should return false for isDirectory', () => {
-        const path = join(filesRoot, 'test.txt');
-        expect(tree.isDirectory(path)).to.be.false;
-      });
-
-      it('should return true for isDirectory', () => {
-        expect(tree.isDirectory(filesRoot)).to.be.true;
-      });
-
-      it('should throw an error if path does not exist', () => {
-        const path = 'dne';
-        assert.throws(() => tree.isDirectory(path), SfError, messages.getMessage('error_path_not_found', [path]));
-      });
-    });
-
-    describe('readDirectory', () => {
-      it('should return correct directory entries for directory with files and directories', () => {
-        expect(tree.readDirectory(filesRoot)).to.deep.equal(['test.txt', 'test2.txt', 'morefiles']);
-      });
-
-      it('should return correct directory entries for directory only files', () => {
-        const path = join(filesRoot, 'morefiles');
-        expect(tree.readDirectory(path)).to.deep.equal(['test3.txt']);
-      });
-
-      it('should return correct directory entries for directory with only directories', () => {
-        expect(tree.readDirectory('main')).to.deep.equal(['default']);
-      });
-
-      it('should return correct directory entries for current directory character', () => {
-        expect(tree.readDirectory('.')).to.deep.equal(['main']);
-      });
-
-      it('should throw an error if path is not a directory', () => {
-        const path = join(filesRoot, 'test2.txt');
-        assert.throws(
-          () => tree.readDirectory(path),
-          SfError,
-          messages.getMessage('error_expected_directory_path', [path])
-        );
-      });
-    });
-
-    describe('readFile', () => {
-      it('should read contents of zip entry into buffer', async () => {
-        const path = join(filesRoot, 'test.txt');
-        const contents = (await tree.readFile(path)).toString();
-        expect(contents).to.equal('test text');
-      });
-
-      it('should throw an error if path is to directory', async () => {
-        try {
-          await tree.readFile(filesRoot);
-          assert(false, 'Expected an error to be thrown');
-        } catch (err) {
-          expect(err).to.be.instanceOf(SfError);
-          const errMsg = `Expected a file at path ${filesRoot} but found a directory.`;
-          expect(err).to.have.property('message', errMsg);
-        }
-      });
-    });
-
-    describe('readFileSync', () => {
-      it('should throw an error because it is not implemented yet', () => {
-        assert.throws(() => tree.readFileSync(join(filesRoot, 'test.txt')), Error, 'Method not implemented');
-      });
-    });
-
-    describe('stream', () => {
-      it('should return a readable stream', async () => {
-        const path = join(filesRoot, 'test.txt');
-        const readableStream = tree.stream(path);
-        expect(readableStream instanceof Readable).to.be.true;
-        const contents = await streamToString(readableStream);
-        expect(contents).to.equal('test text');
-      });
-
-      it('should throw an error if given path is to a directory', () => {
-        try {
-          tree.stream(filesRoot);
-          assert(false, 'Expected an error to be thrown');
-        } catch (err) {
-          expect(err).to.be.instanceOf(SfError);
-          const errMsg = messages.getMessage('error_no_directory_stream', [tree.constructor.name]);
-          expect(err).to.have.property('message', errMsg);
-        }
-      });
-    });
-  });
-
-  describe('VirtualTreeContainer', () => {
-    const virtualFS: VirtualDirectory[] = [
-      {
-        dirPath: '.',
-        children: ['test.txt', 'test2.txt', 'files', 'logs'],
-      },
-      {
-        dirPath: join('.', 'files'),
-        children: ['test3.txt'],
-      },
-      {
-        dirPath: join('.', 'logs'),
-        children: [{ name: 'run.log', data: Buffer.from('successful') }],
-      },
-    ];
-    const tree = new VirtualTreeContainer(virtualFS);
-
-    describe('exists', () => {
-      it('should return true for file that exists', () => {
-        const path = join('.', 'test.txt');
-        expect(tree.exists(path)).to.be.true;
-      });
-
-      it('should return true for directory that exists', () => {
-        const path = join('.', 'files');
-        expect(tree.exists(path)).to.be.true;
-      });
-
-      it('should return false for file that does not exist', () => {
-        const path = join('.', 'files', 'text4.txt');
-        expect(tree.exists(path)).to.be.false;
-      });
-
-      it('should return false for directory that does not exist', () => {
-        const path = join('.', 'otherfiles');
-        expect(tree.exists(path)).to.be.false;
-      });
-    });
-
-    describe('isDirectory', () => {
-      it('should return false for isDirectory', () => {
-        const path = join('.', 'test.txt');
-        expect(tree.isDirectory(path)).to.be.false;
-      });
-
-      it('should return true for isDirectory', () => {
-        const path = join('.', 'files');
-        expect(tree.isDirectory(path)).to.be.true;
-      });
-
-      it('should throw an error if path does not exist', () => {
-        const path = 'dne';
-        assert.throws(() => tree.isDirectory(path), SfError, messages.getMessage('error_path_not_found', [path]));
-      });
-    });
-
-    describe('readDirectory', () => {
-      it('should return directory entries for readDirectory', () => {
-        expect(tree.readDirectory('.')).to.deep.equal(virtualFS[0].children);
-      });
-
-      it('should throw an error if path is not a directory', () => {
-        assert.throws(
-          () => tree.readDirectory('test.txt'),
-          SfError,
-          messages.getMessage('error_expected_directory_path', ['test.txt'])
-        );
-      });
-    });
-
-    describe('readFile', () => {
-      it('should return file data for given path', async () => {
-        const data = await tree.readFile(join('.', 'logs', 'run.log'));
-        expect(data.toString()).to.equal('successful');
-      });
-
-      it('should return empty string buffer if file initialize without data', async () => {
-        const data = await tree.readFile(join('.', 'test.txt'));
-        expect(data.toString()).to.equal('');
-      });
-
-      it('should throw error if path does not exist', async () => {
-        const path = 'dne';
-        try {
-          await tree.readFile(path);
-          assert.fail('should have thrown an error');
-        } catch (e) {
-          assert(e instanceof Error);
-          expect(e.message).to.deep.equal(messages.getMessage('error_path_not_found', [path]));
-        }
-      });
-    });
-
-    describe('readFileSync', () => {
-      it('should return file data for given path', () => {
-        const data = tree.readFileSync(join('.', 'logs', 'run.log'));
-        expect(data.toString()).to.equal('successful');
-      });
-
-      it('should return empty string buffer if file initialize without data', () => {
-        const data = tree.readFileSync(join('.', 'test.txt'));
-        expect(data.toString()).to.equal('');
-      });
-
-      it('should throw error if path does not exist', () => {
-        const path = 'dne';
-        try {
-          tree.readFileSync(path);
-          assert.fail('should have thrown an error');
-        } catch (e) {
-          assert(e instanceof Error);
-          expect(e.message).to.deep.equal(messages.getMessage('error_path_not_found', [path]));
-        }
-      });
-    });
-
-    describe('stream', () => {
-      it('should throw a not implemented error', () => {
-        assert.throws(() => tree.stream('file'), 'Method not implemented');
-      });
-    });
-
-    describe('fromFilePaths', () => {
-      const classesPath = join('force-app', 'main', 'default', 'classes');
-      const tree = VirtualTreeContainer.fromFilePaths([
-        join(classesPath, 'TestOrderController.cls'),
-        join(classesPath, 'TestOrderController.cls-meta.xml'),
-      ]);
-
-      it('tree has expected structure', () => {
-        expect(tree.isDirectory('force-app'), 'force-app').to.equal(true);
-        expect(tree.isDirectory(join('force-app', 'main')), 'force-app/main').to.equal(true);
-        expect(tree.isDirectory(join('force-app', 'main', 'default')), 'force-app/main/default').to.equal(true);
-        expect(tree.isDirectory(classesPath), classesPath).to.equal(true);
-        expect(tree.readDirectory(classesPath)).to.deep.equal([
-          'TestOrderController.cls',
-          'TestOrderController.cls-meta.xml',
-        ]);
-      });
-
-      it('tree resolves to a class', () => {
-        const resolver = new MetadataResolver(undefined, tree);
-        const resolved = resolver.getComponentsFromPath('force-app');
-        expect(resolved.length).to.equal(1);
-        expect(resolved[0].type.name).to.equal('ApexClass');
-      });
+    it('produces no tree entries for a root-level filename (no parent segments)', () => {
+      const tree = VirtualTreeContainer.fromFilePaths(['rootOnly.txt']);
+      expect(tree.exists('rootOnly.txt')).to.be.false;
+      expect(() => tree.readFileSync('rootOnly.txt')).to.throw();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,12 +614,7 @@
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
   integrity sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==
 
-"@jsonjoy.com/buffers@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@jsonjoy.com/buffers/-/buffers-1.0.0.tgz#ade6895b7d3883d70f87b5743efaa12c71dfef7a"
-  integrity sha512-NDigYR3PHqCnQLXYyoLbnEdzMMvzeiCWo1KOut7Q0CoIqg9tUAPKJ1iq/2nFhc5kZtexzutNY0LFjdwWL3Dw3Q==
-
-"@jsonjoy.com/buffers@^1.2.0":
+"@jsonjoy.com/buffers@^1.0.0", "@jsonjoy.com/buffers@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz#8d99c7f67eaf724d3428dfd9826c6455266a5c83"
   integrity sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==
@@ -1213,17 +1208,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.11.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
-ajv@^8.18.0:
+ajv@^8.11.0, ajv@^8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -1488,7 +1473,7 @@ brace-expansion@^5.0.2:
   dependencies:
     balanced-match "^4.0.2"
 
-braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2616,18 +2601,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.7, fast-glob@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.3.2:
+fast-glob@^3.2.11, fast-glob@^3.2.7, fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -4118,14 +4092,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
-
 micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
@@ -4218,12 +4184,7 @@ minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
-  integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
-
-minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
@@ -5177,12 +5138,7 @@ semver@^6.0.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.4, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-semver@^7.7.3:
+semver@^7.3.4, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
@@ -5746,15 +5702,10 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tunnel-agent@*:
   version "0.6.0"


### PR DESCRIPTION
- Stat-backed cache in ForceIgnore.findAndCreate (mtime/size invalidation)

- Precompute isDirectory map before sort in getComponentsFromPathRecursive

- Optimize VirtualTreeContainer.fromFilePaths (incremental paths, Set-based children)

- Tests for ForceIgnore cache and fromFilePaths; relax dirs-before-files assertion
@W-21986538@
