### PR TITLE
@W-22186996: add AiSurface and AiResponseFormat metadata types

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -117,8 +117,10 @@
     "ai": "aiapplication",
     "aiAgentScorerDefinition": "aiagentscorerdefinition",
     "aiAssistantTemplate": "aiassistanttemplate",
+    "aiResponseFormat": "airesponseformat",
     "aiScoringModelDefVersion": "aiscoringmodeldefversion",
     "aiScoringModelDefinition": "aiscoringmodeldefinition",
+    "aiSurface": "aisurface",
     "aiUsecaseDefinitions": "aiusecasedefinition",
     "aiapplicationconfig": "aiapplicationconfig",
     "animationRule": "animationrule",
@@ -789,6 +791,14 @@
       },
       "strictDirectoryName": true
     },
+    "airesponseformat": {
+      "directoryName": "aiResponseFormats",
+      "id": "airesponseformat",
+      "inFolder": false,
+      "name": "AiResponseFormat",
+      "suffix": "aiResponseFormat",
+      "strictDirectoryName": false
+    },
     "aiscoringmodeldefinition": {
       "children": {
         "directories": {
@@ -814,6 +824,14 @@
       "name": "AIScoringModelDefinition",
       "suffix": "aiScoringModelDefinition",
       "supportsWildcardAndName": true
+    },
+    "aisurface": {
+      "directoryName": "aiSurfaces",
+      "id": "aisurface",
+      "inFolder": false,
+      "name": "AiSurface",
+      "suffix": "aiSurface",
+      "strictDirectoryName": false
     },
     "aiusecasedefinition": {
       "directoryName": "aiUsecaseDefinitions",
@@ -5192,7 +5210,6 @@
       "inFolder": false,
       "strictDirectoryName": false
     },
-
     "telemetrydefinition": {
       "id": "telemetrydefinition",
       "name": "TelemetryDefinition",


### PR DESCRIPTION
### What does this PR do?

Support Surfaces metadata in sf cli

### What issues does this PR fix or reference?

[@W-22186996@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-22186996)

### Functionality Before

<img width="990" height="156" alt="image" src="https://github.com/user-attachments/assets/4fddfdcc-e559-4d88-81a6-6640f0da280a" />

```
Error (RegistryError): Missing metadata type definition in registry for id 'AiSurface'.

Try this:
Did you mean one of the following types? [ApexPage,Audience,DataSource]
```

### Functionality After

Surfaces and Response Format (deployable top levels) metadata type can be deployed via SF CLI.


Example patched via `registryCustomizations`:

<img width="436" height="125" alt="image" src="https://github.com/user-attachments/assets/bba3d88c-cbef-4385-a6ad-e68c70641833" />

```
 ────────────── Retrieving Metadata ──────────────

 Retrieving v66.0 metadata from epic.out.3c20d3736331@orgfarm.salesforce.com
 using the v66.0 SOAP API

 ✔ Preparing retrieve request 6ms
 ✔ Sending request to org 345ms
 ✔ Waiting for the org to respond 945ms
 ✔ Done 0ms

 Status: Succeeded
 Elapsed Time: 1.30s


Retrieved Source
┌─────────┬───────────┬───────────┬────────────────────────────────────────────────────────────────┐
│ State   │ Name      │ Type      │ Path                                                           │
├─────────┼───────────┼───────────┼────────────────────────────────────────────────────────────────┤
│ Created │ Messaging │ AiSurface │ force-app/main/default/aiSurfaces/Messaging.aiSurface-meta.xml │
└─────────┴───────────┴───────────┴────────────────────────────────────────────────────────────────┘
```

```
 ────────── Deploying Metadata (dry-run) ──────────

 Deploying (dry-run) v66.0 metadata to
 epic.out.3c20d3736331@orgfarm.salesforce.com using the v66.0 SOAP API.

 ✔ Preparing 132ms
 ✔ Waiting for the org to respond 519ms
 ✔ Deploying Metadata 747ms
   ▸ Components: 1/1 (100%)
 ◯ Running Tests - Skipped
 ◯ Updating Source Tracking - Skipped
 ✔ Done 0ms

 Status: Succeeded
 Deploy ID: 0AfQZ000001esVl0AI
 Target Org: epic.out.3c20d3736331@orgfarm.salesforce.com
 Elapsed Time: 1.40s


Validated Source
┌───────────┬─────────────────────────┬──────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
│ State     │ Name                    │ Type             │ Path                                                                                       │
├───────────┼─────────────────────────┼──────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
│ Unchanged │ VehicleRegistrationForm │ AiResponseFormat │ force-app/main/default/aiResponseFormats/VehicleRegistrationForm.aiResponseFormat-meta.xml │
└───────────┴─────────────────────────┴──────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘

```



```
────────────── Retrieving Metadata ──────────────

 Retrieving v66.0 metadata from epic.out.3c20d3736331@orgfarm.salesforce.com
 using the v66.0 SOAP API

 ✔ Preparing retrieve request 3ms
 ✔ Sending request to org 206ms
 ✔ Waiting for the org to respond 54.46s
 ✔ Done 0ms

 Status: Succeeded
 Elapsed Time: 54.67s


Retrieved Source
┌─────────┬─────────────────────────┬──────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
│ State   │ Name                    │ Type             │ Path                                                                                       │
├─────────┼─────────────────────────┼──────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
│ Created │ VehicleRegistrationForm │ AiResponseFormat │ force-app/main/default/aiResponseFormats/VehicleRegistrationForm.aiResponseFormat-meta.xml │
└─────────┴─────────────────────────┴──────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
```