### PR TITLE
@W-21799945: fix: rename WebApplicationResource to UIBundleResource in deploy

### DIFF
--- a/src/client/deployMessages.ts
+++ b/src/client/deployMessages.ts
@@ -147,7 +147,7 @@ export const getDeployMessages = (result: MetadataApiDeployStatus): Map<string, 
   return messageMap;
 };
 
-export const UI_BUNDLE_RESOURCE_TYPE = 'WebApplicationResource';
+export const UI_BUNDLE_RESOURCE_TYPE = 'UIBundleResource';
 
 /** Server-generated internal files that should not appear in per-file deploy results. */
 export const isUiBundleInternalPath = (resourceFullName: string): boolean =>

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -468,9 +468,9 @@ const warnIfUnmatchedServerResult =
     [...messageMap.keys()].flatMap((key) => {
       const [type, fullName] = key.split('#');
 
-      // WebApplicationResource messages are already handled by the parent WebApplication component
+      // UIBundleResource messages are already handled by the parent UIBundle component
       const consumedByWebApp =
-        (type === 'WebApplicationResource' || type === 'UIBundleResource') &&
+        type === 'UIBundleResource' &&
         fr.some((c) => c.type === 'UIBundle' && fullName.startsWith(`${c.fullName}/`));
 
       if (
@@ -524,12 +524,12 @@ const buildFileResponsesFromComponentSet =
 
     const fileResponses: FileResponse[] = (cs.getSourceComponents().toArray() ?? [])
       .flatMap((deployedComponent): FileResponse[] => {
-        // WebApplication bundles get per-file status via WebApplicationResource messages
+        // UIBundle bundles get per-file status via UIBundleResource messages
         if (
           deployedComponent.type.name === 'UIBundle' &&
           deployedComponent.content &&
           Array.from(responseMessages.entries()).some(
-            ([key]) => key.startsWith('WebApplicationResource#') && key.includes(`${deployedComponent.fullName}/`)
+            ([key]) => key.startsWith('UIBundleResource#') && key.includes(`${deployedComponent.fullName}/`)
           )
         ) {
           const base = {
@@ -542,7 +542,7 @@ const buildFileResponsesFromComponentSet =
           const perFileResponses = Array.from(responseMessages.entries())
             .filter(
               ([key, msgs]) =>
-                key.startsWith('WebApplicationResource#') &&
+                key.startsWith('UIBundleResource#') &&
                 key.includes(`${deployedComponent.fullName}/`) &&
                 msgs.length > 0
             )

--- a/test/client/deployMessages.test.ts
+++ b/test/client/deployMessages.test.ts
@@ -41,8 +41,8 @@ function createDeployMessage(overrides: Partial<DeployMessage>): DeployMessage {
 
 describe('deployMessages', () => {
   describe('UI_BUNDLE_RESOURCE_TYPE', () => {
-    it('should equal "WebApplicationResource"', () => {
-      expect(UI_BUNDLE_RESOURCE_TYPE).to.equal('WebApplicationResource');
+    it('should equal "UIBundleResource"', () => {
+      expect(UI_BUNDLE_RESOURCE_TYPE).to.equal('UIBundleResource');
     });
   });
 
@@ -77,8 +77,8 @@ describe('deployMessages', () => {
   });
 
   describe('isUiBundleResourceMessage', () => {
-    it('should return true when componentType is WebApplicationResource', () => {
-      const msg = createDeployMessage({ componentType: 'WebApplicationResource' });
+    it('should return true when componentType is UIBundleResource', () => {
+      const msg = createDeployMessage({ componentType: 'UIBundleResource' });
       assert.isTrue(isUiBundleResourceMessage(msg));
     });
 

--- a/test/client/metadataApiDeploy.test.ts
+++ b/test/client/metadataApiDeploy.test.ts
@@ -1376,12 +1376,12 @@ describe('MetadataApiDeploy', () => {
             deleted: 'false',
             success: 'true',
             fullName: `MyApp/${relativePath}`,
-            componentType: 'WebApplicationResource',
-            fileName: `webapplications/MyApp/${relativePath}`,
+            componentType: 'UIBundleResource',
+            fileName: `uiBundles/MyApp/${relativePath}`,
             ...overrides,
           } as DeployMessage);
 
-        it('should build per-file responses for each WebApplicationResource message', () => {
+        it('should build per-file responses for each UIBundleResource message', () => {
           const component = makeWebAppComponent();
           const deployedSet = new ComponentSet([component]);
           const apiStatus: Partial<MetadataApiDeployStatus> = {
@@ -1476,7 +1476,7 @@ describe('MetadataApiDeploy', () => {
           expect(deletedFile!.state).to.equal(ComponentStatus.Deleted);
         });
 
-        it('should include error and problemType for failed WebApplicationResource messages', () => {
+        it('should include error and problemType for failed UIBundleResource messages', () => {
           const component = makeWebAppComponent();
           const deployedSet = new ComponentSet([component]);
           const problem = 'Invalid markup in index.html';
@@ -1492,8 +1492,8 @@ describe('MetadataApiDeploy', () => {
                 problem,
                 problemType,
                 fullName: 'MyApp/dist/index.html',
-                componentType: 'WebApplicationResource',
-                fileName: 'webapplications/MyApp/dist/index.html',
+                componentType: 'UIBundleResource',
+                fileName: 'uiBundles/MyApp/dist/index.html',
               } as DeployMessage,
             },
           };
@@ -1533,7 +1533,7 @@ describe('MetadataApiDeploy', () => {
           expect(filePaths).to.not.include(join(bundlePath, 'languages', 'en_US.json'));
         });
 
-        it('should NOT warn for consumed WebApplicationResource messages', () => {
+        it('should NOT warn for consumed UIBundleResource messages', () => {
           const warnSpy = $$.SANDBOX.stub(Lifecycle.prototype, 'emitWarning');
           const emitSpy = $$.SANDBOX.stub(Lifecycle.prototype, 'emit');
 


### PR DESCRIPTION
@W-21799945@

**What does this PR do?** 
Removes the legacy WebApplicationResource type string from deploy message handling and fully renames it to UIBundleResource across source, constants, and tests.

**Specifically:**

UI_BUNDLE_RESOURCE_TYPE constant changed from 'WebApplicationResource' → 'UIBundleResource'
Removed the dual type === 'WebApplicationResource' || type === 'UIBundleResource' guard in warnIfUnmatchedServerResult — now only checks UIBundleResource
Updated UIBundleResource# key-prefix lookups in buildFileResponsesFromComponentSet (was WebApplicationResource#)
Updated all affected unit test descriptions and fixtures accordingly
What issues does this PR fix or reference? W-21799945 Requested in https://github.com/forcedotcom/source-deploy-retrieve/pull/1725#r3005564640

**Functionality Before**

Deploy message processing checked for both the old WebApplicationResource type and the new UIBundleResource type (kept for local testing convenience during the initial rollout):


(type === 'WebApplicationResource' || type === 'UIBundleResource') &&
UI_BUNDLE_RESOURCE_TYPE = 'WebApplicationResource'

**Functionality After**

Only UIBundleResource is recognized — the legacy WebApplicationResource string is fully removed:


type === 'UIBundleResource' &&
UI_BUNDLE_RESOURCE_TYPE = 'UIBundleResource'

All 87 unit tests pass. 