### PR TITLE
fix: improve polling frequency calculation @W-21321719@ @W-20866522@

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^8.31.2",
+    "@salesforce/core": "^8.31.4",
     "@salesforce/kit": "^3.2.4",
     "@salesforce/ts-types": "^2.0.12",
     "@salesforce/types": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@jsforce/jsforce-node": "^3.10.15",
+    "@jsforce/jsforce-node": "^3.10.16",
     "@salesforce/cli-plugins-testkit": "^5.3.58",
     "@salesforce/dev-scripts": "^11.0.4",
     "@types/deep-equal-in-any-order": "^1.0.1",

--- a/src/client/metadataApiDeploy.ts
+++ b/src/client/metadataApiDeploy.ts
@@ -193,6 +193,10 @@ export class MetadataApiDeploy extends MetadataTransfer<
     await connection.metadata.cancelDeploy(this.id);
   }
 
+  protected getZipSize(): number | undefined {
+    return this.zipSize;
+  }
+
   protected async pre(): Promise<AsyncResult> {
     const LifecycleInstance = Lifecycle.getInstance();
     const connection = await this.getConnection();

--- a/src/client/metadataTransfer.ts
+++ b/src/client/metadataTransfer.ts
@@ -89,7 +89,7 @@ export abstract class MetadataTransfer<
 
   /**
    * Poll for the status of the metadata transfer request.
-   * Default frequency is 100 ms.
+   * Default frequency is 1000ms minimum, scaling with deploy size (zip bytes or component count).
    * Default timeout is 60 minutes.
    *
    * @param options Polling options; frequency, timeout, polling function.
@@ -98,7 +98,7 @@ export abstract class MetadataTransfer<
   public async pollStatus(options?: Partial<PollingClient.Options>): Promise<Result>;
   /**
    * Poll for the status of the metadata transfer request.
-   * Default frequency is based on the number of SourceComponents, n, in the transfer, it ranges from 100ms -> n
+   * Default frequency is 1000ms minimum, scaling with deploy size (zip bytes or component count, capped at 10s).
    * Default timeout is 60 minutes.
    *
    * @param frequency Polling frequency in milliseconds.
@@ -110,7 +110,12 @@ export abstract class MetadataTransfer<
     frequencyOrOptions?: number | Partial<PollingClient.Options>,
     timeout?: number
   ): Promise<Result | undefined> {
-    const normalizedOptions = normalizePollingInputs(frequencyOrOptions, timeout, sizeOfComponentSet(this.components));
+    const normalizedOptions = normalizePollingInputs(
+      frequencyOrOptions,
+      timeout,
+      sizeOfComponentSet(this.components),
+      this.getZipSize()
+    );
     // Initialize error retry tracking
     this.consecutiveErrorRetries = 0;
     this.errorRetryLimit = calculateErrorRetryLimit(this.logger);
@@ -202,6 +207,11 @@ export abstract class MetadataTransfer<
 
   public onError(subscriber: (result: Error) => void): void {
     this.event.on('error', subscriber);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected getZipSize(): number | undefined {
+    return undefined;
   }
 
   protected async maybeSaveTempDirectory(target: SfdxFileFormat, cs?: ComponentSet): Promise<void> {
@@ -367,10 +377,11 @@ const getConnectionNoHigherThanOrgAllows = async (conn: Connection, requestedVer
 export const normalizePollingInputs = (
   frequencyOrOptions?: number | Partial<PollingClient.Options>,
   timeout?: number,
-  componentSetSize = 0
+  componentSetSize = 0,
+  zipSize?: number
 ): Pick<PollingClient.Options, 'frequency' | 'timeout'> => {
   let pollingOptions: Pick<PollingClient.Options, 'frequency' | 'timeout'> = {
-    frequency: Duration.milliseconds(calculatePollingFrequency(componentSetSize)),
+    frequency: Duration.milliseconds(calculatePollingFrequency(componentSetSize, zipSize)),
     timeout: Duration.minutes(60),
   };
   if (isNumber(frequencyOrOptions)) {
@@ -383,7 +394,7 @@ export const normalizePollingInputs = (
   }
   // from the overloaded methods, there's a possibility frequency/timeout isn't set
   // guarantee frequency and timeout are set
-  pollingOptions.frequency ??= Duration.milliseconds(calculatePollingFrequency(componentSetSize));
+  pollingOptions.frequency ??= Duration.milliseconds(calculatePollingFrequency(componentSetSize, zipSize));
   pollingOptions.timeout ??= Duration.minutes(60);
 
   return pollingOptions;
@@ -392,21 +403,25 @@ export const normalizePollingInputs = (
 /** yeah, there's a size property on CS.  But we want the actual number of source components */
 const sizeOfComponentSet = (cs?: ComponentSet): number => cs?.getSourceComponents().toArray().length ?? 0;
 
-/** based on the size of the components, pick a reasonable polling frequency */
-export const calculatePollingFrequency = (size: number): number => {
-  if (size === 0) {
-    // no component set size is possible for retrieve
-    return 1000;
-  } else if (size <= 10) {
-    return 100;
-  } else if (size <= 50) {
-    return 250;
-  } else if (size <= 100) {
-    return 500;
-  } else if (size <= 1000) {
+/** based on the size of the deploy (zip bytes for large deploys, component count for small ones), pick a reasonable polling frequency */
+export const calculatePollingFrequency = (componentCount: number, zipSize?: number): number => {
+  // Use zip size only for large payloads where component count alone underestimates deploy time
+  if (zipSize !== undefined && zipSize > 1_000_000) {
+    const ONE_MB = 1_000_000;
+    if (zipSize <= 5 * ONE_MB) {
+      return 2000;
+    } else if (zipSize <= 15 * ONE_MB) {
+      return 5000;
+    } else {
+      // large deploys (15MB+ up to 39MB limit) — poll every 10s
+      return 10_000;
+    }
+  }
+
+  if (componentCount <= 1000) {
     return 1000;
   } else {
-    return size;
+    return Math.min(componentCount, 10_000);
   }
 };
 

--- a/test/client/metadataTransfer.test.ts
+++ b/test/client/metadataTransfer.test.ts
@@ -468,14 +468,51 @@ describe('MetadataTransfer', () => {
   });
 
   describe('calculatePollingFrequency', () => {
-    it('0 => 1000', () => {
-      expect(calculatePollingFrequency(0)).to.equal(1000);
+    describe('component count fallback (no zipSize)', () => {
+      it('0 => 1000', () => {
+        expect(calculatePollingFrequency(0)).to.equal(1000);
+      });
+      it('10 => 1000 (minimum floor)', () => {
+        expect(calculatePollingFrequency(10)).to.equal(1000);
+      });
+      it('1000 => 1000', () => {
+        expect(calculatePollingFrequency(1000)).to.equal(1000);
+      });
+      it('2520 => 2520 (scales with component count above 1000)', () => {
+        expect(calculatePollingFrequency(2520)).to.equal(2520);
+      });
+      it('caps at 10000ms for very large component counts', () => {
+        expect(calculatePollingFrequency(35_000)).to.equal(10_000);
+      });
     });
-    it('10 => 100', () => {
-      expect(calculatePollingFrequency(10)).to.equal(100);
-    });
-    it('2520 => 2520', () => {
-      expect(calculatePollingFrequency(2520)).to.equal(2520);
+    describe('zipSize-based frequency', () => {
+      it('small zip (<= 1MB) falls through to component count', () => {
+        expect(calculatePollingFrequency(5, 500_000)).to.equal(1000);
+      });
+      it('zip at exactly 1MB falls through to component count', () => {
+        expect(calculatePollingFrequency(5, 1_000_000)).to.equal(1000);
+      });
+      it('zip just over 1MB uses zip-based frequency => 2000ms', () => {
+        expect(calculatePollingFrequency(5, 1_000_001)).to.equal(2000);
+      });
+      it('medium zip (<= 5MB) => 2000ms', () => {
+        expect(calculatePollingFrequency(5, 3_000_000)).to.equal(2000);
+      });
+      it('large zip (<= 15MB) => 5000ms', () => {
+        expect(calculatePollingFrequency(5, 10_000_000)).to.equal(5000);
+      });
+      it('very large zip (> 15MB) => 10000ms', () => {
+        expect(calculatePollingFrequency(5, 20_000_000)).to.equal(10_000);
+      });
+      it('zipSize takes priority over component count when > 1MB', () => {
+        expect(calculatePollingFrequency(10_000, 10_000_000)).to.equal(5000);
+      });
+      it('zipSize of 0 falls through to component count', () => {
+        expect(calculatePollingFrequency(5, 0)).to.equal(1000);
+      });
+      it('undefined zipSize falls through to component count', () => {
+        expect(calculatePollingFrequency(5, undefined)).to.equal(1000);
+      });
     });
   });
 
@@ -621,6 +658,20 @@ describe('MetadataTransfer', () => {
         );
         expect(result.timeout.seconds).to.deep.equal(Duration.minutes(20).seconds);
         expect(result.frequency.milliseconds).to.deep.equal(125);
+      });
+    });
+    describe('zipSize parameter', () => {
+      it('uses zip-based frequency when zipSize > 1MB and no explicit frequency', () => {
+        const result = normalizePollingInputs({}, undefined, 5, 3_000_000);
+        expect(result.frequency).to.deep.equal(Duration.milliseconds(2000));
+      });
+      it('explicit frequency in options overrides zip-based frequency', () => {
+        const result = normalizePollingInputs({ frequency: Duration.milliseconds(500) }, undefined, 5, 10_000_000);
+        expect(result.frequency.milliseconds).to.equal(500);
+      });
+      it('explicit frequency as number overrides zip-based frequency', () => {
+        const result = normalizePollingInputs(750, undefined, 5, 10_000_000);
+        expect(result.frequency).to.deep.equal(Duration.milliseconds(750));
       });
     });
   });

--- a/test/resolve/forceIgnore.test.ts
+++ b/test/resolve/forceIgnore.test.ts
@@ -117,7 +117,7 @@ describe('ForceIgnore', () => {
       const seed = join(tmp, 'force-app');
       const readSpy = env.spy(fs, 'readFileSync');
       ForceIgnore.findAndCreate(seed);
-      writeFileSync(fiPath, '**/new/**\n');
+      writeFileSync(fiPath, '**/new_pattern/**\n');
       ForceIgnore.findAndCreate(seed);
       const readsForFi = readSpy
         .getCalls()

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,23 +661,7 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
-"@jsforce/jsforce-node@^3.10.15":
-  version "3.10.16"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.16.tgz#a7f320896b5d3ff98dce8048a2a26f5c561d8f16"
-  integrity sha512-Fh5Op3vgyWMmPhjsr0d50AwPj6X9rsUNiJOPqA2OmJmv3HduIRY8tK+nc/IdtkOGdYXDk09q1cu0PG5pGERGgA==
-  dependencies:
-    "@sindresorhus/is" "^4"
-    base64url "^3.0.1"
-    csv-parse "^5.5.2"
-    csv-stringify "^6.6.0"
-    faye "^1.4.0"
-    form-data "^4.0.4"
-    https-proxy-agent "^5.0.0"
-    multistream "^3.1.0"
-    node-fetch "^2.6.1"
-    xml2js "^0.6.2"
-
-"@jsforce/jsforce-node@^3.10.17":
+"@jsforce/jsforce-node@^3.10.16", "@jsforce/jsforce-node@^3.10.17":
   version "3.10.17"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz#c8f0a9d3b88925d45b297f2a9dac8af2a17c47ee"
   integrity sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,21 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
+"@jsforce/jsforce-node@^3.10.17":
+  version "3.10.17"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz#c8f0a9d3b88925d45b297f2a9dac8af2a17c47ee"
+  integrity sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.6.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    multistream "^3.1.0"
+    undici "^8.5.0"
+    xml2js "^0.6.2"
+
 "@jsonjoy.com/base64@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
@@ -780,6 +795,31 @@
   integrity sha512-naqnq7Z+gbl1LdnyNvrGrNUoeMUQtCOsnrS6DfqeuLMJTFqcL9Dq0/od+xcuqi0+l7HTyH0/gU1BQitWpd1rag==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.13"
+    "@salesforce/kit" "^3.2.4"
+    "@salesforce/ts-types" "^2.0.12"
+    ajv "^8.18.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.1"
+    form-data "^4.0.5"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.3"
+    jszip "3.10.1"
+    memfs "4.38.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.8.0"
+    ts-retry-promise "^0.8.1"
+    zod "^4.1.12"
+
+"@salesforce/core@^8.31.4":
+  version "8.31.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.4.tgz#481f0330347da5ef4d23ebf6a8bd628a54106103"
+  integrity sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.17"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
     ajv "^8.18.0"
@@ -6088,6 +6128,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.5.0.tgz#31ba9021a3d84c15e61cc5e28be2d7c451e66a66"
+  integrity sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,7 +645,22 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.10.15", "@jsforce/jsforce-node@^3.10.17":
+"@jsforce/jsforce-node@^3.10.16":
+  version "3.10.18"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.18.tgz#0e1548ef6da39ccc8e884fb2eeb64c3da09c3866"
+  integrity sha512-3Nr7ykox18niSpjROR5orfLjuQ+SWoxycx4k6Bu6OTnwT8gjrLSOjkr6qC51ohDnvHGAG75q4h3VCnFrohXjJA==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.6.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    multistream "^3.1.0"
+    undici "^8.5.0"
+    xml2js "^0.6.2"
+
+"@jsforce/jsforce-node@^3.10.17":
   version "3.10.17"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz#c8f0a9d3b88925d45b297f2a9dac8af2a17c47ee"
   integrity sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==
@@ -758,31 +773,6 @@
     ts-retry-promise "^0.8.1"
 
 "@salesforce/core@^8.23.1", "@salesforce/core@^8.31.2", "@salesforce/core@^8.31.4":
-  version "8.31.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.4.tgz#481f0330347da5ef4d23ebf6a8bd628a54106103"
-  integrity sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==
-  dependencies:
-    "@jsforce/jsforce-node" "^3.10.17"
-    "@salesforce/kit" "^3.2.4"
-    "@salesforce/ts-types" "^2.0.12"
-    ajv "^8.18.0"
-    change-case "^4.1.2"
-    fast-levenshtein "^3.0.0"
-    faye "^1.4.1"
-    form-data "^4.0.5"
-    js2xmlparser "^4.0.1"
-    jsonwebtoken "9.0.3"
-    jszip "3.10.1"
-    memfs "4.38.1"
-    pino "^9.7.0"
-    pino-abstract-transport "^1.2.0"
-    pino-pretty "^11.3.0"
-    proper-lockfile "^4.1.2"
-    semver "^7.8.0"
-    ts-retry-promise "^0.8.1"
-    zod "^4.1.12"
-
-"@salesforce/core@^8.31.4":
   version "8.31.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.4.tgz#481f0330347da5ef4d23ebf6a8bd628a54106103"
   integrity sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==


### PR DESCRIPTION
## Summary

- Use deploy zip size (bytes) to determine polling frequency for large deploys (>1MB), preventing aggressive polling on deploys that take minutes to complete
- Raise the minimum polling frequency from 100ms to 1000ms for all deploys — the sub-second intervals (100/250/500ms) provide no practical benefit given typical metadata API response times
- Small deploys are unaffected (1s floor is still fast enough for sub-second server-side completions)

## Polling Frequency Tiers

| Condition | Frequency |
|-----------|-----------|
| Zip > 15MB | 10s |
| Zip 5–15MB | 5s |
| Zip 1–5MB | 2s |
| ≤ 1MB zip or no zip, ≤ 1000 components | 1s |
| ≤ 1MB zip or no zip, > 1000 components | scales with component count |

## Telemetry Validation

Analyzed 30 days of `metadata_api_deploy_result` telemetry data. The vast majority of deploys are small (median zip ~7KB) and were polling at an average of ~200ms — well below useful thresholds. The new 1s floor significantly reduces unnecessary API calls for the most common case without impacting perceived latency. Large deploys (>15MB) were polling at ~6-7s via component count scaling; the explicit 10s tier better matches their actual completion time.

## Work Items

- @W-21321719@: Reduce checkDeployStatus polling frequency — large deploys were polling at 100ms
- @W-20866522@: Simplify `calculatePollingFrequency` with 1000ms minimum floor

## Test plan

- [x] All existing polling frequency tests updated and passing
- [x] New tests for zip-size-based frequency tiers and boundary conditions
- [x] Type check clean
- [x] Lint clean (warnings only, all pre-existing)
- [ ] Verify no regression in deploy UX for small deploys (1s poll is imperceptible)
- [ ] Verify large deploy polling is noticeably less aggressive