### PR TITLE
feat: @W-22168765: [CODA-MDAPI] Enable CLI for PolicyRuleDefinition and PolicyRuleDefinitionSet

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -547,6 +547,7 @@
     "workflowSend": "workflowsend",
     "workflowTask": "workflowtask",
     "xmd": "wavexmd",
+    "xml": "emailservicesfunction",
     "policyRuleDefinition": "policyruledefinition",
     "policyRuleDefinitionSet": "policyruledefinitionset",
     "xorghub": "xorghub",

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -547,7 +547,8 @@
     "workflowSend": "workflowsend",
     "workflowTask": "workflowtask",
     "xmd": "wavexmd",
-    "xml": "emailservicesfunction",
+    "policyRuleDefinition": "policyruledefinition",
+    "policyRuleDefinitionSet": "policyruledefinitionset",
     "xorghub": "xorghub",
     "ecaPush": "extlclntapppushsettings",
     "ecaPushPlcy": "extlclntapppushconfigurablepolicies",
@@ -5192,7 +5193,6 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-
     "telemetrydefinition": {
       "id": "telemetrydefinition",
       "name": "TelemetryDefinition",
@@ -5318,6 +5318,22 @@
       "name": "MeetingPlaybookDefinition",
       "suffix": "meetingPlaybookDefinition",
       "directoryName": "meetingPlaybookDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "policyruledefinition": {
+      "id": "policyruledefinition",
+      "name": "PolicyRuleDefinition",
+      "suffix": "policyRuleDefinition",
+      "directoryName": "policyRuleDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "policyruledefinitionset": {
+      "id": "policyruledefinitionset",
+      "name": "PolicyRuleDefinitionSet",
+      "suffix": "policyRuleDefinitionSet",
+      "directoryName": "policyRuleDefinitionSets",
       "inFolder": false,
       "strictDirectoryName": false
     }


### PR DESCRIPTION
### What does this PR do?

This PR added PolicyRuleDefinition and PolicyRuleDefinitionSet to metadataRegistry so that SF CLI could work with Policy API features

### What issues does this PR fix or reference?

This PR added PolicyRuleDefinition and PolicyRuleDefinitionSet to metadataRegistry so that SF CLI could work with Policy API features

#, @@W-22168765@

### Functionality Before

SF CLI doesn't current support Policy API features. An attempt to retrieve metadata type PolicyRuleDefinition and PolicyRuleDefinitionSet will result in error "Error (RegistryError): Missing metadata type definition in registry for id 'PolicyRuleDefinition'." or  "Error (RegistryError): Missing metadata type definition in registry for id 'PolicyRuleDefinitionSet'."


### Functionality After

SF CLI supports interaction with PolicyRuleDefinition and PolicyRuleDefinitionSet entities.

<img width="2041" height="688" alt="Screenshot 2026-04-23 at 2 37 22 AM" src="https://github.com/user-attachments/assets/6c3f3732-8a57-4de0-a964-3c2150c4c03f" />
<img width="2031" height="75" alt="Screenshot 2026-04-23 at 12 07 37 AM" src="https://github.com/user-attachments/assets/119d185a-c84b-4924-ac68-1f8666032167" />

