### PR TITLE
feat: add AnalyticsDatasetDefinition to registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -123,6 +123,7 @@
     "aiTestingDefinition": "aitestingdefinition",
     "aiUsecaseDefinitions": "aiusecasedefinition",
     "aiapplicationconfig": "aiapplicationconfig",
+    "analyticsDatasetDefinition": "analyticsdatasetdefinition",
     "animationRule": "animationrule",
     "app": "customapplication",
     "appMenu": "appmenu",
@@ -852,6 +853,14 @@
       "name": "AIUsecaseDefinition",
       "strictDirectoryName": false,
       "suffix": "aiUsecaseDefinitions"
+    },
+    "analyticsdatasetdefinition": {
+      "id": "analyticsdatasetdefinition",
+      "name": "AnalyticsDatasetDefinition",
+      "suffix": "analyticsDatasetDefinition",
+      "directoryName": "analyticsDatasetDefinitions",
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "analyticsnapshot": {
       "directoryName": "analyticSnapshots",


### PR DESCRIPTION
### What does this PR do?
Adds `AnalyticsDatasetDefinition` to the metadata registry for deploy/retrieve support.

### What issues does this PR fix or reference?
Closes a gap identified in `METADATA_SUPPORT.md` — `AnalyticsDatasetDefinition` is listed as ❌ "Not supported, but support could be added."

### Functionality Before
`AnalyticsDatasetDefinition` metadata type could not be deployed or retrieved using the CLI because it was absent from the registry.

### Functionality After
`AnalyticsDatasetDefinition` is now recognized by the registry, enabling standard deploy/retrieve operations.

### Metadata Registry: Successful Deploy and Retrieve (required if applicable)
Registry entry generated following the documented contribution guidelines at [contributing/metadata.md](https://github.com/forcedotcom/source-deploy-retrieve/blob/main/contributing/metadata.md).

Validation results:
- `yarn mocha test/registry/registryValidation.test.ts` — **29,124 passing**
- Entry follows existing alphabetical ordering conventions in `suffixes` and `types`
- No suffix collisions introduced
