### PR TITLE
@W-22580065 feat: add CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule to meta…

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -597,6 +597,8 @@
     "cnfgItemSourceDefinition": "cnfgitemsourcedefinition",
     "cnfgItemTypeAttrRelDef": "cnfgitemtypeattrreldef",
     "cnfgItemTypeDef": "cnfgitemtypedef",
+    "cnfgItemTypeIdentFieldMap": "cnfgitemtypeidentfieldmap",
+    "cnfgItemTypeIdentRule": "cnfgitemtypeidentrule",
     "cnfgItemTypeRelationDef": "cnfgitemtyperelationdef",
     "cnfgMgmtRelationTypeDef": "cnfgmgmtrelationtypedef",
     "meetingPlaybookDefinition": "meetingplaybookdefinition"
@@ -5294,6 +5296,22 @@
       "name": "CnfgItemTypeAttrRelDef",
       "suffix": "cnfgItemTypeAttrRelDef",
       "directoryName": "cnfgItemTypeAttrRelDefs",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "cnfgitemtypeidentfieldmap": {
+      "id": "cnfgitemtypeidentfieldmap",
+      "name": "CnfgItemTypeIdentFieldMap",
+      "suffix": "cnfgItemTypeIdentFieldMap",
+      "directoryName": "cnfgItemTypeIdentFieldMaps",
+      "inFolder": false,
+      "strictDirectoryName": false
+    },
+    "cnfgitemtypeidentrule": {
+      "id": "cnfgitemtypeidentrule",
+      "name": "CnfgItemTypeIdentRule",
+      "suffix": "cnfgItemTypeIdentRule",
+      "directoryName": "cnfgItemTypeIdentRules",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
…data registry

Register CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule as packageable metadata types in metadataRegistry.json, following the same pattern as the other CMDB entities added in PR #1710.

### What does this PR do?
Introduce CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule as metadata to be extracted using cli

### What issues does this PR fix or reference?
Introduce CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule as metadata to be extracted using cli

@W-22580065@

### Functionality Before

Earlier CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule couldn't be retrieved via CLI

### Functionality After

CnfgItemTypeIdentFieldMap and CnfgItemTypeIdentRule can be retrieved via CLI

<img width="1058" height="375" alt="Screenshot 2026-05-25 at 3 57 15 PM" src="https://github.com/user-attachments/assets/cbe2f840-d853-4ef6-8fd2-d5e76451af02" />

<img width="1073" height="314" alt="Screenshot 2026-05-25 at 5 38 10 PM" src="https://github.com/user-attachments/assets/ddeca94b-9bc3-45cc-8afc-b710b35743f6" />
<img width="1096" height="241" alt="Screenshot 2026-05-25 at 5 38 35 PM" src="https://github.com/user-attachments/assets/d7f917bc-285e-4d56-90eb-fed22708aab7" />



