### PR TITLE
@W-22809731: fix lightningOutApp directoryName to plural

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -5160,7 +5160,7 @@
       "id": "lightningoutapp",
       "name": "LightningOutApp",
       "suffix": "lightningOutApp",
-      "directoryName": "lightningOutApp",
+      "directoryName": "lightningOutApps",
       "inFolder": false,
       "strictDirectoryName": false
     },


### PR DESCRIPTION
  ### What does this PR do?
  Corrects the `LightningOutApp` registry entry's `directoryName` from the singular `lightningOutApp` to the
  plural `lightningOutApps`, aligning the SDR registry with the directory name used by Core and required by
  the Lightning Out 2.0 DX Requirements (§4.2).

  ### What issues does this PR fix or reference?
  [@W-22809731@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bQbaHYAS/view)

  Aligns SDR with Core PR #29387, where the SDR/Core directory-name mismatch (singular `lightningOutApp` vs.
  plural `lightningOutApps`) was identified as a blocker for `LightningOutApp` Metadata API enablement.

  ### Functionality Before
With the default registry (directoryName: `lightningOutApp`, singular), LightningOutApp could not be retrieved or deployed via DX. `sf project retrieve start --metadata LightningOutApp:InstalledPkgApp` returned status: 0 with 0 files - the singular directory name didn't match the server's lightningOutApps/ path, so nothing resolved to source.

<img width="1201" height="334" alt="Screenshot 2026-06-16 at 1 20 26 PM" src="https://github.com/user-attachments/assets/d201c72b-06ec-4819-aaf2-ff620c0540be" />


  ### Functionality After
  SDR retrieve/deploy uses `force-app/main/default/lightningOutApps/`, matching Core.

### Metadata Registry: Successful Deploy and Retrieve (required if applicable)

<!-- Attach a screenshot or paste CLI output logs showing a successful deploy and retrieve.
    For manual testing instructions, see: https://github.com/forcedotcom/source-deploy-retrieve/blob/main/contributing/metadata.md#manual-testing -->

**Deploy output:**

<img width="1158" height="431" alt="Screenshot 2026-06-16 at 1 23 24 PM" src="https://github.com/user-attachments/assets/45378bd9-1108-402e-b645-5131ea628701" />


**Retrieve output:**

<img width="1192" height="380" alt="Screenshot 2026-06-16 at 1 20 48 PM" src="https://github.com/user-attachments/assets/98dc25d7-5e37-4b3f-9c41-efc3824f8555" />