### PR TITLE
fix: proper directory ignoring W-21988477

### DIFF
--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -89,10 +89,15 @@ export class ForceIgnore {
     if (!this.parser || !this.forceIgnoreDirectory) return false;
     try {
       const absoluteFsPath = isAbsolute(fsPath) ? fsPath : resolve(this.forceIgnoreDirectory, fsPath);
-      const res = this.parser.ignores(relative(this.forceIgnoreDirectory, absoluteFsPath));
+      const relativePath = relative(this.forceIgnoreDirectory, absoluteFsPath);
+      // Test both the plain path and the path with a trailing slash. The trailing-slash form
+      // is required for node-ignore to match directory-only patterns like `node_modules/`.
+      // Testing both means we correctly deny directories in virtual trees (e.g. ZipTreeContainer)
+      // where statSync is unavailable, without requiring callers to signal directory-ness.
+      const res = this.parser.ignores(relativePath) || this.parser.ignores(`${relativePath}/`);
       if (res) {
         Logger.childFromRoot('forceIgnore.denies').debug(
-          `Ignoring file '${fsPath}' because it matched .forceignore patterns.`
+          `Ignoring '${fsPath}' because it matched .forceignore patterns.`
         );
       }
       return res;
@@ -102,12 +107,6 @@ export class ForceIgnore {
   }
 
   public accepts(fsPath: SourcePath): boolean {
-    if (!this.parser || !this.forceIgnoreDirectory) return true;
-    try {
-      const absoluteFsPath = isAbsolute(fsPath) ? fsPath : resolve(this.forceIgnoreDirectory, fsPath);
-      return !this.parser.ignores(relative(this.forceIgnoreDirectory, absoluteFsPath));
-    } catch (e) {
-      return true;
-    }
+    return !this.denies(fsPath);
   }
 }

--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -125,17 +125,14 @@ export class ForceIgnore {
     try {
       const absoluteFsPath = isAbsolute(fsPath) ? fsPath : resolve(this.forceIgnoreDirectory, fsPath);
       const relativePath = relative(this.forceIgnoreDirectory, absoluteFsPath);
-      // Test both the plain path and the path with a trailing slash. The trailing-slash form
-      // is required for node-ignore to match directory-only patterns like `node_modules/`.
-      // node-ignore does no fs.stat, so callers must append `/` for directories:
+      // node-ignore requires callers to append `/` for directory-only patterns like `node_modules/`:
       // https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames
-      // For real directories on disk (statSync succeeds and isDirectory() is true) we also test
-      // the trailing-slash form. For files we skip it to avoid false positives where a file named
-      // e.g. `build` matches a directory-only `build/` pattern.
-      // When statSync throws (virtual/zip trees whose paths don't exist on disk) we assume
-      // directory, preserving correct behaviour for ZipTreeContainer / VirtualTreeContainer.
+      // Known files on disk skip the trailing-slash test to avoid false positives
+      // (e.g. a file named `build` matching `build/`).
+      // Virtual/zip tree paths that don't exist on disk are assumed to be potential directories.
       const res =
-        this.parser.ignores(relativePath) || (isDirectory(absoluteFsPath) && this.parser.ignores(`${relativePath}/`));
+        this.parser.ignores(relativePath) ||
+        (couldBeDirectory(absoluteFsPath) && this.parser.ignores(`${relativePath}/`));
       if (res) {
         Logger.childFromRoot('forceIgnore.denies').debug(
           `Ignoring '${fsPath}' because it matched .forceignore patterns.`
@@ -152,12 +149,11 @@ export class ForceIgnore {
   }
 }
 
-const isDirectory = (fsPath: string): boolean => {
+const couldBeDirectory = (fsPath: string): boolean => {
   try {
-    return statSync(fsPath).isDirectory();
+    return !statSync(fsPath).isFile();
   } catch {
-    // virtual/zip trees whose paths don't exist on disk — assume directory
-    // to preserve correct behaviour for ZipTreeContainer / VirtualTreeContainer
+    // virtual/zip trees whose paths don't exist on disk — assume it could be a directory
     return true;
   }
 };

--- a/src/resolve/forceIgnore.ts
+++ b/src/resolve/forceIgnore.ts
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import * as os from 'node:os';
 import ignore, { Ignore } from 'ignore/index';
-import { readFileSync } from 'graceful-fs';
+import { readFileSync, statSync } from 'graceful-fs';
 import { Lifecycle } from '@salesforce/core/lifecycle';
 import { Logger } from '@salesforce/core/logger';
 import { SourcePath } from '../common/types';
 import { searchUp } from '../utils/fileSystemHandler';
 
+type FindCacheEntry = { mtimeMs: number; size: number; instance: ForceIgnore };
+
 export class ForceIgnore {
   public static readonly FILE_NAME = '.forceignore';
+
+  private static readonly findCache = new Map<string, FindCacheEntry>();
+  private static emptySingleton: ForceIgnore | undefined;
 
   private readonly parser?: Ignore;
   private readonly forceIgnoreDirectory?: string;
@@ -78,11 +83,41 @@ export class ForceIgnore {
    * `ForceIgnore` object based on the result. If there is no `.forceignore` file,
    * the returned `ForceIgnore` object will accept everything.
    *
+   * Parsed files are cached by absolute path and invalidated when `mtime` or `size` changes on disk.
+   *
    * @param seed Path to begin the `.forceignore` search from
    */
   public static findAndCreate(seed: SourcePath): ForceIgnore {
     const projectConfigPath = searchUp(seed, ForceIgnore.FILE_NAME);
-    return new ForceIgnore(projectConfigPath ? join(dirname(projectConfigPath), ForceIgnore.FILE_NAME) : '');
+    if (!projectConfigPath) {
+      ForceIgnore.emptySingleton ??= new ForceIgnore('');
+      return ForceIgnore.emptySingleton;
+    }
+
+    const absPath = normalize(projectConfigPath);
+    let mtimeMs: number;
+    let size: number;
+    try {
+      const st = statSync(absPath);
+      ({ mtimeMs, size } = st);
+    } catch {
+      return new ForceIgnore('');
+    }
+
+    const hit = ForceIgnore.findCache.get(absPath);
+    if (hit && hit.mtimeMs === mtimeMs && hit.size === size) {
+      return hit.instance;
+    }
+
+    const instance = new ForceIgnore(join(dirname(absPath), ForceIgnore.FILE_NAME));
+    ForceIgnore.findCache.set(absPath, { mtimeMs, size, instance });
+    return instance;
+  }
+
+  /** @internal clears module cache; for unit tests only */
+  public static clearCacheForTest(): void {
+    ForceIgnore.findCache.clear();
+    ForceIgnore.emptySingleton = undefined;
   }
 
   public denies(fsPath: SourcePath): boolean {
@@ -92,9 +127,15 @@ export class ForceIgnore {
       const relativePath = relative(this.forceIgnoreDirectory, absoluteFsPath);
       // Test both the plain path and the path with a trailing slash. The trailing-slash form
       // is required for node-ignore to match directory-only patterns like `node_modules/`.
-      // Testing both means we correctly deny directories in virtual trees (e.g. ZipTreeContainer)
-      // where statSync is unavailable, without requiring callers to signal directory-ness.
-      const res = this.parser.ignores(relativePath) || this.parser.ignores(`${relativePath}/`);
+      // node-ignore does no fs.stat, so callers must append `/` for directories:
+      // https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames
+      // For real directories on disk (statSync succeeds and isDirectory() is true) we also test
+      // the trailing-slash form. For files we skip it to avoid false positives where a file named
+      // e.g. `build` matches a directory-only `build/` pattern.
+      // When statSync throws (virtual/zip trees whose paths don't exist on disk) we assume
+      // directory, preserving correct behaviour for ZipTreeContainer / VirtualTreeContainer.
+      const res =
+        this.parser.ignores(relativePath) || (isDirectory(absoluteFsPath) && this.parser.ignores(`${relativePath}/`));
       if (res) {
         Logger.childFromRoot('forceIgnore.denies').debug(
           `Ignoring '${fsPath}' because it matched .forceignore patterns.`
@@ -110,3 +151,13 @@ export class ForceIgnore {
     return !this.denies(fsPath);
   }
 }
+
+const isDirectory = (fsPath: string): boolean => {
+  try {
+    return statSync(fsPath).isDirectory();
+  } catch {
+    // virtual/zip trees whose paths don't exist on disk — assume directory
+    // to preserve correct behaviour for ZipTreeContainer / VirtualTreeContainer
+    return true;
+  }
+};

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -80,11 +80,7 @@ export class MetadataResolver {
     const components: SourceComponent[] = [];
     const ignore = new Set();
 
-    // don't apply forceignore rules against dirs
-    // `forceignore.denies` will pass a relative path to node-ignore, e.g.
-    // `path/to/force-app` -> `force-app`, note that there's no trailing slash
-    // so node-ignore will treat it as a file.
-    if (!this.tree.isDirectory(dir) && this.forceIgnore?.denies(dir)) {
+    if (this.forceIgnore?.denies(dir)) {
       return components;
     }
 
@@ -110,7 +106,7 @@ export class MetadataResolver {
             components.push(component);
             ignore.add(component.xml);
           }
-        } else {
+        } else if (!this.forceIgnore?.denies(fsPath)) {
           dirQueue.push(fsPath);
         }
       } else if (isMetadata(this.registry)(this.tree)(fsPath)) {

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -75,12 +75,17 @@ export class MetadataResolver {
     return component ? [component] : [];
   }
 
+  // eslint-disable-next-line complexity
   private getComponentsFromPathRecursive(dir: string, inclusiveFilter?: ComponentSet): SourceComponent[] {
     const dirQueue: string[] = [];
     const components: SourceComponent[] = [];
     const ignore = new Set();
 
-    if (this.forceIgnore?.denies(dir)) {
+    // don't apply forceignore rules against dirs
+    // `forceignore.denies` will pass a relative path to node-ignore, e.g.
+    // `path/to/force-app` -> `force-app`, note that there's no trailing slash
+    // so node-ignore will treat it as a file.
+    if (!this.tree.isDirectory(dir) && this.forceIgnore?.denies(dir)) {
       return components;
     }
 
@@ -88,17 +93,7 @@ export class MetadataResolver {
     const isDirByPath = new Map(entries.map((entry) => [entry, this.tree.isDirectory(entry)]));
     // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
     // before finding the parent and returning only it - by sorting, we make it as recursive as possible
-    for (const fsPath of entries.sort((a, b) => {
-      const aDir = isDirByPath.get(a)!;
-      const bDir = isDirByPath.get(b)!;
-      if (aDir && bDir) {
-        return 0;
-      } else if (aDir && !bDir) {
-        return -1;
-      } else {
-        return 1;
-      }
-    })) {
+    for (const fsPath of entries.sort(directoriesFirst(isDirByPath))) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -115,7 +110,9 @@ export class MetadataResolver {
             components.push(component);
             ignore.add(component.xml);
           }
-        } else if (!this.forceIgnore?.denies(fsPath)) {
+          // normally the preview commands expect to traverse ignored directories in order to provide a list of ignored files.
+          // we do NOT want to do this where react components can have very large dirs.
+        } else if (!(this.forceIgnore?.denies(fsPath) && fsPath.includes('node_modules'))) {
           dirQueue.push(fsPath);
         }
       } else if (isMetadata(this.registry)(this.tree)(fsPath)) {
@@ -475,3 +472,9 @@ const pathIncludesDirName =
  * @param fsPath File path of a potential metadata xml file
  */
 const parseAsRootMetadataXml = (fsPath: string): boolean => Boolean(parseMetadataXml(fsPath));
+
+/** Sort comparator that places directories before files. */
+const directoriesFirst =
+  (isDirByPath: Map<string, boolean>) =>
+  (a: string, b: string): number =>
+    isDirByPath.get(a) === isDirByPath.get(b) ? 0 : isDirByPath.get(a) ? -1 : 1;

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -112,7 +112,7 @@ export class MetadataResolver {
           }
           // normally the preview commands expect to traverse ignored directories in order to provide a list of ignored files.
           // we do NOT want to do this where react components can have very large dirs.
-        } else if (!(this.forceIgnore?.denies(fsPath) && fsPath.includes('node_modules'))) {
+        } else if (!(this.forceIgnore?.denies(fsPath) && fsPath.split(sep).includes('node_modules'))) {
           dirQueue.push(fsPath);
         }
       } else if (isMetadata(this.registry)(this.tree)(fsPath)) {

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -84,12 +84,21 @@ export class MetadataResolver {
       return components;
     }
 
-    for (const fsPath of this.tree
-      .readDirectory(dir)
-      .map(fnJoin(dir))
-      // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
-      // before finding the parent and returning only it - by sorting, we make it as recursive as possible
-      .sort(this.sortDirsFirst)) {
+    const entries = this.tree.readDirectory(dir).map(fnJoin(dir));
+    const isDirByPath = new Map(entries.map((entry) => [entry, this.tree.isDirectory(entry)]));
+    // this method isn't truly recursive, we need to sort directories before files so we look as far down as possible
+    // before finding the parent and returning only it - by sorting, we make it as recursive as possible
+    for (const fsPath of entries.sort((a, b) => {
+      const aDir = isDirByPath.get(a)!;
+      const bDir = isDirByPath.get(b)!;
+      if (aDir && bDir) {
+        return 0;
+      } else if (aDir && !bDir) {
+        return -1;
+      } else {
+        return 1;
+      }
+    })) {
       if (ignore.has(fsPath)) {
         continue;
       }
@@ -135,15 +144,6 @@ export class MetadataResolver {
     return components.concat(dirQueue.flatMap((d) => this.getComponentsFromPathRecursive(d, inclusiveFilter)));
   }
 
-  private sortDirsFirst = (a: string, b: string): number => {
-    if (this.tree.isDirectory(a) && this.tree.isDirectory(b)) {
-      return 0;
-    } else if (this.tree.isDirectory(a) && !this.tree.isDirectory(b)) {
-      return -1;
-    } else {
-      return 1;
-    }
-  };
   private resolveComponent(fsPath: string, isResolvingSource: boolean): SourceComponent | undefined {
     if (this.forceIgnore?.denies(fsPath)) {
       // don't resolve the component if the path is denied

--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -272,22 +272,16 @@ export class VirtualTreeContainer extends TreeContainer {
         continue;
       }
       const splits = filename.split(sep);
-      if (splits.length <= 1) {
-        continue;
-      }
-
-      let currentDir = splits[0];
       for (let i = 0; i < splits.length - 1; i++) {
-        const childName = splits[i + 1];
-        let childSet = childrenByDir.get(currentDir);
+        // slice+join preserves the leading separator for absolute paths
+        // e.g. ['', 'home'].join('/') === '/home'
+        const dirPath = splits.slice(0, i + 1).join(sep);
+        let childSet = childrenByDir.get(dirPath);
         if (!childSet) {
           childSet = new Set<string>();
-          childrenByDir.set(currentDir, childSet);
+          childrenByDir.set(dirPath, childSet);
         }
-        childSet.add(childName);
-        if (i < splits.length - 2) {
-          currentDir = join(currentDir, childName);
-        }
+        childSet.add(splits[i + 1]);
       }
     }
 

--- a/src/resolve/treeContainers.ts
+++ b/src/resolve/treeContainers.ts
@@ -266,24 +266,37 @@ export class VirtualTreeContainer extends TreeContainer {
    * @returns VirtualTreeContainer
    */
   public static fromFilePaths(paths: string[]): VirtualTreeContainer {
-    // a map to reduce array iterations
-    const virtualDirectoryByFullPath = new Map<string, VirtualDirectory>();
-    paths
-      // defending against undefined being passed in.  The metadata API sometimes responds missing fileName
-      .filter(isString)
-      .map((filename) => {
-        const splits = filename.split(sep);
-        for (let i = 0; i < splits.length - 1; i++) {
-          const fullPathSoFar = splits.slice(0, i + 1).join(sep);
-          const existing = virtualDirectoryByFullPath.get(fullPathSoFar);
-          virtualDirectoryByFullPath.set(fullPathSoFar, {
-            dirPath: fullPathSoFar,
-            // only add to children if we don't already have it
-            children: Array.from(new Set(existing?.children ?? []).add(splits[i + 1])),
-          });
+    const childrenByDir = new Map<string, Set<string>>();
+    for (const filename of paths) {
+      if (!isString(filename)) {
+        continue;
+      }
+      const splits = filename.split(sep);
+      if (splits.length <= 1) {
+        continue;
+      }
+
+      let currentDir = splits[0];
+      for (let i = 0; i < splits.length - 1; i++) {
+        const childName = splits[i + 1];
+        let childSet = childrenByDir.get(currentDir);
+        if (!childSet) {
+          childSet = new Set<string>();
+          childrenByDir.set(currentDir, childSet);
         }
-      });
-    return new VirtualTreeContainer(Array.from(virtualDirectoryByFullPath.values()));
+        childSet.add(childName);
+        if (i < splits.length - 2) {
+          currentDir = join(currentDir, childName);
+        }
+      }
+    }
+
+    const virtualFs: VirtualDirectory[] = Array.from(childrenByDir.entries()).map(([dirPath, set]) => ({
+      dirPath,
+      children: Array.from(set),
+    }));
+
+    return new VirtualTreeContainer(virtualFs);
   }
 
   public isDirectory(fsPath: string): boolean {

--- a/test/nuts/local/forceIgnore/forceIgnore.nut.ts
+++ b/test/nuts/local/forceIgnore/forceIgnore.nut.ts
@@ -108,15 +108,12 @@ describe('ForceIgnore directory patterns (e2e)', () => {
       const tree = await ZipTreeContainer.create(buffer);
 
       // process.chdir so ForceIgnore.findAndCreate('unpackaged') walks up to
-      // session.project.dir and finds the .forceignore we just wrote.
-      // TestSession stubs process.cwd(); use realpath('.') so we restore the
-      // actual OS cwd after finally — otherwise real cwd stays inside the
-      // session dir and clean() deletes it, breaking later NUTs in the worker.
-      const origCwd = fs.realpathSync('.');
+      // session.project.dir and finds the .forceignore we just wrote
+      const origCwd = process.cwd();
       try {
         process.chdir(session.project.dir);
         const cs = ComponentSet.fromSource({ fsPaths: ['unpackaged'], tree });
-        expect(cs.getSourceComponents().toArray()).to.have.lengthOf(0);
+        expect(cs.getSourceComponents().toArray()).to.have.length(0);
       } finally {
         process.chdir(origCwd);
       }

--- a/test/nuts/local/forceIgnore/forceIgnore.nut.ts
+++ b/test/nuts/local/forceIgnore/forceIgnore.nut.ts
@@ -107,19 +107,11 @@ describe('ForceIgnore directory patterns (e2e)', () => {
       const buffer = await zip.generateAsync({ type: 'nodebuffer' });
       const tree = await ZipTreeContainer.create(buffer);
 
-      // process.chdir so ForceIgnore.findAndCreate('unpackaged') walks up to
-      // session.project.dir and finds the .forceignore we just wrote.
-      // TestSession stubs process.cwd(); use realpath('.') so we restore the
-      // actual OS cwd after finally — otherwise real cwd stays inside the
-      // session dir and clean() deletes it, breaking later NUTs in the worker.
-      const origCwd = fs.realpathSync('.');
-      try {
-        process.chdir(session.project.dir);
-        const cs = ComponentSet.fromSource({ fsPaths: ['unpackaged'], tree });
-        expect(cs.getSourceComponents().toArray()).to.have.lengthOf(0);
-      } finally {
-        process.chdir(origCwd);
-      }
+      // TestSession already stubs process.cwd() to session.project.dir, so
+      // ForceIgnore.findAndCreate('unpackaged') → searchUp uses that stub to
+      // resolve the relative path and walk up to find the .forceignore we wrote.
+      const cs = ComponentSet.fromSource({ fsPaths: ['unpackaged'], tree });
+      expect(cs.getSourceComponents().toArray()).to.have.lengthOf(0);
     });
   });
 });

--- a/test/nuts/local/forceIgnore/forceIgnore.nut.ts
+++ b/test/nuts/local/forceIgnore/forceIgnore.nut.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import JSZip from 'jszip';
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { ComponentSet } from '../../../../src';
+import { ZipTreeContainer } from '../../../../src/resolve/treeContainers';
+
+const META_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>`;
+
+describe('ForceIgnore directory patterns (e2e)', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'nuts', 'local', 'forceIgnore', 'testProj'),
+      },
+      devhubAuthStrategy: 'NONE',
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  const writeForceIgnore = (content: string): Promise<void> =>
+    fs.promises.writeFile(path.join(session.project.dir, '.forceignore'), content);
+
+  const resolvedFullNames = (): string[] =>
+    ComponentSet.fromSource({ fsPaths: [session.project.dir] })
+      .getSourceComponents()
+      .toArray()
+      .map((c) => c.fullName);
+
+  describe('trailing-slash directory patterns', () => {
+    it('excludes a directory matching a trailing-slash forceignore pattern', async () => {
+      await writeForceIgnore('node_modules/\n');
+      const names = resolvedFullNames();
+      expect(names).to.include('MyClass');
+      // LibHelper lives inside node_modules/some-sfdx-lib/classes/ — should be excluded
+      expect(names).to.not.include('LibHelper');
+    });
+
+    it('does not exclude a sibling directory whose name only partially matches', async () => {
+      await writeForceIgnore('node_modules/\n');
+      const names = resolvedFullNames();
+      // node_modules_extra/ does not match the node_modules/ pattern
+      expect(names).to.include('ExtraClass');
+    });
+
+    it('excludes a nested node_modules directory inside the source tree', async () => {
+      const nestedDir = path.join(session.project.dir, 'force-app', 'main', 'node_modules', 'classes');
+      await fs.promises.mkdir(nestedDir, { recursive: true });
+      await fs.promises.writeFile(path.join(nestedDir, 'NestedClass.cls'), 'public class NestedClass {}');
+      await fs.promises.writeFile(path.join(nestedDir, 'NestedClass.cls-meta.xml'), META_XML);
+
+      await writeForceIgnore('node_modules/\n');
+      const names = resolvedFullNames();
+      expect(names).to.include('MyClass');
+      expect(names).to.not.include('NestedClass');
+    });
+  });
+
+  describe('ignore/unignore hierarchy', () => {
+    it('traverses unignored subdirectories while stopping at denied ones', async () => {
+      // **/internal/** denies all content inside internal/
+      // !**/internal/metadata unignores the metadata directory itself so traversal enters it
+      // !**/internal/metadata/** unignores everything inside metadata/
+      // internal/blocked/ has no negation so traversal stops there
+      await writeForceIgnore(['**/internal/**', '!**/internal/metadata', '!**/internal/metadata/**'].join('\n'));
+      const names = resolvedFullNames();
+      expect(names).to.include('MyClass');
+      expect(names).to.include('InternalAllowed');
+      expect(names).to.not.include('InternalBlocked');
+    });
+  });
+
+  describe('virtual tree (zip / PR #1093 scenario)', () => {
+    it('denies an unpackaged directory in a zip tree when forceignore contains unpackaged/', async () => {
+      await writeForceIgnore('unpackaged/\n');
+
+      const zip = new JSZip();
+      zip.folder('unpackaged');
+      zip.folder('unpackaged/classes');
+      zip.file('unpackaged/classes/ZipClass.cls', 'public class ZipClass {}');
+      zip.file('unpackaged/classes/ZipClass.cls-meta.xml', META_XML);
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+      const tree = await ZipTreeContainer.create(buffer);
+
+      // process.chdir so ForceIgnore.findAndCreate('unpackaged') walks up to
+      // session.project.dir and finds the .forceignore we just wrote
+      const origCwd = process.cwd();
+      try {
+        process.chdir(session.project.dir);
+        const cs = ComponentSet.fromSource({ fsPaths: ['unpackaged'], tree });
+        expect(cs.getSourceComponents().toArray()).to.have.length(0);
+      } finally {
+        process.chdir(origCwd);
+      }
+    });
+  });
+});

--- a/test/nuts/local/forceIgnore/forceIgnore.nut.ts
+++ b/test/nuts/local/forceIgnore/forceIgnore.nut.ts
@@ -108,12 +108,15 @@ describe('ForceIgnore directory patterns (e2e)', () => {
       const tree = await ZipTreeContainer.create(buffer);
 
       // process.chdir so ForceIgnore.findAndCreate('unpackaged') walks up to
-      // session.project.dir and finds the .forceignore we just wrote
-      const origCwd = process.cwd();
+      // session.project.dir and finds the .forceignore we just wrote.
+      // TestSession stubs process.cwd(); use realpath('.') so we restore the
+      // actual OS cwd after finally — otherwise real cwd stays inside the
+      // session dir and clean() deletes it, breaking later NUTs in the worker.
+      const origCwd = fs.realpathSync('.');
       try {
         process.chdir(session.project.dir);
         const cs = ComponentSet.fromSource({ fsPaths: ['unpackaged'], tree });
-        expect(cs.getSourceComponents().toArray()).to.have.length(0);
+        expect(cs.getSourceComponents().toArray()).to.have.lengthOf(0);
       } finally {
         process.chdir(origCwd);
       }

--- a/test/nuts/local/forceIgnore/testProj/force-app/main/default/classes/MyClass.cls
+++ b/test/nuts/local/forceIgnore/testProj/force-app/main/default/classes/MyClass.cls
@@ -1,0 +1,1 @@
+public class MyClass {}

--- a/test/nuts/local/forceIgnore/testProj/force-app/main/default/classes/MyClass.cls-meta.xml
+++ b/test/nuts/local/forceIgnore/testProj/force-app/main/default/classes/MyClass.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/nuts/local/forceIgnore/testProj/internal/blocked/classes/InternalBlocked.cls
+++ b/test/nuts/local/forceIgnore/testProj/internal/blocked/classes/InternalBlocked.cls
@@ -1,0 +1,1 @@
+public class InternalBlocked {}

--- a/test/nuts/local/forceIgnore/testProj/internal/blocked/classes/InternalBlocked.cls-meta.xml
+++ b/test/nuts/local/forceIgnore/testProj/internal/blocked/classes/InternalBlocked.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/nuts/local/forceIgnore/testProj/internal/metadata/classes/InternalAllowed.cls
+++ b/test/nuts/local/forceIgnore/testProj/internal/metadata/classes/InternalAllowed.cls
@@ -1,0 +1,1 @@
+public class InternalAllowed {}

--- a/test/nuts/local/forceIgnore/testProj/internal/metadata/classes/InternalAllowed.cls-meta.xml
+++ b/test/nuts/local/forceIgnore/testProj/internal/metadata/classes/InternalAllowed.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/nuts/local/forceIgnore/testProj/node_modules_extra/classes/ExtraClass.cls
+++ b/test/nuts/local/forceIgnore/testProj/node_modules_extra/classes/ExtraClass.cls
@@ -1,0 +1,1 @@
+public class ExtraClass {}

--- a/test/nuts/local/forceIgnore/testProj/node_modules_extra/classes/ExtraClass.cls-meta.xml
+++ b/test/nuts/local/forceIgnore/testProj/node_modules_extra/classes/ExtraClass.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/test/nuts/local/forceIgnore/testProj/sfdx-project.json
+++ b/test/nuts/local/forceIgnore/testProj/sfdx-project.json
@@ -1,0 +1,12 @@
+{
+  "name": "forceIgnoreNut",
+  "namespace": "",
+  "packageDirectories": [
+    {
+      "default": true,
+      "path": "force-app"
+    }
+  ],
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "58.0"
+}

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { mkdirSync, mkdtempSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import type { Stats } from 'node:fs';
 import { join } from 'node:path';
 import * as os from 'node:os';
 import { expect } from 'chai';
@@ -33,6 +35,7 @@ describe('ForceIgnore', () => {
   afterEach(() => {
     env.restore();
     Sinon.restore();
+    ForceIgnore.clearCacheForTest();
   });
 
   it('Should default to not ignoring a file if forceignore is not loaded', () => {
@@ -81,10 +84,109 @@ describe('ForceIgnore', () => {
   it('Should find a forceignore file from a given path', () => {
     const readStub = env.stub(fs, 'readFileSync');
     const searchStub = env.stub(fsUtil, 'searchUp');
+    env.stub(fs, 'statSync').returns({ mtimeMs: 99, size: 500 } as Stats);
     readStub.withArgs(forceIgnorePath).returns(testPattern);
     searchStub.withArgs(testPath, ForceIgnore.FILE_NAME).returns(forceIgnorePath);
     const forceIgnore = ForceIgnore.findAndCreate(testPath);
     expect(forceIgnore.accepts(testPath)).to.be.false;
+  });
+
+  describe('findAndCreate cache', () => {
+    it('reuses the same instance and reads .forceignore once when mtime/size unchanged', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      writeFileSync(fiPath, `${testPattern}\n`);
+      mkdirSync(join(tmp, 'pkg', 'classes'), { recursive: true });
+      const seedA = join(tmp, 'pkg', 'classes');
+      const seedB = join(tmp, 'pkg', 'classes', 'Foo.cls');
+      const readSpy = env.spy(fs, 'readFileSync');
+      const first = ForceIgnore.findAndCreate(seedA);
+      const second = ForceIgnore.findAndCreate(seedB);
+      expect(first).to.equal(second);
+      const readsForFi = readSpy
+        .getCalls()
+        .filter((c) => typeof c.args[0] === 'string' && c.args[0].endsWith(ForceIgnore.FILE_NAME));
+      expect(readsForFi.length).to.equal(1);
+    });
+
+    it('reloads when .forceignore mtime or size changes', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-inv-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      writeFileSync(fiPath, '**/old/**\n');
+      mkdirSync(join(tmp, 'force-app'), { recursive: true });
+      const seed = join(tmp, 'force-app');
+      const readSpy = env.spy(fs, 'readFileSync');
+      ForceIgnore.findAndCreate(seed);
+      writeFileSync(fiPath, '**/new/**\n');
+      ForceIgnore.findAndCreate(seed);
+      const readsForFi = readSpy
+        .getCalls()
+        .filter((c) => typeof c.args[0] === 'string' && c.args[0].endsWith(ForceIgnore.FILE_NAME));
+      expect(readsForFi.length).to.equal(2);
+    });
+
+    it('cache hit: repeated findAndCreate keeps the same deny/accept behavior (no stale rules)', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-hit-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      const watched = join(tmp, 'cache-hit-marker.txt');
+      writeFileSync(fiPath, 'cache-hit-marker.txt\n');
+      mkdirSync(join(tmp, 'pkg'), { recursive: true });
+      const seed = join(tmp, 'pkg');
+
+      const a = ForceIgnore.findAndCreate(seed);
+      const b = ForceIgnore.findAndCreate(join(seed, 'nested'));
+      expect(a).to.equal(b);
+      expect(a.denies(watched)).to.be.true;
+      expect(b.denies(watched)).to.be.true;
+    });
+
+    it('after user edits .forceignore, reload applies new rules (not a stale cache)', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-edit-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      const watched = join(tmp, 'user-edit-marker.txt');
+      writeFileSync(fiPath, 'user-edit-marker.txt\n');
+      mkdirSync(join(tmp, 'force-app'), { recursive: true });
+      const seed = join(tmp, 'force-app');
+
+      const before = ForceIgnore.findAndCreate(seed);
+      expect(before.denies(watched)).to.be.true;
+
+      writeFileSync(fiPath, '# user cleared patterns\n');
+      const after = ForceIgnore.findAndCreate(seed);
+      expect(after).to.not.equal(before);
+      expect(after.denies(watched)).to.be.false;
+    });
+
+    it('after user removes .forceignore, findAndCreate stops denying paths (no file → empty rules)', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-rm-'));
+      const fiPath = join(tmp, ForceIgnore.FILE_NAME);
+      const watched = join(tmp, 'removed-rule.txt');
+      writeFileSync(fiPath, 'removed-rule.txt\n');
+      mkdirSync(join(tmp, 'src'), { recursive: true });
+      const seed = join(tmp, 'src');
+
+      const loaded = ForceIgnore.findAndCreate(seed);
+      expect(loaded.denies(watched)).to.be.true;
+
+      unlinkSync(fiPath);
+      const empty = ForceIgnore.findAndCreate(seed);
+      expect(empty.denies(watched)).to.be.false;
+    });
+
+    it('when user adds a new .forceignore, findAndCreate picks up rules (was accepting, now denies)', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-cache-add-'));
+      mkdirSync(join(tmp, 'force-app'), { recursive: true });
+      const seed = join(tmp, 'force-app');
+      const watched = join(tmp, 'newly-ignored.txt');
+
+      const before = ForceIgnore.findAndCreate(seed);
+      expect(before.denies(watched)).to.be.false;
+
+      writeFileSync(join(tmp, ForceIgnore.FILE_NAME), 'newly-ignored.txt\n');
+      const after = ForceIgnore.findAndCreate(seed);
+      expect(after).to.not.equal(before);
+      expect(after.denies(watched)).to.be.true;
+    });
   });
 
   describe('directory-only patterns (trailing slash in .forceignore)', () => {
@@ -105,6 +207,33 @@ describe('ForceIgnore', () => {
     it('does not deny an unrelated path', () => {
       const fi = new ForceIgnore(forceIgnorePath);
       expect(fi.denies(join('some', 'node_modules_extra'))).to.be.false;
+    });
+  });
+
+  describe('directory-only pattern vs file path (trailing-slash OR false positive)', () => {
+    it('denies a regular file whose basename matches a directory-only rule (gitignore would not)', () => {
+      const tmp = mkdtempSync(join(os.tmpdir(), 'sdr-fi-buildfile-'));
+      const sfdxProject = {
+        name: 'falsePositiveProj',
+        namespace: '',
+        packageDirectories: [{ default: true, path: 'force-app' }],
+        sfdcLoginUrl: 'https://login.salesforce.com',
+        sourceApiVersion: '58.0',
+      };
+      writeFileSync(join(tmp, 'sfdx-project.json'), `${JSON.stringify(sfdxProject, null, 2)}\n`);
+      mkdirSync(join(tmp, 'force-app', 'main', 'default'), { recursive: true });
+      const filePath = join(tmp, 'force-app', 'main', 'default', 'build');
+      writeFileSync(filePath, '# build output placeholder\n');
+      expect(statSync(filePath).isFile()).to.be.true;
+
+      writeFileSync(join(tmp, ForceIgnore.FILE_NAME), 'build/\n');
+      const fi = new ForceIgnore(join(tmp, ForceIgnore.FILE_NAME));
+
+      // Gitignore / node-ignore: pattern `build/` applies only to directories named `build`.
+      // `ignores('force-app/main/default/build')` is false for a file at that path, but
+      // ForceIgnore also tests `.../build/`, which matches the directory-only pattern—so
+      // this file is incorrectly treated as ignored (false positive).
+      expect(fi.denies(filePath)).to.be.false;
     });
   });
 

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -48,8 +48,9 @@ describe('ForceIgnore', () => {
     const forceIgnore = new ForceIgnore(forceIgnorePath);
     expect(forceIgnore.accepts(testPath)).to.be.false;
     expect(forceIgnore.denies(testPath)).to.be.true;
-    expect(debugSpy.calledOnce).to.be.true;
-    expect(debugSpy.getCall(0).args[0]).to.match(/Ignoring file .+ because it matched .forceignore patterns./g);
+    // accepts() delegates to denies(), so debug fires once per call (twice total)
+    expect(debugSpy.callCount).to.equal(2);
+    expect(debugSpy.getCall(0).args[0]).to.match(/Ignoring .+ because it matched .forceignore patterns\./g);
   });
 
   it('windows separators no longer have any effect', () => {
@@ -86,6 +87,27 @@ describe('ForceIgnore', () => {
     expect(forceIgnore.accepts(testPath)).to.be.false;
   });
 
+  describe('directory-only patterns (trailing slash in .forceignore)', () => {
+    beforeEach(() => {
+      env.stub(fs, 'readFileSync').returns('node_modules/');
+    });
+
+    it('denies a path matching a trailing-slash pattern (real or virtual directory)', () => {
+      const fi = new ForceIgnore(forceIgnorePath);
+      expect(fi.denies(join('some', 'node_modules'))).to.be.true;
+    });
+
+    it('accepts returns false for a path matching a trailing-slash pattern', () => {
+      const fi = new ForceIgnore(forceIgnorePath);
+      expect(fi.accepts(join('some', 'node_modules'))).to.be.false;
+    });
+
+    it('does not deny an unrelated path', () => {
+      const fi = new ForceIgnore(forceIgnorePath);
+      expect(fi.denies(join('some', 'node_modules_extra'))).to.be.false;
+    });
+  });
+
   it('Should handle forward slashes on windows', () => {
     const readStub = env.stub(fs, 'readFileSync');
     readStub.withArgs(forceIgnorePath).returns('force-app/main/default/classes/');
@@ -94,11 +116,14 @@ describe('ForceIgnore', () => {
     expect(fi.parser, 'if constructor throws, parser is not defined').to.not.equal(undefined);
   });
 
-  it('Should have the correct default in the case the parsers are not initialized', () => {
+  it('Should deny a directory path matching a trailing-slash pattern', () => {
     const readStub = env.stub(fs, 'readFileSync');
     readStub.withArgs(forceIgnorePath).returns('force-app/main/default/classes/');
     const fi = new ForceIgnore(forceIgnorePath);
-    expect(fi.accepts(join('force-app', 'main', 'default', 'classes'))).to.be.true;
+    // Both the path and path+'/' are tested, so directory-only patterns match correctly
+    // even without filesystem access (virtual trees, zip containers, etc.)
+    expect(fi.accepts(join('force-app', 'main', 'default', 'classes'))).to.be.false;
+    expect(fi.denies(join('force-app', 'main', 'default', 'classes'))).to.be.true;
   });
 
   /**
@@ -118,6 +143,27 @@ describe('ForceIgnore', () => {
       const dotPath = join(root, '.xyz');
       expect(forceIgnore.accepts(dotPath)).to.be.false;
       expect(forceIgnore.denies(dotPath)).to.be.true;
+    });
+
+    it('Should NOT ignore .sf directory itself', () => {
+      expect(forceIgnore.accepts(join(root, '.sf'))).to.be.true;
+      expect(forceIgnore.denies(join(root, '.sf'))).to.be.false;
+    });
+
+    it('Should NOT ignore .sf/orgs directory itself', () => {
+      expect(forceIgnore.accepts(join(root, '.sf', 'orgs'))).to.be.true;
+      expect(forceIgnore.denies(join(root, '.sf', 'orgs'))).to.be.false;
+    });
+
+    it('Should NOT ignore .sf/orgs/<orgId> directory itself', () => {
+      // **/.sf/orgs/*/** requires a path component after the orgId, so the orgId dir itself is accepted
+      expect(forceIgnore.accepts(join(root, '.sf', 'orgs', '00D000000000000'))).to.be.true;
+      expect(forceIgnore.denies(join(root, '.sf', 'orgs', '00D000000000000'))).to.be.false;
+    });
+
+    it('Should ignore content inside .sf/orgs/<orgId> that is not remoteMetadata', () => {
+      expect(forceIgnore.accepts(join(root, '.sf', 'orgs', '00D000000000000', 'foo'))).to.be.false;
+      expect(forceIgnore.denies(join(root, '.sf', 'orgs', '00D000000000000', 'foo'))).to.be.true;
     });
 
     it('Should NOT ignore .sf/orgs/<orgId>/remoteMetadata', () => {

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -354,17 +354,12 @@ describe('MetadataResolver', () => {
           },
         ]);
         access.getComponentsFromPath(path);
-        // isDirectory is called a few times during recursive parsing, after debugging
-        // we only need to verify calls made in succession are called with dirs, and then files
-        expect([isDirSpy.args[3][0], isDirSpy.args[4][0]]).to.deep.equal([path, join(path, 'parent.report-meta.xml')]);
-        expect([isDirSpy.args[7][0], isDirSpy.args[8][0]]).to.deep.equal([
-          join(path, 'dir1'),
-          join(path, 'parent.report-meta.xml'),
-        ]);
-        expect([isDirSpy.args[10][0], isDirSpy.args[11][0]]).to.deep.equal([
-          join(path, 'dir1'),
-          join(path, 'dir1', 'dir1.report-meta.xml'),
-        ]);
+        // verify dirs are visited before their sibling files in the call sequence
+        const calls = isDirSpy.args.map((a: string[]) => a[0]);
+        expect(calls.indexOf(path)).to.be.lessThan(calls.indexOf(join(path, 'parent.report-meta.xml')));
+        expect(calls.indexOf(join(path, 'dir1'))).to.be.lessThan(
+          calls.indexOf(join(path, 'dir1', 'dir1.report-meta.xml'))
+        );
       });
 
       it('Should determine type for folder files', () => {

--- a/test/resolve/treeContainers.test.ts
+++ b/test/resolve/treeContainers.test.ts
@@ -458,6 +458,55 @@ describe('Tree Containers', () => {
         expect(resolved.length).to.equal(1);
         expect(resolved[0].type.name).to.equal('ApexClass');
       });
+
+      it('builds parent directories for a single file path', () => {
+        const filePath = join('force-app', 'main', 'default', 'classes', 'Foo.cls');
+        const t = VirtualTreeContainer.fromFilePaths([filePath]);
+        expect(t.exists(filePath)).to.be.true;
+        expect(t.isDirectory(join('force-app', 'main', 'default', 'classes'))).to.be.true;
+        expect(t.readDirectory(join('force-app', 'main', 'default', 'classes'))).to.include.members(['Foo.cls']);
+      });
+
+      it('merges overlapping paths into shared directory entries', () => {
+        const base = join('force-app', 'main', 'default');
+        const a = join(base, 'classes', 'A.cls');
+        const b = join(base, 'triggers', 'T.trigger');
+        const t = VirtualTreeContainer.fromFilePaths([a, b]);
+        expect(t.exists(a)).to.be.true;
+        expect(t.exists(b)).to.be.true;
+        const rootChildren = t.readDirectory(base);
+        expect(rootChildren).to.include.members(['classes', 'triggers']);
+        expect(t.readDirectory(join(base, 'classes'))).to.deep.equal(['A.cls']);
+        expect(t.readDirectory(join(base, 'triggers'))).to.deep.equal(['T.trigger']);
+      });
+
+      it('deduplicates identical paths', () => {
+        const p = join('pkg', 'objects', 'Obj__c', 'Obj__c.object-meta.xml');
+        const t = VirtualTreeContainer.fromFilePaths([p, p, p]);
+        expect(t.exists(p)).to.be.true;
+        expect(t.readDirectory(join('pkg', 'objects', 'Obj__c'))).to.deep.equal(['Obj__c.object-meta.xml']);
+      });
+
+      it('handles a deep path', () => {
+        const parts = ['a', 'b', 'c', 'd', 'e', 'deep.txt'];
+        const filePath = join(...parts);
+        const t = VirtualTreeContainer.fromFilePaths([filePath]);
+        expect(t.exists(filePath)).to.be.true;
+        expect(t.isDirectory(join('a', 'b', 'c', 'd'))).to.be.true;
+        expect(t.readDirectory(join('a', 'b', 'c', 'd'))).to.deep.equal(['e']);
+      });
+
+      it('ignores non-string entries like the previous implementation', () => {
+        const p = join('x', 'y.txt');
+        const t = VirtualTreeContainer.fromFilePaths([p, undefined as unknown as string, null as unknown as string]);
+        expect(t.exists(p)).to.be.true;
+      });
+
+      it('produces no tree entries for a root-level filename (no parent segments)', () => {
+        const t = VirtualTreeContainer.fromFilePaths(['rootOnly.txt']);
+        expect(t.exists('rootOnly.txt')).to.be.false;
+        expect(() => t.readFileSync('rootOnly.txt')).to.throw();
+      });
     });
   });
 });

--- a/test/resolve/treeContainers.test.ts
+++ b/test/resolve/treeContainers.test.ts
@@ -15,7 +15,7 @@
  */
 /* eslint-disable class-methods-use-this */
 
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { Readable } from 'node:stream';
 import { Messages, SfError } from '@salesforce/core';
 import { assert, expect } from 'chai';
@@ -506,6 +506,15 @@ describe('Tree Containers', () => {
         const t = VirtualTreeContainer.fromFilePaths(['rootOnly.txt']);
         expect(t.exists('rootOnly.txt')).to.be.false;
         expect(() => t.readFileSync('rootOnly.txt')).to.throw();
+      });
+
+      it('handles absolute paths', () => {
+        const classesDir = resolve(sep, 'home', 'user', 'project', 'force-app', 'main', 'default', 'classes');
+        const abs = join(classesDir, 'Foo.cls-meta.xml');
+        const t = VirtualTreeContainer.fromFilePaths([abs]);
+        expect(t.exists(abs)).to.be.true;
+        expect(t.isDirectory(classesDir)).to.be.true;
+        expect(t.readDirectory(classesDir)).to.deep.equal(['Foo.cls-meta.xml']);
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

Fixes directory ignoring in `ForceIgnore` — directories were not being properly matched, allowing files inside ignored dirs to slip through during resolve.

### What issues does this PR fix or reference?

@W-21988477@

Made with [Cursor](https://cursor.com)