### PR TITLE
@W-22840736 - Add HouseholdNamingConfig (264) to the registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -330,6 +330,7 @@
     "group": "group",
     "homePageComponent": "homepagecomponent",
     "homePageLayout": "homepagelayout",
+    "householdNamingConfig": "householdnamingconfig",
     "icon": "icon",
     "iframeWhiteListUrlSettings": "iframewhitelisturlsettings",
     "inboundCertificate": "inboundcertificate",
@@ -2966,6 +2967,14 @@
       "name": "HomePageLayout",
       "strictDirectoryName": false,
       "suffix": "homePageLayout"
+    },
+    "householdnamingconfig": {
+      "directoryName": "householdNamingConfigs",
+      "id": "householdnamingconfig",
+      "inFolder": false,
+      "name": "HouseholdNamingConfig",
+      "strictDirectoryName": false,
+      "suffix": "householdNamingConfig"
     },
     "icon": {
       "directoryName": "icons",


### PR DESCRIPTION
### What does this PR do?

Enables the new HouseholdNamingConfig entity to be available in the Metadata Registry for customers and partners to reference for metadata retrieval and deployment

### What issues does this PR fix or reference?

@W-22840736@

#<Insert GitHub Issue>, @<Insert GUS WI>@

### Functionality Before

<img width="2418" height="664" alt="image" src="https://github.com/user-attachments/assets/d7824f96-e180-44cf-aa17-dc4288d9650a" />


### Functionality After

<img width="2302" height="552" alt="image" src="https://github.com/user-attachments/assets/93b253d1-e2fc-43b8-9ba0-795755f30e7c" />


### Metadata Registry: Successful Deploy and Retrieve (required if applicable)

<!-- Attach a screenshot or paste CLI output logs showing a successful deploy and retrieve.
    For manual testing instructions, see: https://github.com/forcedotcom/source-deploy-retrieve/blob/main/contributing/metadata.md#manual-testing -->

**Deploy output:**

<img width="2598" height="944" alt="image" src="https://github.com/user-attachments/assets/c25b31cf-9178-4650-894f-aa7b35d9f080" />

<img width="1555" height="767" alt="image" src="https://github.com/user-attachments/assets/9144c681-1e21-4e31-a21a-381d4fe17dc0" />


**Retrieve output:**

<img width="2670" height="802" alt="image" src="https://github.com/user-attachments/assets/894c06c4-8c79-44cd-b01e-f213896a53f4" />

