### PR TITLE
fix: restrict yaml suffix resolution to externalServiceRegistrations directory @W-20424423@

### DIFF
--- a/src/registry/presets/decomposeExternalServiceRegistrationBeta.json
+++ b/src/registry/presets/decomposeExternalServiceRegistrationBeta.json
@@ -11,6 +11,7 @@
             "id": "yaml",
             "isAddressable": false,
             "name": "OAS Yaml Schema",
+            "strictDirectoryName": true,
             "suffix": "yaml",
             "xmlElementName": "schema"
           }

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -357,7 +357,7 @@ const resolveType =
       // It is likely that the metadata file is misspelled or has the wrong suffix.
       // A common occurrence is that a misspelled metadata file will fall back to
       // `EmailServicesFunction` because that is the default for the `.xml` suffix
-      if (resolvedType?.strictDirectoryName === true) {
+      if (resolvedType?.strictDirectoryName === true && !fsPath.split(sep).includes(resolvedType.directoryName)) {
         resolvedType = undefined;
       }
     }

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -22,12 +22,14 @@ import { createSandbox } from 'sinon';
 import {
   ComponentSet,
   MetadataResolver,
+  presetMap,
   registry,
   RegistryAccess,
   SourceComponent,
   VirtualDirectory,
   VirtualTreeContainer,
 } from '../../src';
+import { getEffectiveRegistry } from '../../src/registry/variants';
 import {
   bundle,
   decomposedtoplevel,
@@ -1042,6 +1044,32 @@ describe('MetadataResolver', () => {
       // Should only return the non-empty component
       expect(components).to.have.length(1);
       expect(components[0].name).to.equal('myComponent');
+    });
+  });
+
+  describe('decomposeExternalServiceRegistrationBeta preset', () => {
+    const esrRegistry = new RegistryAccess(
+      getEffectiveRegistry({ presets: [presetMap.get('decomposeExternalServiceRegistrationBeta')!] })
+    );
+
+    it('should not resolve a .yaml file outside externalServiceRegistrations as ExternalServiceRegistration', () => {
+      const yamlPath = join('force-app', 'main', 'default', 'customMetadata', 'stateTransition', 'transitions.yaml');
+      const tree = VirtualTreeContainer.fromFilePaths([yamlPath]);
+      const resolver = new MetadataResolver(esrRegistry, tree, false);
+
+      expect(() => resolver.getComponentsFromPath(yamlPath)).to.throw('Could not infer a metadata type');
+    });
+
+    it('should resolve a .yaml file inside externalServiceRegistrations as ExternalServiceRegistration', () => {
+      const esrDir = join('force-app', 'main', 'default', 'externalServiceRegistrations');
+      const yamlPath = join(esrDir, 'MyService.yaml');
+      const metaPath = join(esrDir, 'MyService.externalServiceRegistration-meta.xml');
+      const tree = VirtualTreeContainer.fromFilePaths([yamlPath, metaPath]);
+      const resolver = new MetadataResolver(esrRegistry, tree, false);
+
+      const components = resolver.getComponentsFromPath(yamlPath);
+      expect(components).to.have.lengthOf(1);
+      expect(components[0].type.name).to.equal('ExternalServiceRegistration');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a bug where enabling `decomposeExternalServiceRegistrationBeta` caused all `.yaml` files to be inferred as `ExternalServiceRegistration`, regardless of their directory location
- Adds `strictDirectoryName: true` to the `yaml` child type in the ESR preset
- Refines the suffix-based type resolution guard to only reject types when the file is NOT in the expected directory (previously it unconditionally rejected all `strictDirectoryName` types from suffix matching)

## Work Item
@W-20424423@: Every *.yml file is now inferred as External Service Registration after enabling metadata decomposition

https://github.com/forcedotcom/cli/issues/3463

## Root Cause
The ESR preset registers `yaml` in the global `suffixes` map. During type resolution "attempt 3" (file extension → suffix lookup), any `.yaml` file would match. The existing guard (`strictDirectoryName === true → reject`) couldn't help because the yaml child type didn't have that flag set.

## Fix
1. Set `strictDirectoryName: true` on the yaml child type
2. Change the guard from unconditional rejection to directory-aware rejection: only reject when `fsPath` does NOT contain the type's `directoryName`

## Proof of Work
- Tests: 30193 passing (2 pre-existing failures unrelated to this change)
- Lint: clean (0 errors, 8 pre-existing warnings)
- Type check: clean
- New tests verify both the fix (yaml outside ESR dir → error) and non-regression (yaml inside ESR dir → resolves correctly)

## Test plan
- [ ] `sf project deploy start` with `decomposeExternalServiceRegistrationBeta` enabled and a `.yaml` file in a non-ESR directory should not produce ConversionError
- [ ] ESR decomposition still works: `.yaml` files in `externalServiceRegistrations/` are resolved and deployed correctly
- [ ] Existing snapshot tests pass (mdapi ↔ source round-trip for ESR)