### PR TITLE
@W-21979510 - fix: remove fieldMappingConfigItem child per platform-cli team recommendation

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -13,7 +13,6 @@
     "escalationrule": "escalationrules",
     "extdatatranfieldtemplate": "extdatatranobjecttemplate",
     "fieldset": "customobject",
-    "fieldmappingconfigitem": "fieldmappingconfig",
     "formsection": "form",
     "index": "customobject",
     "listview": "customobject",
@@ -295,7 +294,6 @@
     "featureParameterInteger": "featureparameterinteger",
     "feedFilter": "customfeedfilter",
     "fieldMappingConfig": "fieldmappingconfig",
-    "fieldMappingConfigItem": "fieldmappingconfigitem",
     "fieldServiceMobileExtension": "fieldservicemobileextension",
     "fieldSrcTrgtRelationship": "fieldsrctrgtrelationship",
     "fieldTranslation": "customfieldtranslation",
@@ -2674,24 +2672,6 @@
       "suffix": "featureParameterInteger"
     },
     "fieldmappingconfig": {
-      "children": {
-        "directories": {
-          "fieldMappingConfigItems": "fieldmappingconfigitem"
-        },
-        "suffixes": {
-          "fieldMappingConfigItem": "fieldmappingconfigitem"
-        },
-        "types": {
-          "fieldmappingconfigitem": {
-            "directoryName": "fieldMappingConfigItems",
-            "id": "fieldmappingconfigitem",
-            "name": "FieldMappingConfigItem",
-            "suffix": "fieldMappingConfigItem",
-            "uniqueIdElement": "processType",
-            "xmlElementName": "fieldMappingConfigItems"
-          }
-        }
-      },
       "directoryName": "fieldMappingConfigs",
       "id": "fieldmappingconfig",
       "inFolder": false,


### PR DESCRIPTION
### What does this PR do?

Removes the child `fieldMappingConfigItems` property from the metadataRegistry for the parent `fieldMappingConfig` item

### What issues does this PR fix or reference?

@W-21979510@

### Functionality Before

Pushing the fieldMappingConfig metadata through the metadata API would return the following error:
```
 Error (ConversionError): Component conversion failed: Missing processType on FieldMappingConfigItem
```
<img width="3136" height="188" alt="image" src="https://github.com/user-attachments/assets/7ec48a47-0679-46ee-803a-12cbc7283ca7" />


<insert gif and/or summary>

### Functionality After

Deploy succeeds without error:
<img width="2652" height="964" alt="image" src="https://github.com/user-attachments/assets/a5cca729-0e8f-4832-b087-46929a1f26cc" />

