### PR TITLE
feat: @w-22893150 - add support for FragmentBundle metadata

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -387,6 +387,7 @@ To contribute a new metadata type, please see the [Contributing Metadata Types t
 |FlowSettings|✅||
 |FlowTest|✅||
 |FlowValueMap|✅||
+|FragmentBundle|✅||
 |ForecastingFilter|✅||
 |ForecastingFilterCondition|✅||
 |ForecastingGroup|✅||

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -71,7 +71,8 @@
     "waveTemplates": "wavetemplatebundle",
     "appTemplates": "appframeworktemplatebundle",
     "lightningTypes": "lightningtypebundle",
-    "uiBundles": "uibundle"
+    "uiBundles": "uibundle",
+    "fragments": "fragmentbundle"
   },
   "suffixes": {
     "Canvas": "canvasmetadata",
@@ -5371,6 +5372,18 @@
       "directoryName": "policyRuleDefinitionSets",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "fragmentbundle": {
+      "id": "fragmentbundle",
+      "name": "FragmentBundle",
+      "directoryName": "fragments",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true,
+      "metaFileSuffix": "fragment.json"
     }
   }
 }

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -400,7 +400,13 @@ const parseAsMetadata =
     if (tree.isDirectory(fsPath)) {
       return;
     }
-    return ['DigitalExperience', 'ExperiencePropertyTypeBundle', 'LightningTypeBundle', 'ContentTypeBundle']
+    return [
+      'DigitalExperience',
+      'ExperiencePropertyTypeBundle',
+      'LightningTypeBundle',
+      'ContentTypeBundle',
+      'FragmentBundle',
+    ]
       .map((type) => registry.getTypeByName(type))
       .find((type) => fsPath.split(sep).includes(type.directoryName))?.name;
   };

--- a/src/utils/filePathGenerator.ts
+++ b/src/utils/filePathGenerator.ts
@@ -125,6 +125,7 @@ export const filePathsFromMetadataComponent = (
       ['ExperiencePropertyTypeBundle', [join(packageDirWithTypeDir, `${fullName}${sep}schema.json`)]],
       ['LightningTypeBundle', [join(packageDirWithTypeDir, `${fullName}${sep}schema.json`)]],
       ['ContentTypeBundle', [join(packageDirWithTypeDir, `${fullName}${sep}schema.json`)]],
+      ['FragmentBundle', [join(packageDirWithTypeDir, `${fullName}${sep}fragment.json`)]],
       ['WaveTemplateBundle', [join(packageDirWithTypeDir, `${fullName}${sep}template-info.json`)]],
       // ui-bundle.json is optional, so only the meta XML is a guaranteed file path.
       ['UIBundle', [join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.uibundle${META_XML_SUFFIX}`)]],

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -266,6 +266,16 @@ describe('MetadataResolver', () => {
         expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
       });
 
+      it('Should determine type for FragmentBundle content file', () => {
+        const fragmentPath = join('unpackaged', 'fragments', 'myFragment', 'fragment.json');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([fragmentPath]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const components = mdResolver.getComponentsFromPath(fragmentPath);
+        expect(components).to.have.lengthOf(1);
+        expect(components[0].type.name).to.equal('FragmentBundle');
+        expect(components[0].name).to.equal('myFragment');
+      });
+
       it('Should determine type for path of mixed content type', () => {
         const path = mixedContentDirectory.MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1];
         const access = testUtil.createMetadataResolver([

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -182,6 +182,16 @@ const testData = {
       },
     ],
   },
+  bundleFragment: {
+    fullName: 'myFragment',
+    typeName: 'FragmentBundle',
+    expectedFilePaths: [getFilePath('fragments/myFragment/fragment.json')],
+    expectedComponents: [
+      {
+        content: getFilePath('fragments/myFragment'),
+      },
+    ],
+  },
   nonDecomposedExplicit: {
     fullName: 'CustomLabels',
     typeName: 'CustomLabels',


### PR DESCRIPTION
## Summary
- Add `FragmentBundle` type to metadataRegistry.json (directoryName: `fragments`, suffix: `fragment`, bundle adapter)
- Add file path mapping for `fragment.json` in filePathGenerator.ts
- Add `FragmentBundle` to directory-based type resolution in metadataResolver.ts
- Update METADATA_SUPPORT.md

## Test plan
- [x] `sf project deploy start --metadata FragmentBundle` succeeds
- [x] `sf project deploy preview` recognizes FragmentBundle components
- [x] `sf project retrieve start --metadata FragmentBundle` recognized by server (no "unsupported type" error)
- [x] End-to-end retrieve with FragmentBundle content in org

🤖 Generated with [Claude Code](https://claude.com/claude-code)