### PR TITLE
feat: add ScopingRule type and fix RestrictionRule missing inFolder

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -601,7 +601,8 @@
     "cnfgItemTypeIdentRule": "cnfgitemtypeidentrule",
     "cnfgItemTypeRelationDef": "cnfgitemtyperelationdef",
     "cnfgMgmtRelationTypeDef": "cnfgmgmtrelationtypedef",
-    "meetingPlaybookDefinition": "meetingplaybookdefinition"
+    "meetingPlaybookDefinition": "meetingplaybookdefinition",
+    "scopingRule": "scopingrule"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -4069,7 +4070,8 @@
       "id": "restrictionrule",
       "name": "RestrictionRule",
       "strictDirectoryName": true,
-      "suffix": "rule"
+      "suffix": "rule",
+      "inFolder": false
     },
     "retrievalsummarydefinition": {
       "directoryName": "RetrievalSummaryDefinitions",
@@ -5362,6 +5364,13 @@
       "directoryName": "policyRuleDefinitionSets",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "scopingrule": {
+      "directoryName": "scopingRules",
+      "id": "scopingrule",
+      "inFolder": false,
+      "name": "ScopingRule",
+      "suffix": "scopingRule"
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Add `ScopingRule`** — new metadata type missing from the registry entirely. Adds entry in `types` and `suffixes`.
- **Fix `RestrictionRule`** — existing entry was missing `inFolder: false`, which is present on the sibling type `FieldRestrictionRule`.

## Changes to `metadataRegistry.json`

### New type: `ScopingRule`
```json
"scopingrule": {
  "directoryName": "scopingRules",
  "id": "scopingrule",
  "inFolder": false,
  "name": "ScopingRule",
  "suffix": "scopingRule"
}
```
Added corresponding suffix entry:
```json
"scopingRule": "scopingrule"
```

### Fix: `RestrictionRule`
Added missing `inFolder: false` to bring it in line with `FieldRestrictionRule`.

## Test plan
- [ ] `yarn mocha test/registry/registryValidation.test.ts` passes
- [ ] `yarn test:registry` passes
- [ ] `sf project retrieve start` correctly handles `.scopingRule-meta.xml` files
- [ ] `sf project retrieve start` correctly handles `.restrictionRule-meta.xml` files