### PR TITLE
fix: singularly encode @W-22199494@

### DIFF
--- a/src/convert/streams.ts
+++ b/src/convert/streams.ts
@@ -304,7 +304,11 @@ export const correctComments = (xml: string): string =>
  * You also can't use Builder.tagValueProcessor to use this function
  * because the escaping of `&` happens AFTER that is called.
  * */
-export const handleSpecialEntities = (xml: string): string => xml.replaceAll('&amp;#160;', '&#160;');
+export const handleSpecialEntities = (xml: string): string =>
+  // Handle all numeric character references (decimal and hexadecimal), not just &#160;
+  // This fixes double-escaping of entities like &#39; (single quote) in formulas
+  // See: https://github.com/forcedotcom/cli/issues/3543
+  xml.replace(/&amp;#(x?[\da-fA-F]+);/g, '&#$1;');
 
 /** discriminate between the shouldDelete and the regular WriteInfo */
 const isWriteInfoWithSource = (writeInfo: WriteInfo): writeInfo is WriteInfo & { source: Readable } =>

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -588,6 +588,26 @@ describe('Streams', () => {
       expect(jsToXml.read().toString()).to.be.equal(expectedBody);
     });
 
+    it('should transform js with numeric character references (decimal and hex) to xml', () => {
+      const xmlObj = {
+        TestType: {
+          [XML_NS_KEY]: XML_NS_URL,
+          formula: 'LOWER(Name & &#39; &#39; & Name)',
+          description: 'Test&#160;with&#39;entities',
+          hexTest: '&#x27;&#xA0;',
+        },
+      };
+      const jsToXml = new streams.JsToXml(xmlObj);
+      let expectedBody = XML_DECL;
+      expectedBody += `<TestType xmlns="${XML_NS_URL}">\n`;
+      expectedBody += '    <formula>LOWER(Name &amp; &#39; &#39; &amp; Name)</formula>\n';
+      expectedBody += '    <description>Test&#160;with&#39;entities</description>\n';
+      expectedBody += '    <hexTest>&#x27;&#xA0;</hexTest>\n';
+      expectedBody += '</TestType>\n';
+
+      expect(jsToXml.read().toString()).to.be.equal(expectedBody);
+    });
+
     it('should transform js object with cdata to xml string', () => {
       const xmlObj = {
         TestType: {

--- a/test/convert/streams.test.ts
+++ b/test/convert/streams.test.ts
@@ -606,6 +606,8 @@ describe('Streams', () => {
       expectedBody += '</TestType>\n';
 
       expect(jsToXml.read().toString()).to.be.equal(expectedBody);
+    });
+    
     it('should preserve boolean attribute values like xsi:nil="true"', () => {
       const xmlObj = {
         TestType: {


### PR DESCRIPTION
### What does this PR do?
fixes HTML entities becoming doubly-encoded

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/3543
@W-22199494@

### Functionality Before

content like: 
`(Name &amp; &amp;#39; &amp;#39; &amp; Name)`

### Functionality After

`(Name &amp; &apos; &apos; &amp; Name)`
