### PR TITLE
feat: @W-23020460@ - add support for UiWidgetBundle metadata

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -8,881 +8,880 @@ Currently, there are 764/829 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|AIApplication|✅||
-|AIApplicationConfig|✅||
-|AIReplyRecommendationsSettings|✅||
-|AIScoringModelDefVersion|✅||
-|AIScoringModelDefinition|✅||
-|AIUsecaseDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AccountForecastSettings|✅||
-|AccountIntelligenceSettings|✅||
-|AccountPlanObjMeasCalcDef|✅||
-|AccountPlanSettings|✅||
-|AccountRelationshipShareRule|✅||
-|AccountSettings|✅||
-|AccountingFieldMapping|✅||
-|AccountingModelConfig|✅||
-|AccountingSettings|✅||
-|AcctMgrTargetSettings|✅||
-|ActionLauncherItemDef|✅||
-|ActionLinkGroupTemplate|✅||
-|ActionPlanTemplate|✅||
-|ActionableEventOrchDef|✅||
-|ActionableEventTypeDef|✅||
-|ActionableListDefinition|✅||
-|ActionsSettings|✅||
-|ActivationPlatform|✅||
-|ActivitiesSettings|✅||
-|ActnblListKeyPrfmIndDef|✅||
-|AddressSettings|✅||
-|AdminSuccessSettings|✅||
-|AdvAccountForecastSet|✅||
-|AdvAcctForecastDimSource|✅||
-|AdvAcctForecastPeriodGroup|✅||
-|AffinityScoreDefinition|✅||
-|AgentPlatformSettings|✅||
-|AgentforceAccountManagementSettings|✅||
-|AgentforceForDevelopersSettings|✅||
-|AgenticCtxtDecorDefinition|❌|Not supported, but support could be added|
-|Ai4mSettings|✅||
-|AiAgentScorerDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AiAuthoringBundle|✅||
-|AiEvaluationDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AiPlannerVoiceAvatarDef|❌|Not supported, but support could be added|
-|AiPlannerVoiceDef|❌|Not supported, but support could be added (but not for tracking)|
-|AiResponseFormat|⚠️|Supports deploy/retrieve but not source tracking|
-|AiResponseFormatIstr|❌|Not supported, but support could be added (but not for tracking)|
-|AiSurface|⚠️|Supports deploy/retrieve but not source tracking|
-|AiSurfaceInput|❌|Not supported, but support could be added (but not for tracking)|
-|AiSurfaceInstruction|❌|Not supported, but support could be added (but not for tracking)|
-|AiTestingDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|AnalyticSnapshot|✅||
-|AnalyticsDashboard|✅||
-|AnalyticsDatasetDefinition|❌|Not supported, but support could be added|
-|AnalyticsSettings|✅||
-|AnalyticsVisualization|✅||
-|AnalyticsWorkspace|✅||
-|AnimationRule|✅||
-|ApexClass|✅||
-|ApexComponent|✅||
-|ApexEmailNotifications|✅||
-|ApexLimitSettings|✅||
-|ApexPage|✅||
-|ApexSettings|✅||
-|ApexTestSuite|✅||
-|ApexTrigger|✅||
-|ApiNamedQuery|✅||
-|AppAnalyticsSettings|✅||
-|AppExperienceSettings|✅||
-|AppFrameworkTemplateBundle|✅||
-|AppMenu|✅||
-|ApplicationRecordTypeConfig|✅||
-|ApplicationSubtypeDefinition|✅||
-|AppointmentAssignmentPolicy|✅||
-|AppointmentBookingSettings|✅||
-|AppointmentSchedulingPolicy|✅||
-|ApprovalProcess|✅||
-|AssessmentConfiguration|✅||
-|AssessmentQuestion|✅||
-|AssessmentQuestionSet|✅||
-|AssignmentRules|✅||
-|AssistantContextItem|✅||
-|AssistantDefinition|✅||
-|AssistantSkillQuickAction|✅||
-|AssistantSkillSobjectAction|✅||
-|AssistantVersion|✅||
-|AssociationEngineSettings|✅||
-|Audience|✅||
-|AuraDefinitionBundle|✅||
-|AuthProvider|✅||
-|AutoResponseRules|✅||
-|AutomatorConfigSettings|✅||
-|BatchCalcJobDefinition|✅||
-|BatchProcessJobDefinition|✅||
-|BenefitAction|✅||
-|BillingSettings|✅||
-|BlacklistedConsumer|✅||
-|BldgEnrgyIntensityCnfg|✅||
-|BlockchainSettings|✅||
-|Bot|✅||
-|BotBlock|✅||
-|BotBlockVersion|❌|Not supported, but support could be added|
-|BotSettings|✅||
-|BotTemplate|✅||
-|BotVersion|✅||
-|BranchManagementSettings|✅||
-|BrandKitSettings|✅||
-|BrandingSet|✅||
-|BriefcaseDefinition|✅||
-|BusinessHoursSettings|✅||
-|BusinessProcess|✅||
-|BusinessProcessGroup|✅||
-|BusinessProcessTypeDefinition|✅||
-|CMSConnectSource|✅||
-|CallCenter|✅||
-|CallCenterRoutingMap|✅||
-|CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
-|CampaignInfluenceModel|✅||
-|CampaignSettings|✅||
-|CanvasMetadata|✅||
-|CareBenefitVerifySettings|✅||
-|CareLimitType|✅||
-|CareProviderAfflRoleConfig|✅||
-|CareProviderSearchConfig|✅||
-|CareRequestConfiguration|✅||
-|CareSystemFieldMapping|✅||
-|CaseSettings|✅||
-|CaseSubjectParticle|✅||
-|CatalogedApi|✅||
-|CatalogedApiArtifactVersionInfo|✅||
-|CatalogedApiVersion|✅||
-|Certificate|✅||
-|ChannelLayout|✅||
-|ChannelObjectLinkingRule|✅||
-|ChannelRevMgmtSettings|✅||
-|ChatterAnswersSettings|✅||
-|ChatterEmailsMDSettings|✅||
-|ChatterExtension|✅||
-|ChatterSettings|✅||
-|ChoiceList|⚠️|Supports deploy/retrieve but not source tracking|
-|ClaimCoverageProdtProcDef|❌|Not supported, but support could be added|
-|ClaimFinancialSettings|✅||
-|ClaimMgmtFoundationEnabledSettings|✅||
-|ClauseCatgConfiguration|✅||
-|CleanDataService|✅||
-|CmsnStmtLineItemConfig|❌|Not supported, but support could be added|
-|CmsnStmtLineItemTypConfig|❌|Not supported, but support could be added|
-|CnfgItemAttrDef|✅||
-|CnfgItemAttrPcklstValDef|✅||
-|CnfgItemAttrPicklistDef|✅||
-|CnfgItemAttrSetAttr|✅||
-|CnfgItemAttrSetDef|✅||
-|CnfgItemSourceDefinition|✅||
-|CnfgItemTypeAttrRelDef|✅||
-|CnfgItemTypeDef|✅||
-|CnfgItemTypeRelationDef|✅||
-|CnfgMgmtRelationTypeDef|✅||
-|CodeBuilderSettings|✅||
-|CollectionsDashboardSettings|✅||
-|CommandAction|✅||
-|CommerceSettings|✅||
-|CommissionStatementConfig|❌|Not supported, but support could be added|
-|CommsServiceConsoleSettings|✅||
-|CommunicationChannelLine|❌|Not supported, but support could be added|
-|CommunicationChannelType|❌|Not supported, but support could be added|
-|CommunitiesSettings|✅||
-|Community|✅||
-|CommunityTemplateDefinition|✅||
-|CommunityThemeDefinition|✅||
-|CompactLayout|✅||
-|CompanySettings|✅||
-|ComputeExtension|✅||
-|ConnectedApp|✅||
-|ConnectedAppSettings|✅||
-|ContentAsset|✅||
-|ContentSettings|✅||
-|ContentTypeBundle|✅||
-|ContextDefinition|✅||
-|ContextMappingConfig|❌|Not supported, but support could be added|
-|ContextUseCaseMapping|✅||
-|ContractSettings|✅||
-|ContractType|✅||
-|ConvIntelligenceSignalRule|✅||
-|ConversationChannelDefinition|✅||
-|ConversationGuidanceSettings|✅||
-|ConversationMessageDefinition|✅||
-|ConversationServiceIntegrationSettings|✅||
-|ConversationVendorInfo|✅||
-|ConversationalIntelligenceSettings|✅||
-|CorsWhitelistOrigin|✅||
-|CourseWaitlistConfig|❌|Not supported, but support could be added|
-|CriteriaSettings|✅||
-|CspTrustedSite|✅||
-|CurrencySettings|✅||
-|CustomAddressFieldSettings|✅||
-|CustomApplication|✅||
-|CustomApplicationComponent|✅||
-|CustomFeedFilter|✅||
-|CustomField|✅||
-|CustomFieldDisplay|❌|Not supported, but support could be added|
-|CustomHelpMenuSection|✅||
-|CustomIndex|✅||
-|CustomLabels|✅||
-|CustomMetadata|✅||
-|CustomNotificationType|✅||
-|CustomObject|✅||
-|CustomObjectBinding|❌|Not supported, but support could be added|
-|CustomObjectTranslation|✅||
-|CustomPageWebLink|✅||
-|CustomPermission|✅||
-|CustomSite|✅||
-|CustomTab|✅||
-|CustomValue|❌|Not supported, but support could be added|
-|CustomerDataPlatformSettings|✅||
-|CustomizablePropensityScoringSettings|✅||
-|Dashboard|✅||
-|DashboardFolder|✅||
-|DataCalcInsightTemplate|✅||
-|DataCategoryGroup|✅||
-|DataCleanRoomProvider|❌|Not supported, but support could be added|
-|DataConnector|✅||
-|DataConnectorIngestApi|✅||
-|DataConnectorS3|✅||
-|DataDotComSettings|✅||
-|DataImportManagementSettings|✅||
-|DataKitObjectDependency|✅||
-|DataKitObjectTemplate|✅||
-|DataMapperDefinition|✅||
-|DataMaskPolicy|❌|Not supported, but support could be added|
-|DataMaskSettings|✅||
-|DataObjectBuildOrgTemplate|✅||
-|DataObjectSearchIndexConf|⚠️|Supports deploy/retrieve but not source tracking|
-|DataPackageKitDefinition|✅||
-|DataPackageKitObject|✅||
-|DataSource|✅||
-|DataSourceBundleDefinition|✅||
-|DataSourceObject|✅||
-|DataSourceTenant|✅||
-|DataSrcDataModelFieldMap|✅||
-|DataStreamDefinition|✅||
-|DataStreamTemplate|✅||
-|DataWeaveResource|✅||
-|DealInsightsSettings|✅||
-|DecisionMatrixDefinition|✅||
-|DecisionMatrixDefinitionVersion|✅||
-|DecisionTable|✅||
-|DecisionTableDatasetLink|✅||
-|DelegateAccessDataSet|❌|Not supported, but support could be added|
-|DelegateAccessDef|❌|Not supported, but support could be added|
-|DelegateAccsDataSetObj|❌|Not supported, but support could be added|
-|DelegateGroup|✅||
-|DeploymentSettings|✅||
-|DevHubSettings|✅||
-|DgtAssetMgmtProvider|✅||
-|DgtAssetMgmtPrvdLghtCpnt|✅||
-|DictionariesSettings|✅||
-|DigitalExperience|✅||
-|DigitalExperienceBundle|✅||
-|DigitalExperienceConfig|✅||
-|DigitalWalletSettings|✅||
-|DisclosureDefinition|✅||
-|DisclosureDefinitionVersion|✅||
-|DisclosureType|✅||
-|DiscoveryAIModel|✅||
-|DiscoveryGoal|✅||
-|DiscoverySettings|✅||
-|DiscoveryStory|✅||
-|Document|✅||
-|DocumentCategory|✅||
-|DocumentCategoryDocumentType|✅||
-|DocumentChecklistSettings|✅||
-|DocumentExtractionDef|❌|Not supported, but support could be added|
-|DocumentFolder|✅||
-|DocumentGenerationSetting|✅||
-|DocumentTemplate|⚠️|Supports deploy/retrieve but not source tracking|
-|DocumentType|✅||
-|DripFeedConfigSettings|✅||
-|DuplicateRule|✅||
-|DxGlobalTermsSettings|✅||
-|DynamicFormsSettings|✅||
-|DynamicFulfillmentOrchestratorSettings|✅||
-|DynamicGanttSettings|✅||
-|EACSettings|✅||
-|ESignatureConfig|✅||
-|ESignatureEnvelopeConfig|✅||
-|EclairGeoData|✅||
-|EinsteinAISettings|✅||
-|EinsteinAgentSettings|✅||
-|EinsteinAssistantSettings|✅||
-|EinsteinCopilotSettings|✅||
-|EinsteinDealInsightsSettings|✅||
-|EinsteinDocumentCaptureSettings|✅||
-|EinsteinGptSettings|✅||
-|EmailAdministrationSettings|✅||
-|EmailAuthorizationSettings|✅||
-|EmailFolder|✅||
-|EmailIntegrationSettings|✅||
-|EmailServicesFunction|✅||
-|EmailTemplate|✅||
-|EmailTemplateFolder|✅||
-|EmailTemplateSettings|✅||
-|EmbeddedServiceBranding|✅||
-|EmbeddedServiceConfig|✅||
-|EmbeddedServiceFlowConfig|✅||
-|EmbeddedServiceLiveAgent|✅||
-|EmbeddedServiceMenuSettings|✅||
-|EmergencySettings|✅||
-|EmployeeDataSyncProfile|✅||
-|EmployeeFieldAccessSettings|✅||
-|EmployeeUserSettings|✅||
-|EnablementMeasureDefinition|✅||
-|EnablementProgramDefinition|✅||
-|EnblProgramTaskSubCategory|✅||
-|EnhancedNotesSettings|✅||
-|EnterpriseApiSettings|✅||
-|EntitlementProcess|✅||
-|EntitlementSettings|✅||
-|EntitlementTemplate|✅||
-|EscalationRules|✅||
-|EssentialsSettings|✅||
-|EventLogObjectSettings|✅||
-|EventRelayConfig|✅||
-|EventSettings|✅||
-|EvfSettings|✅||
-|EvidenceMgmtSettings|✅||
-|ExperienceBundle|✅||
-|ExperienceBundleSettings|✅||
-|ExperiencePropertyTypeBundle|✅||
-|ExplainabilityActionDefinition|✅||
-|ExplainabilityActionVersion|✅||
-|ExplainabilityMsgTemplate|✅||
-|ExpressionSetDefinition|✅||
-|ExpressionSetDefinitionVersion|✅||
-|ExpressionSetMessageToken|✅||
-|ExpressionSetObjectAlias|✅||
-|ExtDataTranFieldTemplate|❌|Not supported, but support could be added|
-|ExtDataTranObjectTemplate|✅||
-|ExternalAIModel|✅||
-|ExternalAuthIdentityProvider|✅||
-|ExternalClientAppSettings|✅||
-|ExternalClientApplication|✅||
-|ExternalCredential|✅||
-|ExternalDataConnector|✅||
-|ExternalDataSource|✅||
-|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
-|ExternalDataTranField|❌|Not supported, but support could be added|
-|ExternalDataTranObject|✅||
-|ExternalDocStorageConfig|✅||
-|ExternalServiceRegistration|✅||
-|ExternalStoragePrvdConfig|✅||
-|ExtlClntAppAttestConfigurablePolicies|❌|Not supported, but support could be added (but not for tracking)|
-|ExtlClntAppAttestSettings|✅||
-|ExtlClntAppCanvasSettings|✅||
-|ExtlClntAppConfigurablePolicies|✅||
-|ExtlClntAppGlobalOauthSettings|✅||
-|ExtlClntAppMobileConfigurablePolicies|✅||
-|ExtlClntAppMobileSettings|✅||
-|ExtlClntAppNotificationSettings|✅||
-|ExtlClntAppOauthConfigurablePolicies|✅||
-|ExtlClntAppOauthSecuritySettings|✅||
-|ExtlClntAppOauthSettings|✅||
-|ExtlClntAppPushConfigurablePolicies|✅||
-|ExtlClntAppPushSettings|✅||
-|ExtlClntAppSamlConfigurablePolicies|✅||
-|FeatureParameterBoolean|✅||
-|FeatureParameterDate|✅||
-|FeatureParameterInteger|✅||
-|FieldMappingConfig|✅||
-|FieldRestrictionRule|✅||
-|FieldServiceMobileConfig|✅||
-|FieldServiceMobileExtension|✅||
-|FieldServiceSettings|✅||
-|FieldSet|✅||
-|FieldSrcTrgtRelationship|✅||
-|FileUploadAndDownloadSecuritySettings|✅||
-|FilesConnectSettings|✅||
-|FinancialPortfolioUiConfig|❌|Not supported, but support could be added|
-|FlexcardDefinition|✅||
-|FlexiPage|✅||
-|Flow|✅||
-|FlowCategory|✅||
-|FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|FlowSettings|✅||
-|FlowTest|✅||
-|FlowValueMap|✅||
-|ForecastingFilter|✅||
-|ForecastingFilterCondition|✅||
-|ForecastingGroup|✅||
-|ForecastingObjectListSettings|✅||
-|ForecastingSettings|✅||
-|ForecastingSourceDefinition|✅||
-|ForecastingType|✅||
-|ForecastingTypeSource|✅||
-|FormulaSettings|✅||
-|FuelType|✅||
-|FuelTypeSustnUom|✅||
-|FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
-|FundraisingConfig|✅||
-|GRCIntelligenceUddSettings|✅||
-|GatewayProviderPaymentMethodType|✅||
-|GenAiFunction|✅||
-|GenAiPlannerBundle|✅||
-|GenAiPlugin|✅||
-|GenAiPromptTemplate|✅||
-|GenAiPromptTemplateActv|✅||
-|GenComputingSummaryDef|❌|Not supported, but support could be added|
-|GenOpAgentConfig|❌|Not supported, but support could be added|
-|GenOpPlanEligibilityConfig|❌|Not supported, but support could be added|
-|GeneralConfigSettings|✅||
-|GeocodeSettings|✅||
-|GiftEntryGridTemplate|✅||
-|GlobalValueSet|✅||
-|GlobalValueSetTranslation|✅||
-|GoogleAppsSettings|✅||
-|Group|✅||
-|HerokuAppLinkSettings|✅||
-|HighVelocitySalesSettings|✅||
-|HomePageComponent|✅||
-|HomePageLayout|✅||
-|IPAddressRange|✅||
-|Icon|✅||
-|IdeasSettings|✅||
-|IdentityProviderSettings|✅||
-|IdentityRsolDataSyncDef|❌|Not supported, but support could be added|
-|IdentityVerificationProcDef|✅||
-|IframeWhiteListUrlSettings|✅||
-|InboundCertificate|✅||
-|InboundNetworkConnection|✅||
-|IncidentMgmtSettings|✅||
-|IncludeEstTaxInQuoteCPQSettings|✅||
-|IncludeEstTaxInQuoteSettings|✅||
-|Index|⚠️|Supports deploy/retrieve but not source tracking|
-|IndustriesAutomotiveSettings|✅||
-|IndustriesChannelPartnerInventorySettings|✅||
-|IndustriesConnectedServiceSettings|✅||
-|IndustriesConstraintsSettings|✅||
-|IndustriesContextSettings|✅||
-|IndustriesEinsteinFeatureSettings|✅||
-|IndustriesEnergyUtilitiesMultiSiteSettings|✅||
-|IndustriesEventOrchSettings|✅||
-|IndustriesFieldServiceSettings|✅||
-|IndustriesGamificationSettings|✅||
-|IndustriesInsuranceSettings|✅||
-|IndustriesLoyaltySettings|✅||
-|IndustriesLsCommercialSettings|✅||
-|IndustriesManufacturingSettings|✅||
-|IndustriesMfgSampleManagementSettings|✅||
-|IndustriesPricingSettings|✅||
-|IndustriesRatingSettings|✅||
-|IndustriesSettings|✅||
-|IndustriesUnifiedInventorySettings|✅||
-|IndustriesUnifiedPromotionsSettings|✅||
-|IndustriesUsageSettings|✅||
-|InsBillingConfig|❌|Not supported, but support could be added|
-|InsPlcyCoverageSpecConfig|❌|Not supported, but support could be added|
-|InsPlcyLimitConsumptionRule|❌|Not supported, but support could be added|
-|InsPlcyLineOfBusConfig|❌|Not supported, but support could be added|
-|InsPolicyLifecycleConfig|❌|Not supported, but support could be added|
-|InsPolicyManagementConfig|❌|Not supported, but support could be added|
-|InsRatePlanCmsnConfig|❌|Not supported, but support could be added|
-|InsRatePlanTypeConfig|❌|Not supported, but support could be added|
-|InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
-|InsuranceBrokerageSettings|✅||
-|IntegArtifactDef|✅||
-|IntegratedPlanDefinition|❌|Not supported, but support could be added|
-|IntegrationProcdDefinition|✅||
-|IntegrationProviderDef|✅||
-|InterestTaggingSettings|✅||
-|InternalDataConnector|✅||
-|InvLatePymntRiskCalcSettings|✅||
-|InventoryAllocationSettings|✅||
-|InventoryReplenishmentSettings|✅||
-|InventorySettings|✅||
-|InvocableActionExtension|✅||
-|InvocableActionSettings|✅||
-|IoTSettings|✅||
-|KeywordList|✅||
-|KnowledgeGenerationSettings|✅||
-|KnowledgeSettings|✅||
-|LaborCostOptimCrewMgmtSettings|✅||
-|LaborCostOptimizationSettings|✅||
-|LanguageSettings|✅||
-|LargeQuotesandOrdersForRlmSettings|✅||
-|Layout|✅||
-|LeadConfigSettings|✅||
-|LeadConvertSettings|✅||
-|LearningAchievementConfig|✅||
-|LearningItemType|✅||
-|Letterhead|✅||
-|LicensingSettings|✅||
-|LifeSciConfigCategory|✅||
-|LifeSciConfigRecord|✅||
-|LightningBolt|✅||
-|LightningComponentBundle|✅||
-|LightningExperienceSettings|✅||
-|LightningExperienceTheme|✅||
-|LightningMessageChannel|✅||
-|LightningOnboardingConfig|✅||
-|LightningTypeBundle|✅||
-|ListView|✅||
-|LiveAgentSettings|✅||
-|LiveChatAgentConfig|✅||
-|LiveChatButton|✅||
-|LiveChatDeployment|✅||
-|LiveChatSensitiveDataRule|✅||
-|LiveMessageSettings|✅||
-|LocationUse|✅||
-|LogicSettings|✅||
-|LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
-|MacroSettings|✅||
-|MailMergeSettings|✅||
-|ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
-|ManagedEventSubscription|✅||
-|ManagedTopics|✅||
-|MapReportSettings|✅||
-|MapsAndLocationSettings|✅||
-|MarketSegmentDefinition|✅||
-|MarketingAppExtActivity|❌|Not supported, but support could be added|
-|MarketingAppExtension|✅||
-|MatchingRules|✅||
-|McpServerDefinition|✅||
-|MediaAdSalesSettings|✅||
-|MediaAgentSettings|✅||
-|MeetingPlaybookDefinition|✅||
-|MeetingsSettings|✅||
-|MessagingChannel|⚠️|Supports deploy/retrieve but not source tracking|
-|MfgProgramTemplate|✅||
-|MfgServiceConsoleSettings|✅||
-|MilestoneType|✅||
-|MktCalcInsightObjectDef|✅||
-|MktDataConnection|✅||
-|MktDataConnectionParam|❌|Not supported, but support could be added|
-|MktDataConnectionSrcParam|✅||
-|MktDataTranObject|✅||
-|MlDomain|✅||
-|MobSecurityCertPinConfig|✅||
-|MobileApplicationDetail|✅||
-|MobileSecurityAssignment|✅||
-|MobileSecurityPolicy|✅||
-|MobileSettings|✅||
-|ModerationRule|✅||
-|MutingPermissionSet|✅||
-|MyDomainDiscoverableLogin|✅||
-|MyDomainSettings|✅||
-|NameSettings|✅||
-|NamedCredential|✅||
-|NavigationMenu|✅||
-|Network|✅||
-|NetworkBranding|✅||
-|NotificationTypeConfig|✅||
-|NotificationsSettings|✅||
-|OauthCustomScope|✅||
-|OauthOidcSettings|✅||
-|OauthTokenExchangeHandler|✅||
-|ObjIntegProviderDefMapping|✅||
-|ObjectHierarchyRelationship|✅||
-|ObjectLinkingSettings|✅||
-|ObjectMappingSettings|✅||
-|ObjectSourceTargetMap|✅||
-|OcrSampleDocument|✅||
-|OcrTemplate|✅||
-|OmniChannelPricingSettings|✅||
-|OmniChannelSettings|✅||
-|OmniDataTransform|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniExtTrackingDef|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniIntegrationProcedure|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniInteractionAccessConfig|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniInteractionConfig|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniScript|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniStudioSettings|✅||
-|OmniSupervisorConfig|✅||
-|OmniTrackingGroup|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniUiCard|⚠️|Supports deploy/retrieve but not source tracking|
-|OmniscriptDefinition|✅||
-|OnboardingDataObjectGroup|✅||
-|OnlineSalesSettings|✅||
-|OpportunityScoreSettings|✅||
-|OpportunitySettings|✅||
-|OptimizationSettings|✅||
-|OrchestrationPlanCtxMapping|❌|Not supported, but support could be added|
-|OrderManagementSettings|✅||
-|OrderSettings|✅||
-|OrgSettings|✅||
-|OutboundNetworkConnection|✅||
-|PardotEinsteinSettings|✅||
-|PardotSettings|✅||
-|ParticipantRole|✅||
-|PartyDataModelSettings|✅||
-|PartyProfileDataObjectValidityDefinition|✅||
-|PathAssistant|✅||
-|PathAssistantSettings|✅||
-|PaymentGatewayProvider|✅||
-|PaymentsManagementEnabledSettings|✅||
-|PaymentsSettings|✅||
-|PaymentsSharingSettings|✅||
-|PaynowStarterUpgradeEnabledSettings|✅||
-|PermissionSet|✅||
-|PermissionSetGroup|✅||
-|PermissionSetLicenseDefinition|✅||
-|PersonAccountOwnerPowerUser|✅||
-|PicklistSettings|✅||
-|PicklistValue|❌|Not supported, but support could be added|
-|PipelineInspMetricConfig|✅||
-|PlanningMeasureDef|❌|Not supported, but support could be added|
-|PlanningMeasureGroup|❌|Not supported, but support could be added|
-|PlatformCachePartition|✅||
-|PlatformEventChannel|✅||
-|PlatformEventChannelMember|✅||
-|PlatformEventMigration|❌|Not supported, but support could be added|
-|PlatformEventSettings|✅||
-|PlatformEventSubscriberConfig|✅||
-|PlatformSlackSettings|✅||
-|PlatformWebIdeSettings|✅||
-|PolicyRuleDefinition|✅||
-|PolicyRuleDefinitionSet|✅||
-|PortalDelegablePermissionSet|✅||
-|PortalsSettings|✅||
-|PostTemplate|✅||
-|PredictionBuilderSettings|✅||
-|PresenceDeclineReason|✅||
-|PresenceUserConfig|✅||
-|PricingActionParameters|✅||
-|PricingRecipe|✅||
-|PrivacySettings|✅||
-|PrmCoreSettings|✅||
-|ProcedureOutputResolution|❌|Not supported, but support could be added (but not for tracking)|
-|ProcedurePlanDefinition|⚠️|Supports deploy/retrieve but not source tracking|
-|ProcessFlowMigration|✅||
-|ProductAttrDisplayConfig|✅||
-|ProductAttributeSet|✅||
-|ProductCatalogManagementSettings|✅||
-|ProductConfiguratorSettings|✅||
-|ProductDiscoverySettings|✅||
-|ProductSettings|✅||
-|ProductSpecificationRecType|✅||
-|ProductSpecificationType|✅||
-|Profile|✅||
-|ProfilePasswordPolicy|✅||
-|ProfileSessionSetting|✅||
-|Prompt|✅||
-|ProviderSampleLimitTemplate|❌|Not supported, but support could be added|
-|PublicKeyCertificate|⚠️|Supports deploy/retrieve but not source tracking|
-|PublicKeyCertificateSet|⚠️|Supports deploy/retrieve but not source tracking|
-|PurchaseOrderMgmtSettings|✅||
-|QualityManagementSettings|✅||
-|Queue|✅||
-|QueueRoutingConfig|✅||
-|QuickAction|✅||
-|QuickTextSettings|✅||
-|QuoteSettings|✅||
-|RealTimeEventSettings|✅||
-|RebateAndAccrualMgmtAdvncdSettings|✅||
-|RecAlrtDataSrcExpSetDef|✅||
-|RecommendationBuilderSettings|✅||
-|RecommendationStrategy|✅||
-|RecordActionDeployment|✅||
-|RecordAggregationDefinition|✅||
-|RecordAlertCategory|✅||
-|RecordAlertDataSource|✅||
-|RecordAlertTemplate|✅||
-|RecordPageSettings|✅||
-|RecordType|✅||
-|RedirectWhitelistUrl|✅||
-|ReferencedDashboard|✅||
-|ReferralMarketingConfig|❌|Not supported, but support could be added|
-|ReferralMarketingSettings|✅||
-|RegisteredExternalService|✅||
-|RelatedRecordAccessDef|❌|Not supported, but support could be added|
-|RelatedRecordAssocCriteria|✅||
-|RelationshipGraphDefinition|✅||
-|ReleaseMgmtSettings|✅||
-|RemoteSiteSetting|✅||
-|Report|✅||
-|ReportFolder|✅||
-|ReportType|✅||
-|RestrictionRule|✅||
-|RetailExecutionSettings|✅||
-|RetrievalSummaryDefinition|✅||
-|RevenueManagementSettings|✅||
-|RiskMgmtSettings|✅||
-|Role|✅||
-|SalesAgreementSettings|✅||
-|SalesDealAgentSettings|✅||
-|SalesWorkQueueSettings|✅||
-|SamlSsoConfig|✅||
-|SandboxSettings|✅||
-|SceGlobalModelOptOutSettings|✅||
-|SchedulingObjective|✅||
-|SchedulingRecipeSettings|✅||
-|SchedulingRule|✅||
-|SchemaSettings|✅||
-|ScoreCategory|✅||
-|SearchCustomization|⚠️|Supports deploy/retrieve but not source tracking|
-|SearchOrgWideObjectConfig|⚠️|Supports deploy/retrieve but not source tracking|
-|SearchSettings|✅||
-|SecurityAgentSettings|✅||
-|SecurityHubSettings|✅||
-|SecuritySettings|✅||
-|SelfSvcPortalTopic|❌|Not supported, but support could be added|
-|SequenceServiceSettings|✅||
-|ServiceAIRecommendationsSettings|✅||
-|ServiceAISetupDefinition|✅||
-|ServiceAISetupField|✅||
-|ServiceChannel|✅||
-|ServiceCloudNotificationOrchestratorSettings|✅||
-|ServiceCloudVoiceSettings|✅||
-|ServiceIssueManagementSettings|✅||
-|ServiceItsmChangeManagementSettings|✅||
-|ServiceItsmIntelligenceUddSettings|✅||
-|ServiceLegalStatusesSettings|✅||
-|ServiceMgmtKnwlgArtclConfig|❌|Not supported, but support could be added|
-|ServiceMgmtKnwlgArtclConfigSettings|✅||
-|ServicePresenceStatus|✅||
-|ServiceProcess|✅||
-|ServiceProcessSettings|✅||
-|ServiceScheduleConfig|❌|Not supported, but support could be added|
-|ServiceSetupAssistantSettings|✅||
-|SetupCopilotSettings|✅||
-|SharingCriteriaRule|✅||
-|SharingGuestRule|✅||
-|SharingOwnerRule|✅||
-|SharingReason|✅||
-|SharingRules|⚠️|Supports deploy/retrieve but not source tracking|
-|SharingSet|✅||
-|SharingSettings|✅||
-|SharingTerritoryRule|✅||
-|SiteDotCom|✅||
-|SiteSettings|✅||
-|Skill|✅||
-|SkillType|✅||
-|SlackApp|✅||
-|SoFieldMappingSettings|✅||
-|SocialCustomerServiceSettings|✅||
-|SourceTrackingSettings|✅||
-|SrvcMgmtObjCollabAppCnfg|❌|Not supported, but support could be added|
-|StageAssignment|✅||
-|StageDefinition|✅||
-|StandardValue|❌|Not supported, but support could be added|
-|StandardValueSet|✅||
-|StandardValueSetTranslation|✅||
-|StaticResource|✅||
-|StnryAssetEnvSrcCnfg|✅||
-|StockRotationSettings|✅||
-|StreamingAppDataConnector|✅||
-|SubscriptionManagementSettings|✅||
-|SurveySettings|✅||
-|SurveyStyleSet|❌|Not supported, but support could be added|
-|SustainabilityUom|✅||
-|SustnUomConversion|✅||
-|SvcCatalogCategory|✅||
-|SvcCatalogFilterCriteria|✅||
-|SvcCatalogFulfillmentFlow|✅||
-|SvcCatalogItemDef|✅||
-|SynchronizeSettings|✅||
-|SynonymDictionary|✅||
-|SystemNotificationSettings|✅||
-|Tag|❌|Not supported, but support could be added (but not for tracking)|
-|TagSet|❌|Not supported, but support could be added (but not for tracking)|
-|TelemetryActionDefStep|✅||
-|TelemetryActionDefinition|✅||
-|TelemetryActnDefStepAttr|✅||
-|TelemetryDefinition|✅||
-|TelemetryDefinitionVersion|✅||
-|Territory|✅||
-|Territory2|✅||
-|Territory2Model|✅||
-|Territory2Rule|✅||
-|Territory2Settings|✅||
-|Territory2Type|✅||
-|ThunderbirdVoiceSettings|✅||
-|TimeSheetTemplate|✅||
-|TimelineObjectDefinition|✅||
-|TmfOutboundNotificationSettings|✅||
-|TmshtLaborCostOptimAiSettings|✅||
-|TopicsForObjects|✅||
-|TrailheadSettings|✅||
-|TransactableMarketplacePrivateOfferSettings|✅||
-|TransactionProcessingType|⚠️|Supports deploy/retrieve but not source tracking|
-|TransactionSecurityPolicy|✅||
-|Translations|✅||
-|TrialOrgSettings|✅||
-|TriggerConfigurationsSettings|✅||
-|UIBundle|✅||
-|UIBundleSettings|✅||
-|UIObjectRelationConfig|✅||
-|UiFormatSpecificationSet|✅||
-|UiPlugin|✅||
-|UiPreviewMessageTabDef|✅||
-|UnifiedSalesIntelligenceSettings|✅||
-|UserAccessPolicy|✅||
-|UserAuthCertificate|✅||
-|UserCriteria|✅||
-|UserEngagementSettings|✅||
-|UserInterfaceSettings|✅||
-|UserManagementSettings|✅||
-|UserProvisioningConfig|✅||
-|ValidationRule|✅||
-|VehicleAssetEmssnSrcCnfg|✅||
-|ViewDefinition|✅||
-|VirtualVisitConfig|✅||
-|VoiceEngagementMediaFile|❌|Not supported, but support could be added|
-|VoiceEngagementMediaUsage|❌|Not supported, but support could be added|
-|VoiceEngmtMediaFileAsgnt|❌|Not supported, but support could be added|
-|VoiceSettings|✅||
-|WarrantyLifecycleMgmtSettings|✅||
-|WaveAnalyticAssetCollection|✅||
-|WaveApplication|✅||
-|WaveComponent|✅||
-|WaveDashboard|✅||
-|WaveDataflow|✅||
-|WaveDataset|✅||
-|WaveLens|✅||
-|WaveRecipe|✅||
-|WaveTemplateBundle|✅||
-|WaveXmd|✅||
-|Web3Settings|✅||
-|WebLink|✅||
-|WebStoreBundle|✅||
-|WebStoreTemplate|✅||
-|WebToXSettings|✅||
-|WorkDotComSettings|✅||
-|WorkSkillRouting|✅||
-|Workflow|✅||
-|WorkflowAlert|✅||
-|WorkflowFieldUpdate|✅||
-|WorkflowFlowAction|✅||
-|WorkflowKnowledgePublish|✅||
-|WorkflowOutboundMessage|✅||
-|WorkflowRule|✅||
-|WorkflowSend|✅||
-|WorkflowTask|✅||
-|WorkforceEngagementSettings|✅||
-
-
+| Metadata Type                                | Support | Notes                                                            |
+| :------------------------------------------- | :------ | :--------------------------------------------------------------- |
+| AIApplication                                | ✅      |                                                                  |
+| AIApplicationConfig                          | ✅      |                                                                  |
+| AIReplyRecommendationsSettings               | ✅      |                                                                  |
+| AIScoringModelDefVersion                     | ✅      |                                                                  |
+| AIScoringModelDefinition                     | ✅      |                                                                  |
+| AIUsecaseDefinition                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AccountForecastSettings                      | ✅      |                                                                  |
+| AccountIntelligenceSettings                  | ✅      |                                                                  |
+| AccountPlanObjMeasCalcDef                    | ✅      |                                                                  |
+| AccountPlanSettings                          | ✅      |                                                                  |
+| AccountRelationshipShareRule                 | ✅      |                                                                  |
+| AccountSettings                              | ✅      |                                                                  |
+| AccountingFieldMapping                       | ✅      |                                                                  |
+| AccountingModelConfig                        | ✅      |                                                                  |
+| AccountingSettings                           | ✅      |                                                                  |
+| AcctMgrTargetSettings                        | ✅      |                                                                  |
+| ActionLauncherItemDef                        | ✅      |                                                                  |
+| ActionLinkGroupTemplate                      | ✅      |                                                                  |
+| ActionPlanTemplate                           | ✅      |                                                                  |
+| ActionableEventOrchDef                       | ✅      |                                                                  |
+| ActionableEventTypeDef                       | ✅      |                                                                  |
+| ActionableListDefinition                     | ✅      |                                                                  |
+| ActionsSettings                              | ✅      |                                                                  |
+| ActivationPlatform                           | ✅      |                                                                  |
+| ActivitiesSettings                           | ✅      |                                                                  |
+| ActnblListKeyPrfmIndDef                      | ✅      |                                                                  |
+| AddressSettings                              | ✅      |                                                                  |
+| AdminSuccessSettings                         | ✅      |                                                                  |
+| AdvAccountForecastSet                        | ✅      |                                                                  |
+| AdvAcctForecastDimSource                     | ✅      |                                                                  |
+| AdvAcctForecastPeriodGroup                   | ✅      |                                                                  |
+| AffinityScoreDefinition                      | ✅      |                                                                  |
+| AgentPlatformSettings                        | ✅      |                                                                  |
+| AgentforceAccountManagementSettings          | ✅      |                                                                  |
+| AgentforceForDevelopersSettings              | ✅      |                                                                  |
+| AgenticCtxtDecorDefinition                   | ❌      | Not supported, but support could be added                        |
+| Ai4mSettings                                 | ✅      |                                                                  |
+| AiAgentScorerDefinition                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AiAuthoringBundle                            | ✅      |                                                                  |
+| AiEvaluationDefinition                       | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AiPlannerVoiceAvatarDef                      | ❌      | Not supported, but support could be added                        |
+| AiPlannerVoiceDef                            | ❌      | Not supported, but support could be added (but not for tracking) |
+| AiResponseFormat                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AiResponseFormatIstr                         | ❌      | Not supported, but support could be added (but not for tracking) |
+| AiSurface                                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AiSurfaceInput                               | ❌      | Not supported, but support could be added (but not for tracking) |
+| AiSurfaceInstruction                         | ❌      | Not supported, but support could be added (but not for tracking) |
+| AiTestingDefinition                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| AnalyticSnapshot                             | ✅      |                                                                  |
+| AnalyticsDashboard                           | ✅      |                                                                  |
+| AnalyticsDatasetDefinition                   | ❌      | Not supported, but support could be added                        |
+| AnalyticsSettings                            | ✅      |                                                                  |
+| AnalyticsVisualization                       | ✅      |                                                                  |
+| AnalyticsWorkspace                           | ✅      |                                                                  |
+| AnimationRule                                | ✅      |                                                                  |
+| ApexClass                                    | ✅      |                                                                  |
+| ApexComponent                                | ✅      |                                                                  |
+| ApexEmailNotifications                       | ✅      |                                                                  |
+| ApexLimitSettings                            | ✅      |                                                                  |
+| ApexPage                                     | ✅      |                                                                  |
+| ApexSettings                                 | ✅      |                                                                  |
+| ApexTestSuite                                | ✅      |                                                                  |
+| ApexTrigger                                  | ✅      |                                                                  |
+| ApiNamedQuery                                | ✅      |                                                                  |
+| AppAnalyticsSettings                         | ✅      |                                                                  |
+| AppExperienceSettings                        | ✅      |                                                                  |
+| AppFrameworkTemplateBundle                   | ✅      |                                                                  |
+| AppMenu                                      | ✅      |                                                                  |
+| ApplicationRecordTypeConfig                  | ✅      |                                                                  |
+| ApplicationSubtypeDefinition                 | ✅      |                                                                  |
+| AppointmentAssignmentPolicy                  | ✅      |                                                                  |
+| AppointmentBookingSettings                   | ✅      |                                                                  |
+| AppointmentSchedulingPolicy                  | ✅      |                                                                  |
+| ApprovalProcess                              | ✅      |                                                                  |
+| AssessmentConfiguration                      | ✅      |                                                                  |
+| AssessmentQuestion                           | ✅      |                                                                  |
+| AssessmentQuestionSet                        | ✅      |                                                                  |
+| AssignmentRules                              | ✅      |                                                                  |
+| AssistantContextItem                         | ✅      |                                                                  |
+| AssistantDefinition                          | ✅      |                                                                  |
+| AssistantSkillQuickAction                    | ✅      |                                                                  |
+| AssistantSkillSobjectAction                  | ✅      |                                                                  |
+| AssistantVersion                             | ✅      |                                                                  |
+| AssociationEngineSettings                    | ✅      |                                                                  |
+| Audience                                     | ✅      |                                                                  |
+| AuraDefinitionBundle                         | ✅      |                                                                  |
+| AuthProvider                                 | ✅      |                                                                  |
+| AutoResponseRules                            | ✅      |                                                                  |
+| AutomatorConfigSettings                      | ✅      |                                                                  |
+| BatchCalcJobDefinition                       | ✅      |                                                                  |
+| BatchProcessJobDefinition                    | ✅      |                                                                  |
+| BenefitAction                                | ✅      |                                                                  |
+| BillingSettings                              | ✅      |                                                                  |
+| BlacklistedConsumer                          | ✅      |                                                                  |
+| BldgEnrgyIntensityCnfg                       | ✅      |                                                                  |
+| BlockchainSettings                           | ✅      |                                                                  |
+| Bot                                          | ✅      |                                                                  |
+| BotBlock                                     | ✅      |                                                                  |
+| BotBlockVersion                              | ❌      | Not supported, but support could be added                        |
+| BotSettings                                  | ✅      |                                                                  |
+| BotTemplate                                  | ✅      |                                                                  |
+| BotVersion                                   | ✅      |                                                                  |
+| BranchManagementSettings                     | ✅      |                                                                  |
+| BrandKitSettings                             | ✅      |                                                                  |
+| BrandingSet                                  | ✅      |                                                                  |
+| BriefcaseDefinition                          | ✅      |                                                                  |
+| BusinessHoursSettings                        | ✅      |                                                                  |
+| BusinessProcess                              | ✅      |                                                                  |
+| BusinessProcessGroup                         | ✅      |                                                                  |
+| BusinessProcessTypeDefinition                | ✅      |                                                                  |
+| CMSConnectSource                             | ✅      |                                                                  |
+| CallCenter                                   | ✅      |                                                                  |
+| CallCenterRoutingMap                         | ✅      |                                                                  |
+| CallCoachingMediaProvider                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| CampaignInfluenceModel                       | ✅      |                                                                  |
+| CampaignSettings                             | ✅      |                                                                  |
+| CanvasMetadata                               | ✅      |                                                                  |
+| CareBenefitVerifySettings                    | ✅      |                                                                  |
+| CareLimitType                                | ✅      |                                                                  |
+| CareProviderAfflRoleConfig                   | ✅      |                                                                  |
+| CareProviderSearchConfig                     | ✅      |                                                                  |
+| CareRequestConfiguration                     | ✅      |                                                                  |
+| CareSystemFieldMapping                       | ✅      |                                                                  |
+| CaseSettings                                 | ✅      |                                                                  |
+| CaseSubjectParticle                          | ✅      |                                                                  |
+| CatalogedApi                                 | ✅      |                                                                  |
+| CatalogedApiArtifactVersionInfo              | ✅      |                                                                  |
+| CatalogedApiVersion                          | ✅      |                                                                  |
+| Certificate                                  | ✅      |                                                                  |
+| ChannelLayout                                | ✅      |                                                                  |
+| ChannelObjectLinkingRule                     | ✅      |                                                                  |
+| ChannelRevMgmtSettings                       | ✅      |                                                                  |
+| ChatterAnswersSettings                       | ✅      |                                                                  |
+| ChatterEmailsMDSettings                      | ✅      |                                                                  |
+| ChatterExtension                             | ✅      |                                                                  |
+| ChatterSettings                              | ✅      |                                                                  |
+| ChoiceList                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| ClaimCoverageProdtProcDef                    | ❌      | Not supported, but support could be added                        |
+| ClaimFinancialSettings                       | ✅      |                                                                  |
+| ClaimMgmtFoundationEnabledSettings           | ✅      |                                                                  |
+| ClauseCatgConfiguration                      | ✅      |                                                                  |
+| CleanDataService                             | ✅      |                                                                  |
+| CmsnStmtLineItemConfig                       | ❌      | Not supported, but support could be added                        |
+| CmsnStmtLineItemTypConfig                    | ❌      | Not supported, but support could be added                        |
+| CnfgItemAttrDef                              | ✅      |                                                                  |
+| CnfgItemAttrPcklstValDef                     | ✅      |                                                                  |
+| CnfgItemAttrPicklistDef                      | ✅      |                                                                  |
+| CnfgItemAttrSetAttr                          | ✅      |                                                                  |
+| CnfgItemAttrSetDef                           | ✅      |                                                                  |
+| CnfgItemSourceDefinition                     | ✅      |                                                                  |
+| CnfgItemTypeAttrRelDef                       | ✅      |                                                                  |
+| CnfgItemTypeDef                              | ✅      |                                                                  |
+| CnfgItemTypeRelationDef                      | ✅      |                                                                  |
+| CnfgMgmtRelationTypeDef                      | ✅      |                                                                  |
+| CodeBuilderSettings                          | ✅      |                                                                  |
+| CollectionsDashboardSettings                 | ✅      |                                                                  |
+| CommandAction                                | ✅      |                                                                  |
+| CommerceSettings                             | ✅      |                                                                  |
+| CommissionStatementConfig                    | ❌      | Not supported, but support could be added                        |
+| CommsServiceConsoleSettings                  | ✅      |                                                                  |
+| CommunicationChannelLine                     | ❌      | Not supported, but support could be added                        |
+| CommunicationChannelType                     | ❌      | Not supported, but support could be added                        |
+| CommunitiesSettings                          | ✅      |                                                                  |
+| Community                                    | ✅      |                                                                  |
+| CommunityTemplateDefinition                  | ✅      |                                                                  |
+| CommunityThemeDefinition                     | ✅      |                                                                  |
+| CompactLayout                                | ✅      |                                                                  |
+| CompanySettings                              | ✅      |                                                                  |
+| ComputeExtension                             | ✅      |                                                                  |
+| ConnectedApp                                 | ✅      |                                                                  |
+| ConnectedAppSettings                         | ✅      |                                                                  |
+| ContentAsset                                 | ✅      |                                                                  |
+| ContentSettings                              | ✅      |                                                                  |
+| ContentTypeBundle                            | ✅      |                                                                  |
+| ContextDefinition                            | ✅      |                                                                  |
+| ContextMappingConfig                         | ❌      | Not supported, but support could be added                        |
+| ContextUseCaseMapping                        | ✅      |                                                                  |
+| ContractSettings                             | ✅      |                                                                  |
+| ContractType                                 | ✅      |                                                                  |
+| ConvIntelligenceSignalRule                   | ✅      |                                                                  |
+| ConversationChannelDefinition                | ✅      |                                                                  |
+| ConversationGuidanceSettings                 | ✅      |                                                                  |
+| ConversationMessageDefinition                | ✅      |                                                                  |
+| ConversationServiceIntegrationSettings       | ✅      |                                                                  |
+| ConversationVendorInfo                       | ✅      |                                                                  |
+| ConversationalIntelligenceSettings           | ✅      |                                                                  |
+| CorsWhitelistOrigin                          | ✅      |                                                                  |
+| CourseWaitlistConfig                         | ❌      | Not supported, but support could be added                        |
+| CriteriaSettings                             | ✅      |                                                                  |
+| CspTrustedSite                               | ✅      |                                                                  |
+| CurrencySettings                             | ✅      |                                                                  |
+| CustomAddressFieldSettings                   | ✅      |                                                                  |
+| CustomApplication                            | ✅      |                                                                  |
+| CustomApplicationComponent                   | ✅      |                                                                  |
+| CustomFeedFilter                             | ✅      |                                                                  |
+| CustomField                                  | ✅      |                                                                  |
+| CustomFieldDisplay                           | ❌      | Not supported, but support could be added                        |
+| CustomHelpMenuSection                        | ✅      |                                                                  |
+| CustomIndex                                  | ✅      |                                                                  |
+| CustomLabels                                 | ✅      |                                                                  |
+| CustomMetadata                               | ✅      |                                                                  |
+| CustomNotificationType                       | ✅      |                                                                  |
+| CustomObject                                 | ✅      |                                                                  |
+| CustomObjectBinding                          | ❌      | Not supported, but support could be added                        |
+| CustomObjectTranslation                      | ✅      |                                                                  |
+| CustomPageWebLink                            | ✅      |                                                                  |
+| CustomPermission                             | ✅      |                                                                  |
+| CustomSite                                   | ✅      |                                                                  |
+| CustomTab                                    | ✅      |                                                                  |
+| CustomValue                                  | ❌      | Not supported, but support could be added                        |
+| CustomerDataPlatformSettings                 | ✅      |                                                                  |
+| CustomizablePropensityScoringSettings        | ✅      |                                                                  |
+| Dashboard                                    | ✅      |                                                                  |
+| DashboardFolder                              | ✅      |                                                                  |
+| DataCalcInsightTemplate                      | ✅      |                                                                  |
+| DataCategoryGroup                            | ✅      |                                                                  |
+| DataCleanRoomProvider                        | ❌      | Not supported, but support could be added                        |
+| DataConnector                                | ✅      |                                                                  |
+| DataConnectorIngestApi                       | ✅      |                                                                  |
+| DataConnectorS3                              | ✅      |                                                                  |
+| DataDotComSettings                           | ✅      |                                                                  |
+| DataImportManagementSettings                 | ✅      |                                                                  |
+| DataKitObjectDependency                      | ✅      |                                                                  |
+| DataKitObjectTemplate                        | ✅      |                                                                  |
+| DataMapperDefinition                         | ✅      |                                                                  |
+| DataMaskPolicy                               | ❌      | Not supported, but support could be added                        |
+| DataMaskSettings                             | ✅      |                                                                  |
+| DataObjectBuildOrgTemplate                   | ✅      |                                                                  |
+| DataObjectSearchIndexConf                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| DataPackageKitDefinition                     | ✅      |                                                                  |
+| DataPackageKitObject                         | ✅      |                                                                  |
+| DataSource                                   | ✅      |                                                                  |
+| DataSourceBundleDefinition                   | ✅      |                                                                  |
+| DataSourceObject                             | ✅      |                                                                  |
+| DataSourceTenant                             | ✅      |                                                                  |
+| DataSrcDataModelFieldMap                     | ✅      |                                                                  |
+| DataStreamDefinition                         | ✅      |                                                                  |
+| DataStreamTemplate                           | ✅      |                                                                  |
+| DataWeaveResource                            | ✅      |                                                                  |
+| DealInsightsSettings                         | ✅      |                                                                  |
+| DecisionMatrixDefinition                     | ✅      |                                                                  |
+| DecisionMatrixDefinitionVersion              | ✅      |                                                                  |
+| DecisionTable                                | ✅      |                                                                  |
+| DecisionTableDatasetLink                     | ✅      |                                                                  |
+| DelegateAccessDataSet                        | ❌      | Not supported, but support could be added                        |
+| DelegateAccessDef                            | ❌      | Not supported, but support could be added                        |
+| DelegateAccsDataSetObj                       | ❌      | Not supported, but support could be added                        |
+| DelegateGroup                                | ✅      |                                                                  |
+| DeploymentSettings                           | ✅      |                                                                  |
+| DevHubSettings                               | ✅      |                                                                  |
+| DgtAssetMgmtProvider                         | ✅      |                                                                  |
+| DgtAssetMgmtPrvdLghtCpnt                     | ✅      |                                                                  |
+| DictionariesSettings                         | ✅      |                                                                  |
+| DigitalExperience                            | ✅      |                                                                  |
+| DigitalExperienceBundle                      | ✅      |                                                                  |
+| DigitalExperienceConfig                      | ✅      |                                                                  |
+| DigitalWalletSettings                        | ✅      |                                                                  |
+| DisclosureDefinition                         | ✅      |                                                                  |
+| DisclosureDefinitionVersion                  | ✅      |                                                                  |
+| DisclosureType                               | ✅      |                                                                  |
+| DiscoveryAIModel                             | ✅      |                                                                  |
+| DiscoveryGoal                                | ✅      |                                                                  |
+| DiscoverySettings                            | ✅      |                                                                  |
+| DiscoveryStory                               | ✅      |                                                                  |
+| Document                                     | ✅      |                                                                  |
+| DocumentCategory                             | ✅      |                                                                  |
+| DocumentCategoryDocumentType                 | ✅      |                                                                  |
+| DocumentChecklistSettings                    | ✅      |                                                                  |
+| DocumentExtractionDef                        | ❌      | Not supported, but support could be added                        |
+| DocumentFolder                               | ✅      |                                                                  |
+| DocumentGenerationSetting                    | ✅      |                                                                  |
+| DocumentTemplate                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| DocumentType                                 | ✅      |                                                                  |
+| DripFeedConfigSettings                       | ✅      |                                                                  |
+| DuplicateRule                                | ✅      |                                                                  |
+| DxGlobalTermsSettings                        | ✅      |                                                                  |
+| DynamicFormsSettings                         | ✅      |                                                                  |
+| DynamicFulfillmentOrchestratorSettings       | ✅      |                                                                  |
+| DynamicGanttSettings                         | ✅      |                                                                  |
+| EACSettings                                  | ✅      |                                                                  |
+| ESignatureConfig                             | ✅      |                                                                  |
+| ESignatureEnvelopeConfig                     | ✅      |                                                                  |
+| EclairGeoData                                | ✅      |                                                                  |
+| EinsteinAISettings                           | ✅      |                                                                  |
+| EinsteinAgentSettings                        | ✅      |                                                                  |
+| EinsteinAssistantSettings                    | ✅      |                                                                  |
+| EinsteinCopilotSettings                      | ✅      |                                                                  |
+| EinsteinDealInsightsSettings                 | ✅      |                                                                  |
+| EinsteinDocumentCaptureSettings              | ✅      |                                                                  |
+| EinsteinGptSettings                          | ✅      |                                                                  |
+| EmailAdministrationSettings                  | ✅      |                                                                  |
+| EmailAuthorizationSettings                   | ✅      |                                                                  |
+| EmailFolder                                  | ✅      |                                                                  |
+| EmailIntegrationSettings                     | ✅      |                                                                  |
+| EmailServicesFunction                        | ✅      |                                                                  |
+| EmailTemplate                                | ✅      |                                                                  |
+| EmailTemplateFolder                          | ✅      |                                                                  |
+| EmailTemplateSettings                        | ✅      |                                                                  |
+| EmbeddedServiceBranding                      | ✅      |                                                                  |
+| EmbeddedServiceConfig                        | ✅      |                                                                  |
+| EmbeddedServiceFlowConfig                    | ✅      |                                                                  |
+| EmbeddedServiceLiveAgent                     | ✅      |                                                                  |
+| EmbeddedServiceMenuSettings                  | ✅      |                                                                  |
+| EmergencySettings                            | ✅      |                                                                  |
+| EmployeeDataSyncProfile                      | ✅      |                                                                  |
+| EmployeeFieldAccessSettings                  | ✅      |                                                                  |
+| EmployeeUserSettings                         | ✅      |                                                                  |
+| EnablementMeasureDefinition                  | ✅      |                                                                  |
+| EnablementProgramDefinition                  | ✅      |                                                                  |
+| EnblProgramTaskSubCategory                   | ✅      |                                                                  |
+| EnhancedNotesSettings                        | ✅      |                                                                  |
+| EnterpriseApiSettings                        | ✅      |                                                                  |
+| EntitlementProcess                           | ✅      |                                                                  |
+| EntitlementSettings                          | ✅      |                                                                  |
+| EntitlementTemplate                          | ✅      |                                                                  |
+| EscalationRules                              | ✅      |                                                                  |
+| EssentialsSettings                           | ✅      |                                                                  |
+| EventLogObjectSettings                       | ✅      |                                                                  |
+| EventRelayConfig                             | ✅      |                                                                  |
+| EventSettings                                | ✅      |                                                                  |
+| EvfSettings                                  | ✅      |                                                                  |
+| EvidenceMgmtSettings                         | ✅      |                                                                  |
+| ExperienceBundle                             | ✅      |                                                                  |
+| ExperienceBundleSettings                     | ✅      |                                                                  |
+| ExperiencePropertyTypeBundle                 | ✅      |                                                                  |
+| ExplainabilityActionDefinition               | ✅      |                                                                  |
+| ExplainabilityActionVersion                  | ✅      |                                                                  |
+| ExplainabilityMsgTemplate                    | ✅      |                                                                  |
+| ExpressionSetDefinition                      | ✅      |                                                                  |
+| ExpressionSetDefinitionVersion               | ✅      |                                                                  |
+| ExpressionSetMessageToken                    | ✅      |                                                                  |
+| ExpressionSetObjectAlias                     | ✅      |                                                                  |
+| ExtDataTranFieldTemplate                     | ❌      | Not supported, but support could be added                        |
+| ExtDataTranObjectTemplate                    | ✅      |                                                                  |
+| ExternalAIModel                              | ✅      |                                                                  |
+| ExternalAuthIdentityProvider                 | ✅      |                                                                  |
+| ExternalClientAppSettings                    | ✅      |                                                                  |
+| ExternalClientApplication                    | ✅      |                                                                  |
+| ExternalCredential                           | ✅      |                                                                  |
+| ExternalDataConnector                        | ✅      |                                                                  |
+| ExternalDataSource                           | ✅      |                                                                  |
+| ExternalDataSrcDescriptor                    | ❌      | Not supported, but support could be added                        |
+| ExternalDataTranField                        | ❌      | Not supported, but support could be added                        |
+| ExternalDataTranObject                       | ✅      |                                                                  |
+| ExternalDocStorageConfig                     | ✅      |                                                                  |
+| ExternalServiceRegistration                  | ✅      |                                                                  |
+| ExternalStoragePrvdConfig                    | ✅      |                                                                  |
+| ExtlClntAppAttestConfigurablePolicies        | ❌      | Not supported, but support could be added (but not for tracking) |
+| ExtlClntAppAttestSettings                    | ✅      |                                                                  |
+| ExtlClntAppCanvasSettings                    | ✅      |                                                                  |
+| ExtlClntAppConfigurablePolicies              | ✅      |                                                                  |
+| ExtlClntAppGlobalOauthSettings               | ✅      |                                                                  |
+| ExtlClntAppMobileConfigurablePolicies        | ✅      |                                                                  |
+| ExtlClntAppMobileSettings                    | ✅      |                                                                  |
+| ExtlClntAppNotificationSettings              | ✅      |                                                                  |
+| ExtlClntAppOauthConfigurablePolicies         | ✅      |                                                                  |
+| ExtlClntAppOauthSecuritySettings             | ✅      |                                                                  |
+| ExtlClntAppOauthSettings                     | ✅      |                                                                  |
+| ExtlClntAppPushConfigurablePolicies          | ✅      |                                                                  |
+| ExtlClntAppPushSettings                      | ✅      |                                                                  |
+| ExtlClntAppSamlConfigurablePolicies          | ✅      |                                                                  |
+| FeatureParameterBoolean                      | ✅      |                                                                  |
+| FeatureParameterDate                         | ✅      |                                                                  |
+| FeatureParameterInteger                      | ✅      |                                                                  |
+| FieldMappingConfig                           | ✅      |                                                                  |
+| FieldRestrictionRule                         | ✅      |                                                                  |
+| FieldServiceMobileConfig                     | ✅      |                                                                  |
+| FieldServiceMobileExtension                  | ✅      |                                                                  |
+| FieldServiceSettings                         | ✅      |                                                                  |
+| FieldSet                                     | ✅      |                                                                  |
+| FieldSrcTrgtRelationship                     | ✅      |                                                                  |
+| FileUploadAndDownloadSecuritySettings        | ✅      |                                                                  |
+| FilesConnectSettings                         | ✅      |                                                                  |
+| FinancialPortfolioUiConfig                   | ❌      | Not supported, but support could be added                        |
+| FlexcardDefinition                           | ✅      |                                                                  |
+| FlexiPage                                    | ✅      |                                                                  |
+| Flow                                         | ✅      |                                                                  |
+| FlowCategory                                 | ✅      |                                                                  |
+| FlowDefinition                               | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| FlowSettings                                 | ✅      |                                                                  |
+| FlowTest                                     | ✅      |                                                                  |
+| FlowValueMap                                 | ✅      |                                                                  |
+| ForecastingFilter                            | ✅      |                                                                  |
+| ForecastingFilterCondition                   | ✅      |                                                                  |
+| ForecastingGroup                             | ✅      |                                                                  |
+| ForecastingObjectListSettings                | ✅      |                                                                  |
+| ForecastingSettings                          | ✅      |                                                                  |
+| ForecastingSourceDefinition                  | ✅      |                                                                  |
+| ForecastingType                              | ✅      |                                                                  |
+| ForecastingTypeSource                        | ✅      |                                                                  |
+| FormulaSettings                              | ✅      |                                                                  |
+| FuelType                                     | ✅      |                                                                  |
+| FuelTypeSustnUom                             | ✅      |                                                                  |
+| FunctionReference                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| FundraisingConfig                            | ✅      |                                                                  |
+| GRCIntelligenceUddSettings                   | ✅      |                                                                  |
+| GatewayProviderPaymentMethodType             | ✅      |                                                                  |
+| GenAiFunction                                | ✅      |                                                                  |
+| GenAiPlannerBundle                           | ✅      |                                                                  |
+| GenAiPlugin                                  | ✅      |                                                                  |
+| GenAiPromptTemplate                          | ✅      |                                                                  |
+| GenAiPromptTemplateActv                      | ✅      |                                                                  |
+| GenComputingSummaryDef                       | ❌      | Not supported, but support could be added                        |
+| GenOpAgentConfig                             | ❌      | Not supported, but support could be added                        |
+| GenOpPlanEligibilityConfig                   | ❌      | Not supported, but support could be added                        |
+| GeneralConfigSettings                        | ✅      |                                                                  |
+| GeocodeSettings                              | ✅      |                                                                  |
+| GiftEntryGridTemplate                        | ✅      |                                                                  |
+| GlobalValueSet                               | ✅      |                                                                  |
+| GlobalValueSetTranslation                    | ✅      |                                                                  |
+| GoogleAppsSettings                           | ✅      |                                                                  |
+| Group                                        | ✅      |                                                                  |
+| HerokuAppLinkSettings                        | ✅      |                                                                  |
+| HighVelocitySalesSettings                    | ✅      |                                                                  |
+| HomePageComponent                            | ✅      |                                                                  |
+| HomePageLayout                               | ✅      |                                                                  |
+| IPAddressRange                               | ✅      |                                                                  |
+| Icon                                         | ✅      |                                                                  |
+| IdeasSettings                                | ✅      |                                                                  |
+| IdentityProviderSettings                     | ✅      |                                                                  |
+| IdentityRsolDataSyncDef                      | ❌      | Not supported, but support could be added                        |
+| IdentityVerificationProcDef                  | ✅      |                                                                  |
+| IframeWhiteListUrlSettings                   | ✅      |                                                                  |
+| InboundCertificate                           | ✅      |                                                                  |
+| InboundNetworkConnection                     | ✅      |                                                                  |
+| IncidentMgmtSettings                         | ✅      |                                                                  |
+| IncludeEstTaxInQuoteCPQSettings              | ✅      |                                                                  |
+| IncludeEstTaxInQuoteSettings                 | ✅      |                                                                  |
+| Index                                        | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| IndustriesAutomotiveSettings                 | ✅      |                                                                  |
+| IndustriesChannelPartnerInventorySettings    | ✅      |                                                                  |
+| IndustriesConnectedServiceSettings           | ✅      |                                                                  |
+| IndustriesConstraintsSettings                | ✅      |                                                                  |
+| IndustriesContextSettings                    | ✅      |                                                                  |
+| IndustriesEinsteinFeatureSettings            | ✅      |                                                                  |
+| IndustriesEnergyUtilitiesMultiSiteSettings   | ✅      |                                                                  |
+| IndustriesEventOrchSettings                  | ✅      |                                                                  |
+| IndustriesFieldServiceSettings               | ✅      |                                                                  |
+| IndustriesGamificationSettings               | ✅      |                                                                  |
+| IndustriesInsuranceSettings                  | ✅      |                                                                  |
+| IndustriesLoyaltySettings                    | ✅      |                                                                  |
+| IndustriesLsCommercialSettings               | ✅      |                                                                  |
+| IndustriesManufacturingSettings              | ✅      |                                                                  |
+| IndustriesMfgSampleManagementSettings        | ✅      |                                                                  |
+| IndustriesPricingSettings                    | ✅      |                                                                  |
+| IndustriesRatingSettings                     | ✅      |                                                                  |
+| IndustriesSettings                           | ✅      |                                                                  |
+| IndustriesUnifiedInventorySettings           | ✅      |                                                                  |
+| IndustriesUnifiedPromotionsSettings          | ✅      |                                                                  |
+| IndustriesUsageSettings                      | ✅      |                                                                  |
+| InsBillingConfig                             | ❌      | Not supported, but support could be added                        |
+| InsPlcyCoverageSpecConfig                    | ❌      | Not supported, but support could be added                        |
+| InsPlcyLimitConsumptionRule                  | ❌      | Not supported, but support could be added                        |
+| InsPlcyLineOfBusConfig                       | ❌      | Not supported, but support could be added                        |
+| InsPolicyLifecycleConfig                     | ❌      | Not supported, but support could be added                        |
+| InsPolicyManagementConfig                    | ❌      | Not supported, but support could be added                        |
+| InsRatePlanCmsnConfig                        | ❌      | Not supported, but support could be added                        |
+| InsRatePlanTypeConfig                        | ❌      | Not supported, but support could be added                        |
+| InstalledPackage                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| InsuranceBrokerageSettings                   | ✅      |                                                                  |
+| IntegArtifactDef                             | ✅      |                                                                  |
+| IntegratedPlanDefinition                     | ❌      | Not supported, but support could be added                        |
+| IntegrationProcdDefinition                   | ✅      |                                                                  |
+| IntegrationProviderDef                       | ✅      |                                                                  |
+| InterestTaggingSettings                      | ✅      |                                                                  |
+| InternalDataConnector                        | ✅      |                                                                  |
+| InvLatePymntRiskCalcSettings                 | ✅      |                                                                  |
+| InventoryAllocationSettings                  | ✅      |                                                                  |
+| InventoryReplenishmentSettings               | ✅      |                                                                  |
+| InventorySettings                            | ✅      |                                                                  |
+| InvocableActionExtension                     | ✅      |                                                                  |
+| InvocableActionSettings                      | ✅      |                                                                  |
+| IoTSettings                                  | ✅      |                                                                  |
+| KeywordList                                  | ✅      |                                                                  |
+| KnowledgeGenerationSettings                  | ✅      |                                                                  |
+| KnowledgeSettings                            | ✅      |                                                                  |
+| LaborCostOptimCrewMgmtSettings               | ✅      |                                                                  |
+| LaborCostOptimizationSettings                | ✅      |                                                                  |
+| LanguageSettings                             | ✅      |                                                                  |
+| LargeQuotesandOrdersForRlmSettings           | ✅      |                                                                  |
+| Layout                                       | ✅      |                                                                  |
+| LeadConfigSettings                           | ✅      |                                                                  |
+| LeadConvertSettings                          | ✅      |                                                                  |
+| LearningAchievementConfig                    | ✅      |                                                                  |
+| LearningItemType                             | ✅      |                                                                  |
+| Letterhead                                   | ✅      |                                                                  |
+| LicensingSettings                            | ✅      |                                                                  |
+| LifeSciConfigCategory                        | ✅      |                                                                  |
+| LifeSciConfigRecord                          | ✅      |                                                                  |
+| LightningBolt                                | ✅      |                                                                  |
+| LightningComponentBundle                     | ✅      |                                                                  |
+| LightningExperienceSettings                  | ✅      |                                                                  |
+| LightningExperienceTheme                     | ✅      |                                                                  |
+| LightningMessageChannel                      | ✅      |                                                                  |
+| LightningOnboardingConfig                    | ✅      |                                                                  |
+| LightningTypeBundle                          | ✅      |                                                                  |
+| ListView                                     | ✅      |                                                                  |
+| LiveAgentSettings                            | ✅      |                                                                  |
+| LiveChatAgentConfig                          | ✅      |                                                                  |
+| LiveChatButton                               | ✅      |                                                                  |
+| LiveChatDeployment                           | ✅      |                                                                  |
+| LiveChatSensitiveDataRule                    | ✅      |                                                                  |
+| LiveMessageSettings                          | ✅      |                                                                  |
+| LocationUse                                  | ✅      |                                                                  |
+| LogicSettings                                | ✅      |                                                                  |
+| LoyaltyProgramSetup                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| MacroSettings                                | ✅      |                                                                  |
+| MailMergeSettings                            | ✅      |                                                                  |
+| ManagedContentType                           | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| ManagedEventSubscription                     | ✅      |                                                                  |
+| ManagedTopics                                | ✅      |                                                                  |
+| MapReportSettings                            | ✅      |                                                                  |
+| MapsAndLocationSettings                      | ✅      |                                                                  |
+| MarketSegmentDefinition                      | ✅      |                                                                  |
+| MarketingAppExtActivity                      | ❌      | Not supported, but support could be added                        |
+| MarketingAppExtension                        | ✅      |                                                                  |
+| MatchingRules                                | ✅      |                                                                  |
+| McpServerDefinition                          | ✅      |                                                                  |
+| MediaAdSalesSettings                         | ✅      |                                                                  |
+| MediaAgentSettings                           | ✅      |                                                                  |
+| MeetingPlaybookDefinition                    | ✅      |                                                                  |
+| MeetingsSettings                             | ✅      |                                                                  |
+| MessagingChannel                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| MfgProgramTemplate                           | ✅      |                                                                  |
+| MfgServiceConsoleSettings                    | ✅      |                                                                  |
+| MilestoneType                                | ✅      |                                                                  |
+| MktCalcInsightObjectDef                      | ✅      |                                                                  |
+| MktDataConnection                            | ✅      |                                                                  |
+| MktDataConnectionParam                       | ❌      | Not supported, but support could be added                        |
+| MktDataConnectionSrcParam                    | ✅      |                                                                  |
+| MktDataTranObject                            | ✅      |                                                                  |
+| MlDomain                                     | ✅      |                                                                  |
+| MobSecurityCertPinConfig                     | ✅      |                                                                  |
+| MobileApplicationDetail                      | ✅      |                                                                  |
+| MobileSecurityAssignment                     | ✅      |                                                                  |
+| MobileSecurityPolicy                         | ✅      |                                                                  |
+| MobileSettings                               | ✅      |                                                                  |
+| ModerationRule                               | ✅      |                                                                  |
+| MutingPermissionSet                          | ✅      |                                                                  |
+| MyDomainDiscoverableLogin                    | ✅      |                                                                  |
+| MyDomainSettings                             | ✅      |                                                                  |
+| NameSettings                                 | ✅      |                                                                  |
+| NamedCredential                              | ✅      |                                                                  |
+| NavigationMenu                               | ✅      |                                                                  |
+| Network                                      | ✅      |                                                                  |
+| NetworkBranding                              | ✅      |                                                                  |
+| NotificationTypeConfig                       | ✅      |                                                                  |
+| NotificationsSettings                        | ✅      |                                                                  |
+| OauthCustomScope                             | ✅      |                                                                  |
+| OauthOidcSettings                            | ✅      |                                                                  |
+| OauthTokenExchangeHandler                    | ✅      |                                                                  |
+| ObjIntegProviderDefMapping                   | ✅      |                                                                  |
+| ObjectHierarchyRelationship                  | ✅      |                                                                  |
+| ObjectLinkingSettings                        | ✅      |                                                                  |
+| ObjectMappingSettings                        | ✅      |                                                                  |
+| ObjectSourceTargetMap                        | ✅      |                                                                  |
+| OcrSampleDocument                            | ✅      |                                                                  |
+| OcrTemplate                                  | ✅      |                                                                  |
+| OmniChannelPricingSettings                   | ✅      |                                                                  |
+| OmniChannelSettings                          | ✅      |                                                                  |
+| OmniDataTransform                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniExtTrackingDef                           | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniIntegrationProcedure                     | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniInteractionAccessConfig                  | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniInteractionConfig                        | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniScript                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniStudioSettings                           | ✅      |                                                                  |
+| OmniSupervisorConfig                         | ✅      |                                                                  |
+| OmniTrackingGroup                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniUiCard                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| OmniscriptDefinition                         | ✅      |                                                                  |
+| OnboardingDataObjectGroup                    | ✅      |                                                                  |
+| OnlineSalesSettings                          | ✅      |                                                                  |
+| OpportunityScoreSettings                     | ✅      |                                                                  |
+| OpportunitySettings                          | ✅      |                                                                  |
+| OptimizationSettings                         | ✅      |                                                                  |
+| OrchestrationPlanCtxMapping                  | ❌      | Not supported, but support could be added                        |
+| OrderManagementSettings                      | ✅      |                                                                  |
+| OrderSettings                                | ✅      |                                                                  |
+| OrgSettings                                  | ✅      |                                                                  |
+| OutboundNetworkConnection                    | ✅      |                                                                  |
+| PardotEinsteinSettings                       | ✅      |                                                                  |
+| PardotSettings                               | ✅      |                                                                  |
+| ParticipantRole                              | ✅      |                                                                  |
+| PartyDataModelSettings                       | ✅      |                                                                  |
+| PartyProfileDataObjectValidityDefinition     | ✅      |                                                                  |
+| PathAssistant                                | ✅      |                                                                  |
+| PathAssistantSettings                        | ✅      |                                                                  |
+| PaymentGatewayProvider                       | ✅      |                                                                  |
+| PaymentsManagementEnabledSettings            | ✅      |                                                                  |
+| PaymentsSettings                             | ✅      |                                                                  |
+| PaymentsSharingSettings                      | ✅      |                                                                  |
+| PaynowStarterUpgradeEnabledSettings          | ✅      |                                                                  |
+| PermissionSet                                | ✅      |                                                                  |
+| PermissionSetGroup                           | ✅      |                                                                  |
+| PermissionSetLicenseDefinition               | ✅      |                                                                  |
+| PersonAccountOwnerPowerUser                  | ✅      |                                                                  |
+| PicklistSettings                             | ✅      |                                                                  |
+| PicklistValue                                | ❌      | Not supported, but support could be added                        |
+| PipelineInspMetricConfig                     | ✅      |                                                                  |
+| PlanningMeasureDef                           | ❌      | Not supported, but support could be added                        |
+| PlanningMeasureGroup                         | ❌      | Not supported, but support could be added                        |
+| PlatformCachePartition                       | ✅      |                                                                  |
+| PlatformEventChannel                         | ✅      |                                                                  |
+| PlatformEventChannelMember                   | ✅      |                                                                  |
+| PlatformEventMigration                       | ❌      | Not supported, but support could be added                        |
+| PlatformEventSettings                        | ✅      |                                                                  |
+| PlatformEventSubscriberConfig                | ✅      |                                                                  |
+| PlatformSlackSettings                        | ✅      |                                                                  |
+| PlatformWebIdeSettings                       | ✅      |                                                                  |
+| PolicyRuleDefinition                         | ✅      |                                                                  |
+| PolicyRuleDefinitionSet                      | ✅      |                                                                  |
+| PortalDelegablePermissionSet                 | ✅      |                                                                  |
+| PortalsSettings                              | ✅      |                                                                  |
+| PostTemplate                                 | ✅      |                                                                  |
+| PredictionBuilderSettings                    | ✅      |                                                                  |
+| PresenceDeclineReason                        | ✅      |                                                                  |
+| PresenceUserConfig                           | ✅      |                                                                  |
+| PricingActionParameters                      | ✅      |                                                                  |
+| PricingRecipe                                | ✅      |                                                                  |
+| PrivacySettings                              | ✅      |                                                                  |
+| PrmCoreSettings                              | ✅      |                                                                  |
+| ProcedureOutputResolution                    | ❌      | Not supported, but support could be added (but not for tracking) |
+| ProcedurePlanDefinition                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| ProcessFlowMigration                         | ✅      |                                                                  |
+| ProductAttrDisplayConfig                     | ✅      |                                                                  |
+| ProductAttributeSet                          | ✅      |                                                                  |
+| ProductCatalogManagementSettings             | ✅      |                                                                  |
+| ProductConfiguratorSettings                  | ✅      |                                                                  |
+| ProductDiscoverySettings                     | ✅      |                                                                  |
+| ProductSettings                              | ✅      |                                                                  |
+| ProductSpecificationRecType                  | ✅      |                                                                  |
+| ProductSpecificationType                     | ✅      |                                                                  |
+| Profile                                      | ✅      |                                                                  |
+| ProfilePasswordPolicy                        | ✅      |                                                                  |
+| ProfileSessionSetting                        | ✅      |                                                                  |
+| Prompt                                       | ✅      |                                                                  |
+| ProviderSampleLimitTemplate                  | ❌      | Not supported, but support could be added                        |
+| PublicKeyCertificate                         | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| PublicKeyCertificateSet                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| PurchaseOrderMgmtSettings                    | ✅      |                                                                  |
+| QualityManagementSettings                    | ✅      |                                                                  |
+| Queue                                        | ✅      |                                                                  |
+| QueueRoutingConfig                           | ✅      |                                                                  |
+| QuickAction                                  | ✅      |                                                                  |
+| QuickTextSettings                            | ✅      |                                                                  |
+| QuoteSettings                                | ✅      |                                                                  |
+| RealTimeEventSettings                        | ✅      |                                                                  |
+| RebateAndAccrualMgmtAdvncdSettings           | ✅      |                                                                  |
+| RecAlrtDataSrcExpSetDef                      | ✅      |                                                                  |
+| RecommendationBuilderSettings                | ✅      |                                                                  |
+| RecommendationStrategy                       | ✅      |                                                                  |
+| RecordActionDeployment                       | ✅      |                                                                  |
+| RecordAggregationDefinition                  | ✅      |                                                                  |
+| RecordAlertCategory                          | ✅      |                                                                  |
+| RecordAlertDataSource                        | ✅      |                                                                  |
+| RecordAlertTemplate                          | ✅      |                                                                  |
+| RecordPageSettings                           | ✅      |                                                                  |
+| RecordType                                   | ✅      |                                                                  |
+| RedirectWhitelistUrl                         | ✅      |                                                                  |
+| ReferencedDashboard                          | ✅      |                                                                  |
+| ReferralMarketingConfig                      | ❌      | Not supported, but support could be added                        |
+| ReferralMarketingSettings                    | ✅      |                                                                  |
+| RegisteredExternalService                    | ✅      |                                                                  |
+| RelatedRecordAccessDef                       | ❌      | Not supported, but support could be added                        |
+| RelatedRecordAssocCriteria                   | ✅      |                                                                  |
+| RelationshipGraphDefinition                  | ✅      |                                                                  |
+| ReleaseMgmtSettings                          | ✅      |                                                                  |
+| RemoteSiteSetting                            | ✅      |                                                                  |
+| Report                                       | ✅      |                                                                  |
+| ReportFolder                                 | ✅      |                                                                  |
+| ReportType                                   | ✅      |                                                                  |
+| RestrictionRule                              | ✅      |                                                                  |
+| RetailExecutionSettings                      | ✅      |                                                                  |
+| RetrievalSummaryDefinition                   | ✅      |                                                                  |
+| RevenueManagementSettings                    | ✅      |                                                                  |
+| RiskMgmtSettings                             | ✅      |                                                                  |
+| Role                                         | ✅      |                                                                  |
+| SalesAgreementSettings                       | ✅      |                                                                  |
+| SalesDealAgentSettings                       | ✅      |                                                                  |
+| SalesWorkQueueSettings                       | ✅      |                                                                  |
+| SamlSsoConfig                                | ✅      |                                                                  |
+| SandboxSettings                              | ✅      |                                                                  |
+| SceGlobalModelOptOutSettings                 | ✅      |                                                                  |
+| SchedulingObjective                          | ✅      |                                                                  |
+| SchedulingRecipeSettings                     | ✅      |                                                                  |
+| SchedulingRule                               | ✅      |                                                                  |
+| SchemaSettings                               | ✅      |                                                                  |
+| ScoreCategory                                | ✅      |                                                                  |
+| SearchCustomization                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| SearchOrgWideObjectConfig                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| SearchSettings                               | ✅      |                                                                  |
+| SecurityAgentSettings                        | ✅      |                                                                  |
+| SecurityHubSettings                          | ✅      |                                                                  |
+| SecuritySettings                             | ✅      |                                                                  |
+| SelfSvcPortalTopic                           | ❌      | Not supported, but support could be added                        |
+| SequenceServiceSettings                      | ✅      |                                                                  |
+| ServiceAIRecommendationsSettings             | ✅      |                                                                  |
+| ServiceAISetupDefinition                     | ✅      |                                                                  |
+| ServiceAISetupField                          | ✅      |                                                                  |
+| ServiceChannel                               | ✅      |                                                                  |
+| ServiceCloudNotificationOrchestratorSettings | ✅      |                                                                  |
+| ServiceCloudVoiceSettings                    | ✅      |                                                                  |
+| ServiceIssueManagementSettings               | ✅      |                                                                  |
+| ServiceItsmChangeManagementSettings          | ✅      |                                                                  |
+| ServiceItsmIntelligenceUddSettings           | ✅      |                                                                  |
+| ServiceLegalStatusesSettings                 | ✅      |                                                                  |
+| ServiceMgmtKnwlgArtclConfig                  | ❌      | Not supported, but support could be added                        |
+| ServiceMgmtKnwlgArtclConfigSettings          | ✅      |                                                                  |
+| ServicePresenceStatus                        | ✅      |                                                                  |
+| ServiceProcess                               | ✅      |                                                                  |
+| ServiceProcessSettings                       | ✅      |                                                                  |
+| ServiceScheduleConfig                        | ❌      | Not supported, but support could be added                        |
+| ServiceSetupAssistantSettings                | ✅      |                                                                  |
+| SetupCopilotSettings                         | ✅      |                                                                  |
+| SharingCriteriaRule                          | ✅      |                                                                  |
+| SharingGuestRule                             | ✅      |                                                                  |
+| SharingOwnerRule                             | ✅      |                                                                  |
+| SharingReason                                | ✅      |                                                                  |
+| SharingRules                                 | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| SharingSet                                   | ✅      |                                                                  |
+| SharingSettings                              | ✅      |                                                                  |
+| SharingTerritoryRule                         | ✅      |                                                                  |
+| SiteDotCom                                   | ✅      |                                                                  |
+| SiteSettings                                 | ✅      |                                                                  |
+| Skill                                        | ✅      |                                                                  |
+| SkillType                                    | ✅      |                                                                  |
+| SlackApp                                     | ✅      |                                                                  |
+| SoFieldMappingSettings                       | ✅      |                                                                  |
+| SocialCustomerServiceSettings                | ✅      |                                                                  |
+| SourceTrackingSettings                       | ✅      |                                                                  |
+| SrvcMgmtObjCollabAppCnfg                     | ❌      | Not supported, but support could be added                        |
+| StageAssignment                              | ✅      |                                                                  |
+| StageDefinition                              | ✅      |                                                                  |
+| StandardValue                                | ❌      | Not supported, but support could be added                        |
+| StandardValueSet                             | ✅      |                                                                  |
+| StandardValueSetTranslation                  | ✅      |                                                                  |
+| StaticResource                               | ✅      |                                                                  |
+| StnryAssetEnvSrcCnfg                         | ✅      |                                                                  |
+| StockRotationSettings                        | ✅      |                                                                  |
+| StreamingAppDataConnector                    | ✅      |                                                                  |
+| SubscriptionManagementSettings               | ✅      |                                                                  |
+| SurveySettings                               | ✅      |                                                                  |
+| SurveyStyleSet                               | ❌      | Not supported, but support could be added                        |
+| SustainabilityUom                            | ✅      |                                                                  |
+| SustnUomConversion                           | ✅      |                                                                  |
+| SvcCatalogCategory                           | ✅      |                                                                  |
+| SvcCatalogFilterCriteria                     | ✅      |                                                                  |
+| SvcCatalogFulfillmentFlow                    | ✅      |                                                                  |
+| SvcCatalogItemDef                            | ✅      |                                                                  |
+| SynchronizeSettings                          | ✅      |                                                                  |
+| SynonymDictionary                            | ✅      |                                                                  |
+| SystemNotificationSettings                   | ✅      |                                                                  |
+| Tag                                          | ❌      | Not supported, but support could be added (but not for tracking) |
+| TagSet                                       | ❌      | Not supported, but support could be added (but not for tracking) |
+| TelemetryActionDefStep                       | ✅      |                                                                  |
+| TelemetryActionDefinition                    | ✅      |                                                                  |
+| TelemetryActnDefStepAttr                     | ✅      |                                                                  |
+| TelemetryDefinition                          | ✅      |                                                                  |
+| TelemetryDefinitionVersion                   | ✅      |                                                                  |
+| Territory                                    | ✅      |                                                                  |
+| Territory2                                   | ✅      |                                                                  |
+| Territory2Model                              | ✅      |                                                                  |
+| Territory2Rule                               | ✅      |                                                                  |
+| Territory2Settings                           | ✅      |                                                                  |
+| Territory2Type                               | ✅      |                                                                  |
+| ThunderbirdVoiceSettings                     | ✅      |                                                                  |
+| TimeSheetTemplate                            | ✅      |                                                                  |
+| TimelineObjectDefinition                     | ✅      |                                                                  |
+| TmfOutboundNotificationSettings              | ✅      |                                                                  |
+| TmshtLaborCostOptimAiSettings                | ✅      |                                                                  |
+| TopicsForObjects                             | ✅      |                                                                  |
+| TrailheadSettings                            | ✅      |                                                                  |
+| TransactableMarketplacePrivateOfferSettings  | ✅      |                                                                  |
+| TransactionProcessingType                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
+| TransactionSecurityPolicy                    | ✅      |                                                                  |
+| Translations                                 | ✅      |                                                                  |
+| TrialOrgSettings                             | ✅      |                                                                  |
+| TriggerConfigurationsSettings                | ✅      |                                                                  |
+| UIBundle                                     | ✅      |                                                                  |
+| UIBundleSettings                             | ✅      |                                                                  |
+| UIObjectRelationConfig                       | ✅      |                                                                  |
+| UiFormatSpecificationSet                     | ✅      |                                                                  |
+| UiPlugin                                     | ✅      |                                                                  |
+| UiPreviewMessageTabDef                       | ✅      |                                                                  |
+| UiWidgetBundle                               | ✅      |                                                                  |
+| UnifiedSalesIntelligenceSettings             | ✅      |                                                                  |
+| UserAccessPolicy                             | ✅      |                                                                  |
+| UserAuthCertificate                          | ✅      |                                                                  |
+| UserCriteria                                 | ✅      |                                                                  |
+| UserEngagementSettings                       | ✅      |                                                                  |
+| UserInterfaceSettings                        | ✅      |                                                                  |
+| UserManagementSettings                       | ✅      |                                                                  |
+| UserProvisioningConfig                       | ✅      |                                                                  |
+| ValidationRule                               | ✅      |                                                                  |
+| VehicleAssetEmssnSrcCnfg                     | ✅      |                                                                  |
+| ViewDefinition                               | ✅      |                                                                  |
+| VirtualVisitConfig                           | ✅      |                                                                  |
+| VoiceEngagementMediaFile                     | ❌      | Not supported, but support could be added                        |
+| VoiceEngagementMediaUsage                    | ❌      | Not supported, but support could be added                        |
+| VoiceEngmtMediaFileAsgnt                     | ❌      | Not supported, but support could be added                        |
+| VoiceSettings                                | ✅      |                                                                  |
+| WarrantyLifecycleMgmtSettings                | ✅      |                                                                  |
+| WaveAnalyticAssetCollection                  | ✅      |                                                                  |
+| WaveApplication                              | ✅      |                                                                  |
+| WaveComponent                                | ✅      |                                                                  |
+| WaveDashboard                                | ✅      |                                                                  |
+| WaveDataflow                                 | ✅      |                                                                  |
+| WaveDataset                                  | ✅      |                                                                  |
+| WaveLens                                     | ✅      |                                                                  |
+| WaveRecipe                                   | ✅      |                                                                  |
+| WaveTemplateBundle                           | ✅      |                                                                  |
+| WaveXmd                                      | ✅      |                                                                  |
+| Web3Settings                                 | ✅      |                                                                  |
+| WebLink                                      | ✅      |                                                                  |
+| WebStoreBundle                               | ✅      |                                                                  |
+| WebStoreTemplate                             | ✅      |                                                                  |
+| WebToXSettings                               | ✅      |                                                                  |
+| WorkDotComSettings                           | ✅      |                                                                  |
+| WorkSkillRouting                             | ✅      |                                                                  |
+| Workflow                                     | ✅      |                                                                  |
+| WorkflowAlert                                | ✅      |                                                                  |
+| WorkflowFieldUpdate                          | ✅      |                                                                  |
+| WorkflowFlowAction                           | ✅      |                                                                  |
+| WorkflowKnowledgePublish                     | ✅      |                                                                  |
+| WorkflowOutboundMessage                      | ✅      |                                                                  |
+| WorkflowRule                                 | ✅      |                                                                  |
+| WorkflowSend                                 | ✅      |                                                                  |
+| WorkflowTask                                 | ✅      |                                                                  |
+| WorkforceEngagementSettings                  | ✅      |                                                                  |
 
 ## Next Release (v68)
 
-v68 introduces the following new types.  Here's their current level of support
+v68 introduces the following new types. Here's their current level of support
 
-|Metadata Type|Support|Notes|
-|:---|:---|:---|
-|AgentforcePlatformTracingSettings|✅||
-|AiAgentDefinition|❌|Not supported, but support could be added|
-|AiAgentDefinitionVersion|❌|Not supported, but support could be added|
-|BotEmailDefinition|❌|Not supported, but support could be added|
-|CnfgItemTypeIdentFieldMap|✅||
-|CnfgItemTypeIdentRule|✅||
-|ContentWorkspace|❌|Not supported, but support could be added|
-|ContentWorkspacePermission|❌|Not supported, but support could be added|
-|DCOpportunityScoringSettings|✅||
-|DebugLevel|❌|Not supported, but support could be added|
-|DynamicUiCardDefinition|✅||
-|HelpSettings|✅||
-|HouseholdNamingConfig|✅||
-|IdpConfiguration|⚠️|Supports deploy/retrieve but not source tracking|
-|IndustriesRepossessionSettings|✅||
-|InvMgmtForUnusableQtySettings|✅||
-|LightningOutApp|✅||
-|MCETransformationsSettings|✅||
-|MarketingHierarchyGroupDef|❌|Not supported, but support could be added|
-|MarketingHierarchyNodeDef|❌|Not supported, but support could be added|
-|MktPlanningOpsSettings|✅||
-|PlanningDimensionDef|❌|Not supported, but support could be added|
-|RecLifecyclCompanCpblDef|❌|Not supported, but support could be added|
-|RecLifecyclCompanDef|❌|Not supported, but support could be added|
-|ScndTelephPrvdOtbdDtl|❌|Not supported, but support could be added|
-|SecondaryTelephonyProvider|❌|Not supported, but support could be added|
-|ServiceItamSettings|✅||
-|StatisticalDealInsightsSettings|✅||
-|TelephonyProvider|❌|Not supported, but support could be added|
-|TrustedTelephonyProvider|❌|Not supported, but support could be added|
-|WinProbabilityScoringSetup|❌|Not supported, but support could be added|
+| Metadata Type                     | Support | Notes                                            |
+| :-------------------------------- | :------ | :----------------------------------------------- |
+| AgentforcePlatformTracingSettings | ✅      |                                                  |
+| AiAgentDefinition                 | ❌      | Not supported, but support could be added        |
+| AiAgentDefinitionVersion          | ❌      | Not supported, but support could be added        |
+| BotEmailDefinition                | ❌      | Not supported, but support could be added        |
+| CnfgItemTypeIdentFieldMap         | ✅      |                                                  |
+| CnfgItemTypeIdentRule             | ✅      |                                                  |
+| ContentWorkspace                  | ❌      | Not supported, but support could be added        |
+| ContentWorkspacePermission        | ❌      | Not supported, but support could be added        |
+| DCOpportunityScoringSettings      | ✅      |                                                  |
+| DebugLevel                        | ❌      | Not supported, but support could be added        |
+| DynamicUiCardDefinition           | ✅      |                                                  |
+| HelpSettings                      | ✅      |                                                  |
+| HouseholdNamingConfig             | ✅      |                                                  |
+| IdpConfiguration                  | ⚠️      | Supports deploy/retrieve but not source tracking |
+| IndustriesRepossessionSettings    | ✅      |                                                  |
+| InvMgmtForUnusableQtySettings     | ✅      |                                                  |
+| LightningOutApp                   | ✅      |                                                  |
+| MCETransformationsSettings        | ✅      |                                                  |
+| MarketingHierarchyGroupDef        | ❌      | Not supported, but support could be added        |
+| MarketingHierarchyNodeDef         | ❌      | Not supported, but support could be added        |
+| MktPlanningOpsSettings            | ✅      |                                                  |
+| PlanningDimensionDef              | ❌      | Not supported, but support could be added        |
+| RecLifecyclCompanCpblDef          | ❌      | Not supported, but support could be added        |
+| RecLifecyclCompanDef              | ❌      | Not supported, but support could be added        |
+| ScndTelephPrvdOtbdDtl             | ❌      | Not supported, but support could be added        |
+| SecondaryTelephonyProvider        | ❌      | Not supported, but support could be added        |
+| ServiceItamSettings               | ✅      |                                                  |
+| StatisticalDealInsightsSettings   | ✅      |                                                  |
+| TelephonyProvider                 | ❌      | Not supported, but support could be added        |
+| TrustedTelephonyProvider          | ❌      | Not supported, but support could be added        |
+| WinProbabilityScoringSetup        | ❌      | Not supported, but support could be added        |
 
 ## Additional Types
 
-> The following types are supported by this library but not in the coverage reports for either version.  These are typically
+> The following types are supported by this library but not in the coverage reports for either version. These are typically
 >
 > 1. types that have been removed from the metadata API but were supported in previous versions
 > 1. types that are available for pilots but not officially part of the metadata API (use with caution)

--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -8,880 +8,882 @@ Currently, there are 764/829 supported metadata types.
 For status on any existing gaps, please search or file an issue in the [Salesforce CLI issues only repo](https://github.com/forcedotcom/cli/issues).
 To contribute a new metadata type, please see the [Contributing Metadata Types to the Registry](./contributing/metadata.md)
 
-| Metadata Type                                | Support | Notes                                                            |
-| :------------------------------------------- | :------ | :--------------------------------------------------------------- |
-| AIApplication                                | ✅      |                                                                  |
-| AIApplicationConfig                          | ✅      |                                                                  |
-| AIReplyRecommendationsSettings               | ✅      |                                                                  |
-| AIScoringModelDefVersion                     | ✅      |                                                                  |
-| AIScoringModelDefinition                     | ✅      |                                                                  |
-| AIUsecaseDefinition                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AccountForecastSettings                      | ✅      |                                                                  |
-| AccountIntelligenceSettings                  | ✅      |                                                                  |
-| AccountPlanObjMeasCalcDef                    | ✅      |                                                                  |
-| AccountPlanSettings                          | ✅      |                                                                  |
-| AccountRelationshipShareRule                 | ✅      |                                                                  |
-| AccountSettings                              | ✅      |                                                                  |
-| AccountingFieldMapping                       | ✅      |                                                                  |
-| AccountingModelConfig                        | ✅      |                                                                  |
-| AccountingSettings                           | ✅      |                                                                  |
-| AcctMgrTargetSettings                        | ✅      |                                                                  |
-| ActionLauncherItemDef                        | ✅      |                                                                  |
-| ActionLinkGroupTemplate                      | ✅      |                                                                  |
-| ActionPlanTemplate                           | ✅      |                                                                  |
-| ActionableEventOrchDef                       | ✅      |                                                                  |
-| ActionableEventTypeDef                       | ✅      |                                                                  |
-| ActionableListDefinition                     | ✅      |                                                                  |
-| ActionsSettings                              | ✅      |                                                                  |
-| ActivationPlatform                           | ✅      |                                                                  |
-| ActivitiesSettings                           | ✅      |                                                                  |
-| ActnblListKeyPrfmIndDef                      | ✅      |                                                                  |
-| AddressSettings                              | ✅      |                                                                  |
-| AdminSuccessSettings                         | ✅      |                                                                  |
-| AdvAccountForecastSet                        | ✅      |                                                                  |
-| AdvAcctForecastDimSource                     | ✅      |                                                                  |
-| AdvAcctForecastPeriodGroup                   | ✅      |                                                                  |
-| AffinityScoreDefinition                      | ✅      |                                                                  |
-| AgentPlatformSettings                        | ✅      |                                                                  |
-| AgentforceAccountManagementSettings          | ✅      |                                                                  |
-| AgentforceForDevelopersSettings              | ✅      |                                                                  |
-| AgenticCtxtDecorDefinition                   | ❌      | Not supported, but support could be added                        |
-| Ai4mSettings                                 | ✅      |                                                                  |
-| AiAgentScorerDefinition                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AiAuthoringBundle                            | ✅      |                                                                  |
-| AiEvaluationDefinition                       | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AiPlannerVoiceAvatarDef                      | ❌      | Not supported, but support could be added                        |
-| AiPlannerVoiceDef                            | ❌      | Not supported, but support could be added (but not for tracking) |
-| AiResponseFormat                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AiResponseFormatIstr                         | ❌      | Not supported, but support could be added (but not for tracking) |
-| AiSurface                                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AiSurfaceInput                               | ❌      | Not supported, but support could be added (but not for tracking) |
-| AiSurfaceInstruction                         | ❌      | Not supported, but support could be added (but not for tracking) |
-| AiTestingDefinition                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| AnalyticSnapshot                             | ✅      |                                                                  |
-| AnalyticsDashboard                           | ✅      |                                                                  |
-| AnalyticsDatasetDefinition                   | ❌      | Not supported, but support could be added                        |
-| AnalyticsSettings                            | ✅      |                                                                  |
-| AnalyticsVisualization                       | ✅      |                                                                  |
-| AnalyticsWorkspace                           | ✅      |                                                                  |
-| AnimationRule                                | ✅      |                                                                  |
-| ApexClass                                    | ✅      |                                                                  |
-| ApexComponent                                | ✅      |                                                                  |
-| ApexEmailNotifications                       | ✅      |                                                                  |
-| ApexLimitSettings                            | ✅      |                                                                  |
-| ApexPage                                     | ✅      |                                                                  |
-| ApexSettings                                 | ✅      |                                                                  |
-| ApexTestSuite                                | ✅      |                                                                  |
-| ApexTrigger                                  | ✅      |                                                                  |
-| ApiNamedQuery                                | ✅      |                                                                  |
-| AppAnalyticsSettings                         | ✅      |                                                                  |
-| AppExperienceSettings                        | ✅      |                                                                  |
-| AppFrameworkTemplateBundle                   | ✅      |                                                                  |
-| AppMenu                                      | ✅      |                                                                  |
-| ApplicationRecordTypeConfig                  | ✅      |                                                                  |
-| ApplicationSubtypeDefinition                 | ✅      |                                                                  |
-| AppointmentAssignmentPolicy                  | ✅      |                                                                  |
-| AppointmentBookingSettings                   | ✅      |                                                                  |
-| AppointmentSchedulingPolicy                  | ✅      |                                                                  |
-| ApprovalProcess                              | ✅      |                                                                  |
-| AssessmentConfiguration                      | ✅      |                                                                  |
-| AssessmentQuestion                           | ✅      |                                                                  |
-| AssessmentQuestionSet                        | ✅      |                                                                  |
-| AssignmentRules                              | ✅      |                                                                  |
-| AssistantContextItem                         | ✅      |                                                                  |
-| AssistantDefinition                          | ✅      |                                                                  |
-| AssistantSkillQuickAction                    | ✅      |                                                                  |
-| AssistantSkillSobjectAction                  | ✅      |                                                                  |
-| AssistantVersion                             | ✅      |                                                                  |
-| AssociationEngineSettings                    | ✅      |                                                                  |
-| Audience                                     | ✅      |                                                                  |
-| AuraDefinitionBundle                         | ✅      |                                                                  |
-| AuthProvider                                 | ✅      |                                                                  |
-| AutoResponseRules                            | ✅      |                                                                  |
-| AutomatorConfigSettings                      | ✅      |                                                                  |
-| BatchCalcJobDefinition                       | ✅      |                                                                  |
-| BatchProcessJobDefinition                    | ✅      |                                                                  |
-| BenefitAction                                | ✅      |                                                                  |
-| BillingSettings                              | ✅      |                                                                  |
-| BlacklistedConsumer                          | ✅      |                                                                  |
-| BldgEnrgyIntensityCnfg                       | ✅      |                                                                  |
-| BlockchainSettings                           | ✅      |                                                                  |
-| Bot                                          | ✅      |                                                                  |
-| BotBlock                                     | ✅      |                                                                  |
-| BotBlockVersion                              | ❌      | Not supported, but support could be added                        |
-| BotSettings                                  | ✅      |                                                                  |
-| BotTemplate                                  | ✅      |                                                                  |
-| BotVersion                                   | ✅      |                                                                  |
-| BranchManagementSettings                     | ✅      |                                                                  |
-| BrandKitSettings                             | ✅      |                                                                  |
-| BrandingSet                                  | ✅      |                                                                  |
-| BriefcaseDefinition                          | ✅      |                                                                  |
-| BusinessHoursSettings                        | ✅      |                                                                  |
-| BusinessProcess                              | ✅      |                                                                  |
-| BusinessProcessGroup                         | ✅      |                                                                  |
-| BusinessProcessTypeDefinition                | ✅      |                                                                  |
-| CMSConnectSource                             | ✅      |                                                                  |
-| CallCenter                                   | ✅      |                                                                  |
-| CallCenterRoutingMap                         | ✅      |                                                                  |
-| CallCoachingMediaProvider                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| CampaignInfluenceModel                       | ✅      |                                                                  |
-| CampaignSettings                             | ✅      |                                                                  |
-| CanvasMetadata                               | ✅      |                                                                  |
-| CareBenefitVerifySettings                    | ✅      |                                                                  |
-| CareLimitType                                | ✅      |                                                                  |
-| CareProviderAfflRoleConfig                   | ✅      |                                                                  |
-| CareProviderSearchConfig                     | ✅      |                                                                  |
-| CareRequestConfiguration                     | ✅      |                                                                  |
-| CareSystemFieldMapping                       | ✅      |                                                                  |
-| CaseSettings                                 | ✅      |                                                                  |
-| CaseSubjectParticle                          | ✅      |                                                                  |
-| CatalogedApi                                 | ✅      |                                                                  |
-| CatalogedApiArtifactVersionInfo              | ✅      |                                                                  |
-| CatalogedApiVersion                          | ✅      |                                                                  |
-| Certificate                                  | ✅      |                                                                  |
-| ChannelLayout                                | ✅      |                                                                  |
-| ChannelObjectLinkingRule                     | ✅      |                                                                  |
-| ChannelRevMgmtSettings                       | ✅      |                                                                  |
-| ChatterAnswersSettings                       | ✅      |                                                                  |
-| ChatterEmailsMDSettings                      | ✅      |                                                                  |
-| ChatterExtension                             | ✅      |                                                                  |
-| ChatterSettings                              | ✅      |                                                                  |
-| ChoiceList                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| ClaimCoverageProdtProcDef                    | ❌      | Not supported, but support could be added                        |
-| ClaimFinancialSettings                       | ✅      |                                                                  |
-| ClaimMgmtFoundationEnabledSettings           | ✅      |                                                                  |
-| ClauseCatgConfiguration                      | ✅      |                                                                  |
-| CleanDataService                             | ✅      |                                                                  |
-| CmsnStmtLineItemConfig                       | ❌      | Not supported, but support could be added                        |
-| CmsnStmtLineItemTypConfig                    | ❌      | Not supported, but support could be added                        |
-| CnfgItemAttrDef                              | ✅      |                                                                  |
-| CnfgItemAttrPcklstValDef                     | ✅      |                                                                  |
-| CnfgItemAttrPicklistDef                      | ✅      |                                                                  |
-| CnfgItemAttrSetAttr                          | ✅      |                                                                  |
-| CnfgItemAttrSetDef                           | ✅      |                                                                  |
-| CnfgItemSourceDefinition                     | ✅      |                                                                  |
-| CnfgItemTypeAttrRelDef                       | ✅      |                                                                  |
-| CnfgItemTypeDef                              | ✅      |                                                                  |
-| CnfgItemTypeRelationDef                      | ✅      |                                                                  |
-| CnfgMgmtRelationTypeDef                      | ✅      |                                                                  |
-| CodeBuilderSettings                          | ✅      |                                                                  |
-| CollectionsDashboardSettings                 | ✅      |                                                                  |
-| CommandAction                                | ✅      |                                                                  |
-| CommerceSettings                             | ✅      |                                                                  |
-| CommissionStatementConfig                    | ❌      | Not supported, but support could be added                        |
-| CommsServiceConsoleSettings                  | ✅      |                                                                  |
-| CommunicationChannelLine                     | ❌      | Not supported, but support could be added                        |
-| CommunicationChannelType                     | ❌      | Not supported, but support could be added                        |
-| CommunitiesSettings                          | ✅      |                                                                  |
-| Community                                    | ✅      |                                                                  |
-| CommunityTemplateDefinition                  | ✅      |                                                                  |
-| CommunityThemeDefinition                     | ✅      |                                                                  |
-| CompactLayout                                | ✅      |                                                                  |
-| CompanySettings                              | ✅      |                                                                  |
-| ComputeExtension                             | ✅      |                                                                  |
-| ConnectedApp                                 | ✅      |                                                                  |
-| ConnectedAppSettings                         | ✅      |                                                                  |
-| ContentAsset                                 | ✅      |                                                                  |
-| ContentSettings                              | ✅      |                                                                  |
-| ContentTypeBundle                            | ✅      |                                                                  |
-| ContextDefinition                            | ✅      |                                                                  |
-| ContextMappingConfig                         | ❌      | Not supported, but support could be added                        |
-| ContextUseCaseMapping                        | ✅      |                                                                  |
-| ContractSettings                             | ✅      |                                                                  |
-| ContractType                                 | ✅      |                                                                  |
-| ConvIntelligenceSignalRule                   | ✅      |                                                                  |
-| ConversationChannelDefinition                | ✅      |                                                                  |
-| ConversationGuidanceSettings                 | ✅      |                                                                  |
-| ConversationMessageDefinition                | ✅      |                                                                  |
-| ConversationServiceIntegrationSettings       | ✅      |                                                                  |
-| ConversationVendorInfo                       | ✅      |                                                                  |
-| ConversationalIntelligenceSettings           | ✅      |                                                                  |
-| CorsWhitelistOrigin                          | ✅      |                                                                  |
-| CourseWaitlistConfig                         | ❌      | Not supported, but support could be added                        |
-| CriteriaSettings                             | ✅      |                                                                  |
-| CspTrustedSite                               | ✅      |                                                                  |
-| CurrencySettings                             | ✅      |                                                                  |
-| CustomAddressFieldSettings                   | ✅      |                                                                  |
-| CustomApplication                            | ✅      |                                                                  |
-| CustomApplicationComponent                   | ✅      |                                                                  |
-| CustomFeedFilter                             | ✅      |                                                                  |
-| CustomField                                  | ✅      |                                                                  |
-| CustomFieldDisplay                           | ❌      | Not supported, but support could be added                        |
-| CustomHelpMenuSection                        | ✅      |                                                                  |
-| CustomIndex                                  | ✅      |                                                                  |
-| CustomLabels                                 | ✅      |                                                                  |
-| CustomMetadata                               | ✅      |                                                                  |
-| CustomNotificationType                       | ✅      |                                                                  |
-| CustomObject                                 | ✅      |                                                                  |
-| CustomObjectBinding                          | ❌      | Not supported, but support could be added                        |
-| CustomObjectTranslation                      | ✅      |                                                                  |
-| CustomPageWebLink                            | ✅      |                                                                  |
-| CustomPermission                             | ✅      |                                                                  |
-| CustomSite                                   | ✅      |                                                                  |
-| CustomTab                                    | ✅      |                                                                  |
-| CustomValue                                  | ❌      | Not supported, but support could be added                        |
-| CustomerDataPlatformSettings                 | ✅      |                                                                  |
-| CustomizablePropensityScoringSettings        | ✅      |                                                                  |
-| Dashboard                                    | ✅      |                                                                  |
-| DashboardFolder                              | ✅      |                                                                  |
-| DataCalcInsightTemplate                      | ✅      |                                                                  |
-| DataCategoryGroup                            | ✅      |                                                                  |
-| DataCleanRoomProvider                        | ❌      | Not supported, but support could be added                        |
-| DataConnector                                | ✅      |                                                                  |
-| DataConnectorIngestApi                       | ✅      |                                                                  |
-| DataConnectorS3                              | ✅      |                                                                  |
-| DataDotComSettings                           | ✅      |                                                                  |
-| DataImportManagementSettings                 | ✅      |                                                                  |
-| DataKitObjectDependency                      | ✅      |                                                                  |
-| DataKitObjectTemplate                        | ✅      |                                                                  |
-| DataMapperDefinition                         | ✅      |                                                                  |
-| DataMaskPolicy                               | ❌      | Not supported, but support could be added                        |
-| DataMaskSettings                             | ✅      |                                                                  |
-| DataObjectBuildOrgTemplate                   | ✅      |                                                                  |
-| DataObjectSearchIndexConf                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| DataPackageKitDefinition                     | ✅      |                                                                  |
-| DataPackageKitObject                         | ✅      |                                                                  |
-| DataSource                                   | ✅      |                                                                  |
-| DataSourceBundleDefinition                   | ✅      |                                                                  |
-| DataSourceObject                             | ✅      |                                                                  |
-| DataSourceTenant                             | ✅      |                                                                  |
-| DataSrcDataModelFieldMap                     | ✅      |                                                                  |
-| DataStreamDefinition                         | ✅      |                                                                  |
-| DataStreamTemplate                           | ✅      |                                                                  |
-| DataWeaveResource                            | ✅      |                                                                  |
-| DealInsightsSettings                         | ✅      |                                                                  |
-| DecisionMatrixDefinition                     | ✅      |                                                                  |
-| DecisionMatrixDefinitionVersion              | ✅      |                                                                  |
-| DecisionTable                                | ✅      |                                                                  |
-| DecisionTableDatasetLink                     | ✅      |                                                                  |
-| DelegateAccessDataSet                        | ❌      | Not supported, but support could be added                        |
-| DelegateAccessDef                            | ❌      | Not supported, but support could be added                        |
-| DelegateAccsDataSetObj                       | ❌      | Not supported, but support could be added                        |
-| DelegateGroup                                | ✅      |                                                                  |
-| DeploymentSettings                           | ✅      |                                                                  |
-| DevHubSettings                               | ✅      |                                                                  |
-| DgtAssetMgmtProvider                         | ✅      |                                                                  |
-| DgtAssetMgmtPrvdLghtCpnt                     | ✅      |                                                                  |
-| DictionariesSettings                         | ✅      |                                                                  |
-| DigitalExperience                            | ✅      |                                                                  |
-| DigitalExperienceBundle                      | ✅      |                                                                  |
-| DigitalExperienceConfig                      | ✅      |                                                                  |
-| DigitalWalletSettings                        | ✅      |                                                                  |
-| DisclosureDefinition                         | ✅      |                                                                  |
-| DisclosureDefinitionVersion                  | ✅      |                                                                  |
-| DisclosureType                               | ✅      |                                                                  |
-| DiscoveryAIModel                             | ✅      |                                                                  |
-| DiscoveryGoal                                | ✅      |                                                                  |
-| DiscoverySettings                            | ✅      |                                                                  |
-| DiscoveryStory                               | ✅      |                                                                  |
-| Document                                     | ✅      |                                                                  |
-| DocumentCategory                             | ✅      |                                                                  |
-| DocumentCategoryDocumentType                 | ✅      |                                                                  |
-| DocumentChecklistSettings                    | ✅      |                                                                  |
-| DocumentExtractionDef                        | ❌      | Not supported, but support could be added                        |
-| DocumentFolder                               | ✅      |                                                                  |
-| DocumentGenerationSetting                    | ✅      |                                                                  |
-| DocumentTemplate                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| DocumentType                                 | ✅      |                                                                  |
-| DripFeedConfigSettings                       | ✅      |                                                                  |
-| DuplicateRule                                | ✅      |                                                                  |
-| DxGlobalTermsSettings                        | ✅      |                                                                  |
-| DynamicFormsSettings                         | ✅      |                                                                  |
-| DynamicFulfillmentOrchestratorSettings       | ✅      |                                                                  |
-| DynamicGanttSettings                         | ✅      |                                                                  |
-| EACSettings                                  | ✅      |                                                                  |
-| ESignatureConfig                             | ✅      |                                                                  |
-| ESignatureEnvelopeConfig                     | ✅      |                                                                  |
-| EclairGeoData                                | ✅      |                                                                  |
-| EinsteinAISettings                           | ✅      |                                                                  |
-| EinsteinAgentSettings                        | ✅      |                                                                  |
-| EinsteinAssistantSettings                    | ✅      |                                                                  |
-| EinsteinCopilotSettings                      | ✅      |                                                                  |
-| EinsteinDealInsightsSettings                 | ✅      |                                                                  |
-| EinsteinDocumentCaptureSettings              | ✅      |                                                                  |
-| EinsteinGptSettings                          | ✅      |                                                                  |
-| EmailAdministrationSettings                  | ✅      |                                                                  |
-| EmailAuthorizationSettings                   | ✅      |                                                                  |
-| EmailFolder                                  | ✅      |                                                                  |
-| EmailIntegrationSettings                     | ✅      |                                                                  |
-| EmailServicesFunction                        | ✅      |                                                                  |
-| EmailTemplate                                | ✅      |                                                                  |
-| EmailTemplateFolder                          | ✅      |                                                                  |
-| EmailTemplateSettings                        | ✅      |                                                                  |
-| EmbeddedServiceBranding                      | ✅      |                                                                  |
-| EmbeddedServiceConfig                        | ✅      |                                                                  |
-| EmbeddedServiceFlowConfig                    | ✅      |                                                                  |
-| EmbeddedServiceLiveAgent                     | ✅      |                                                                  |
-| EmbeddedServiceMenuSettings                  | ✅      |                                                                  |
-| EmergencySettings                            | ✅      |                                                                  |
-| EmployeeDataSyncProfile                      | ✅      |                                                                  |
-| EmployeeFieldAccessSettings                  | ✅      |                                                                  |
-| EmployeeUserSettings                         | ✅      |                                                                  |
-| EnablementMeasureDefinition                  | ✅      |                                                                  |
-| EnablementProgramDefinition                  | ✅      |                                                                  |
-| EnblProgramTaskSubCategory                   | ✅      |                                                                  |
-| EnhancedNotesSettings                        | ✅      |                                                                  |
-| EnterpriseApiSettings                        | ✅      |                                                                  |
-| EntitlementProcess                           | ✅      |                                                                  |
-| EntitlementSettings                          | ✅      |                                                                  |
-| EntitlementTemplate                          | ✅      |                                                                  |
-| EscalationRules                              | ✅      |                                                                  |
-| EssentialsSettings                           | ✅      |                                                                  |
-| EventLogObjectSettings                       | ✅      |                                                                  |
-| EventRelayConfig                             | ✅      |                                                                  |
-| EventSettings                                | ✅      |                                                                  |
-| EvfSettings                                  | ✅      |                                                                  |
-| EvidenceMgmtSettings                         | ✅      |                                                                  |
-| ExperienceBundle                             | ✅      |                                                                  |
-| ExperienceBundleSettings                     | ✅      |                                                                  |
-| ExperiencePropertyTypeBundle                 | ✅      |                                                                  |
-| ExplainabilityActionDefinition               | ✅      |                                                                  |
-| ExplainabilityActionVersion                  | ✅      |                                                                  |
-| ExplainabilityMsgTemplate                    | ✅      |                                                                  |
-| ExpressionSetDefinition                      | ✅      |                                                                  |
-| ExpressionSetDefinitionVersion               | ✅      |                                                                  |
-| ExpressionSetMessageToken                    | ✅      |                                                                  |
-| ExpressionSetObjectAlias                     | ✅      |                                                                  |
-| ExtDataTranFieldTemplate                     | ❌      | Not supported, but support could be added                        |
-| ExtDataTranObjectTemplate                    | ✅      |                                                                  |
-| ExternalAIModel                              | ✅      |                                                                  |
-| ExternalAuthIdentityProvider                 | ✅      |                                                                  |
-| ExternalClientAppSettings                    | ✅      |                                                                  |
-| ExternalClientApplication                    | ✅      |                                                                  |
-| ExternalCredential                           | ✅      |                                                                  |
-| ExternalDataConnector                        | ✅      |                                                                  |
-| ExternalDataSource                           | ✅      |                                                                  |
-| ExternalDataSrcDescriptor                    | ❌      | Not supported, but support could be added                        |
-| ExternalDataTranField                        | ❌      | Not supported, but support could be added                        |
-| ExternalDataTranObject                       | ✅      |                                                                  |
-| ExternalDocStorageConfig                     | ✅      |                                                                  |
-| ExternalServiceRegistration                  | ✅      |                                                                  |
-| ExternalStoragePrvdConfig                    | ✅      |                                                                  |
-| ExtlClntAppAttestConfigurablePolicies        | ❌      | Not supported, but support could be added (but not for tracking) |
-| ExtlClntAppAttestSettings                    | ✅      |                                                                  |
-| ExtlClntAppCanvasSettings                    | ✅      |                                                                  |
-| ExtlClntAppConfigurablePolicies              | ✅      |                                                                  |
-| ExtlClntAppGlobalOauthSettings               | ✅      |                                                                  |
-| ExtlClntAppMobileConfigurablePolicies        | ✅      |                                                                  |
-| ExtlClntAppMobileSettings                    | ✅      |                                                                  |
-| ExtlClntAppNotificationSettings              | ✅      |                                                                  |
-| ExtlClntAppOauthConfigurablePolicies         | ✅      |                                                                  |
-| ExtlClntAppOauthSecuritySettings             | ✅      |                                                                  |
-| ExtlClntAppOauthSettings                     | ✅      |                                                                  |
-| ExtlClntAppPushConfigurablePolicies          | ✅      |                                                                  |
-| ExtlClntAppPushSettings                      | ✅      |                                                                  |
-| ExtlClntAppSamlConfigurablePolicies          | ✅      |                                                                  |
-| FeatureParameterBoolean                      | ✅      |                                                                  |
-| FeatureParameterDate                         | ✅      |                                                                  |
-| FeatureParameterInteger                      | ✅      |                                                                  |
-| FieldMappingConfig                           | ✅      |                                                                  |
-| FieldRestrictionRule                         | ✅      |                                                                  |
-| FieldServiceMobileConfig                     | ✅      |                                                                  |
-| FieldServiceMobileExtension                  | ✅      |                                                                  |
-| FieldServiceSettings                         | ✅      |                                                                  |
-| FieldSet                                     | ✅      |                                                                  |
-| FieldSrcTrgtRelationship                     | ✅      |                                                                  |
-| FileUploadAndDownloadSecuritySettings        | ✅      |                                                                  |
-| FilesConnectSettings                         | ✅      |                                                                  |
-| FinancialPortfolioUiConfig                   | ❌      | Not supported, but support could be added                        |
-| FlexcardDefinition                           | ✅      |                                                                  |
-| FlexiPage                                    | ✅      |                                                                  |
-| Flow                                         | ✅      |                                                                  |
-| FlowCategory                                 | ✅      |                                                                  |
-| FlowDefinition                               | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| FlowSettings                                 | ✅      |                                                                  |
-| FlowTest                                     | ✅      |                                                                  |
-| FlowValueMap                                 | ✅      |                                                                  |
-| ForecastingFilter                            | ✅      |                                                                  |
-| ForecastingFilterCondition                   | ✅      |                                                                  |
-| ForecastingGroup                             | ✅      |                                                                  |
-| ForecastingObjectListSettings                | ✅      |                                                                  |
-| ForecastingSettings                          | ✅      |                                                                  |
-| ForecastingSourceDefinition                  | ✅      |                                                                  |
-| ForecastingType                              | ✅      |                                                                  |
-| ForecastingTypeSource                        | ✅      |                                                                  |
-| FormulaSettings                              | ✅      |                                                                  |
-| FuelType                                     | ✅      |                                                                  |
-| FuelTypeSustnUom                             | ✅      |                                                                  |
-| FunctionReference                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| FundraisingConfig                            | ✅      |                                                                  |
-| GRCIntelligenceUddSettings                   | ✅      |                                                                  |
-| GatewayProviderPaymentMethodType             | ✅      |                                                                  |
-| GenAiFunction                                | ✅      |                                                                  |
-| GenAiPlannerBundle                           | ✅      |                                                                  |
-| GenAiPlugin                                  | ✅      |                                                                  |
-| GenAiPromptTemplate                          | ✅      |                                                                  |
-| GenAiPromptTemplateActv                      | ✅      |                                                                  |
-| GenComputingSummaryDef                       | ❌      | Not supported, but support could be added                        |
-| GenOpAgentConfig                             | ❌      | Not supported, but support could be added                        |
-| GenOpPlanEligibilityConfig                   | ❌      | Not supported, but support could be added                        |
-| GeneralConfigSettings                        | ✅      |                                                                  |
-| GeocodeSettings                              | ✅      |                                                                  |
-| GiftEntryGridTemplate                        | ✅      |                                                                  |
-| GlobalValueSet                               | ✅      |                                                                  |
-| GlobalValueSetTranslation                    | ✅      |                                                                  |
-| GoogleAppsSettings                           | ✅      |                                                                  |
-| Group                                        | ✅      |                                                                  |
-| HerokuAppLinkSettings                        | ✅      |                                                                  |
-| HighVelocitySalesSettings                    | ✅      |                                                                  |
-| HomePageComponent                            | ✅      |                                                                  |
-| HomePageLayout                               | ✅      |                                                                  |
-| IPAddressRange                               | ✅      |                                                                  |
-| Icon                                         | ✅      |                                                                  |
-| IdeasSettings                                | ✅      |                                                                  |
-| IdentityProviderSettings                     | ✅      |                                                                  |
-| IdentityRsolDataSyncDef                      | ❌      | Not supported, but support could be added                        |
-| IdentityVerificationProcDef                  | ✅      |                                                                  |
-| IframeWhiteListUrlSettings                   | ✅      |                                                                  |
-| InboundCertificate                           | ✅      |                                                                  |
-| InboundNetworkConnection                     | ✅      |                                                                  |
-| IncidentMgmtSettings                         | ✅      |                                                                  |
-| IncludeEstTaxInQuoteCPQSettings              | ✅      |                                                                  |
-| IncludeEstTaxInQuoteSettings                 | ✅      |                                                                  |
-| Index                                        | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| IndustriesAutomotiveSettings                 | ✅      |                                                                  |
-| IndustriesChannelPartnerInventorySettings    | ✅      |                                                                  |
-| IndustriesConnectedServiceSettings           | ✅      |                                                                  |
-| IndustriesConstraintsSettings                | ✅      |                                                                  |
-| IndustriesContextSettings                    | ✅      |                                                                  |
-| IndustriesEinsteinFeatureSettings            | ✅      |                                                                  |
-| IndustriesEnergyUtilitiesMultiSiteSettings   | ✅      |                                                                  |
-| IndustriesEventOrchSettings                  | ✅      |                                                                  |
-| IndustriesFieldServiceSettings               | ✅      |                                                                  |
-| IndustriesGamificationSettings               | ✅      |                                                                  |
-| IndustriesInsuranceSettings                  | ✅      |                                                                  |
-| IndustriesLoyaltySettings                    | ✅      |                                                                  |
-| IndustriesLsCommercialSettings               | ✅      |                                                                  |
-| IndustriesManufacturingSettings              | ✅      |                                                                  |
-| IndustriesMfgSampleManagementSettings        | ✅      |                                                                  |
-| IndustriesPricingSettings                    | ✅      |                                                                  |
-| IndustriesRatingSettings                     | ✅      |                                                                  |
-| IndustriesSettings                           | ✅      |                                                                  |
-| IndustriesUnifiedInventorySettings           | ✅      |                                                                  |
-| IndustriesUnifiedPromotionsSettings          | ✅      |                                                                  |
-| IndustriesUsageSettings                      | ✅      |                                                                  |
-| InsBillingConfig                             | ❌      | Not supported, but support could be added                        |
-| InsPlcyCoverageSpecConfig                    | ❌      | Not supported, but support could be added                        |
-| InsPlcyLimitConsumptionRule                  | ❌      | Not supported, but support could be added                        |
-| InsPlcyLineOfBusConfig                       | ❌      | Not supported, but support could be added                        |
-| InsPolicyLifecycleConfig                     | ❌      | Not supported, but support could be added                        |
-| InsPolicyManagementConfig                    | ❌      | Not supported, but support could be added                        |
-| InsRatePlanCmsnConfig                        | ❌      | Not supported, but support could be added                        |
-| InsRatePlanTypeConfig                        | ❌      | Not supported, but support could be added                        |
-| InstalledPackage                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| InsuranceBrokerageSettings                   | ✅      |                                                                  |
-| IntegArtifactDef                             | ✅      |                                                                  |
-| IntegratedPlanDefinition                     | ❌      | Not supported, but support could be added                        |
-| IntegrationProcdDefinition                   | ✅      |                                                                  |
-| IntegrationProviderDef                       | ✅      |                                                                  |
-| InterestTaggingSettings                      | ✅      |                                                                  |
-| InternalDataConnector                        | ✅      |                                                                  |
-| InvLatePymntRiskCalcSettings                 | ✅      |                                                                  |
-| InventoryAllocationSettings                  | ✅      |                                                                  |
-| InventoryReplenishmentSettings               | ✅      |                                                                  |
-| InventorySettings                            | ✅      |                                                                  |
-| InvocableActionExtension                     | ✅      |                                                                  |
-| InvocableActionSettings                      | ✅      |                                                                  |
-| IoTSettings                                  | ✅      |                                                                  |
-| KeywordList                                  | ✅      |                                                                  |
-| KnowledgeGenerationSettings                  | ✅      |                                                                  |
-| KnowledgeSettings                            | ✅      |                                                                  |
-| LaborCostOptimCrewMgmtSettings               | ✅      |                                                                  |
-| LaborCostOptimizationSettings                | ✅      |                                                                  |
-| LanguageSettings                             | ✅      |                                                                  |
-| LargeQuotesandOrdersForRlmSettings           | ✅      |                                                                  |
-| Layout                                       | ✅      |                                                                  |
-| LeadConfigSettings                           | ✅      |                                                                  |
-| LeadConvertSettings                          | ✅      |                                                                  |
-| LearningAchievementConfig                    | ✅      |                                                                  |
-| LearningItemType                             | ✅      |                                                                  |
-| Letterhead                                   | ✅      |                                                                  |
-| LicensingSettings                            | ✅      |                                                                  |
-| LifeSciConfigCategory                        | ✅      |                                                                  |
-| LifeSciConfigRecord                          | ✅      |                                                                  |
-| LightningBolt                                | ✅      |                                                                  |
-| LightningComponentBundle                     | ✅      |                                                                  |
-| LightningExperienceSettings                  | ✅      |                                                                  |
-| LightningExperienceTheme                     | ✅      |                                                                  |
-| LightningMessageChannel                      | ✅      |                                                                  |
-| LightningOnboardingConfig                    | ✅      |                                                                  |
-| LightningTypeBundle                          | ✅      |                                                                  |
-| ListView                                     | ✅      |                                                                  |
-| LiveAgentSettings                            | ✅      |                                                                  |
-| LiveChatAgentConfig                          | ✅      |                                                                  |
-| LiveChatButton                               | ✅      |                                                                  |
-| LiveChatDeployment                           | ✅      |                                                                  |
-| LiveChatSensitiveDataRule                    | ✅      |                                                                  |
-| LiveMessageSettings                          | ✅      |                                                                  |
-| LocationUse                                  | ✅      |                                                                  |
-| LogicSettings                                | ✅      |                                                                  |
-| LoyaltyProgramSetup                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| MacroSettings                                | ✅      |                                                                  |
-| MailMergeSettings                            | ✅      |                                                                  |
-| ManagedContentType                           | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| ManagedEventSubscription                     | ✅      |                                                                  |
-| ManagedTopics                                | ✅      |                                                                  |
-| MapReportSettings                            | ✅      |                                                                  |
-| MapsAndLocationSettings                      | ✅      |                                                                  |
-| MarketSegmentDefinition                      | ✅      |                                                                  |
-| MarketingAppExtActivity                      | ❌      | Not supported, but support could be added                        |
-| MarketingAppExtension                        | ✅      |                                                                  |
-| MatchingRules                                | ✅      |                                                                  |
-| McpServerDefinition                          | ✅      |                                                                  |
-| MediaAdSalesSettings                         | ✅      |                                                                  |
-| MediaAgentSettings                           | ✅      |                                                                  |
-| MeetingPlaybookDefinition                    | ✅      |                                                                  |
-| MeetingsSettings                             | ✅      |                                                                  |
-| MessagingChannel                             | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| MfgProgramTemplate                           | ✅      |                                                                  |
-| MfgServiceConsoleSettings                    | ✅      |                                                                  |
-| MilestoneType                                | ✅      |                                                                  |
-| MktCalcInsightObjectDef                      | ✅      |                                                                  |
-| MktDataConnection                            | ✅      |                                                                  |
-| MktDataConnectionParam                       | ❌      | Not supported, but support could be added                        |
-| MktDataConnectionSrcParam                    | ✅      |                                                                  |
-| MktDataTranObject                            | ✅      |                                                                  |
-| MlDomain                                     | ✅      |                                                                  |
-| MobSecurityCertPinConfig                     | ✅      |                                                                  |
-| MobileApplicationDetail                      | ✅      |                                                                  |
-| MobileSecurityAssignment                     | ✅      |                                                                  |
-| MobileSecurityPolicy                         | ✅      |                                                                  |
-| MobileSettings                               | ✅      |                                                                  |
-| ModerationRule                               | ✅      |                                                                  |
-| MutingPermissionSet                          | ✅      |                                                                  |
-| MyDomainDiscoverableLogin                    | ✅      |                                                                  |
-| MyDomainSettings                             | ✅      |                                                                  |
-| NameSettings                                 | ✅      |                                                                  |
-| NamedCredential                              | ✅      |                                                                  |
-| NavigationMenu                               | ✅      |                                                                  |
-| Network                                      | ✅      |                                                                  |
-| NetworkBranding                              | ✅      |                                                                  |
-| NotificationTypeConfig                       | ✅      |                                                                  |
-| NotificationsSettings                        | ✅      |                                                                  |
-| OauthCustomScope                             | ✅      |                                                                  |
-| OauthOidcSettings                            | ✅      |                                                                  |
-| OauthTokenExchangeHandler                    | ✅      |                                                                  |
-| ObjIntegProviderDefMapping                   | ✅      |                                                                  |
-| ObjectHierarchyRelationship                  | ✅      |                                                                  |
-| ObjectLinkingSettings                        | ✅      |                                                                  |
-| ObjectMappingSettings                        | ✅      |                                                                  |
-| ObjectSourceTargetMap                        | ✅      |                                                                  |
-| OcrSampleDocument                            | ✅      |                                                                  |
-| OcrTemplate                                  | ✅      |                                                                  |
-| OmniChannelPricingSettings                   | ✅      |                                                                  |
-| OmniChannelSettings                          | ✅      |                                                                  |
-| OmniDataTransform                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniExtTrackingDef                           | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniIntegrationProcedure                     | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniInteractionAccessConfig                  | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniInteractionConfig                        | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniScript                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniStudioSettings                           | ✅      |                                                                  |
-| OmniSupervisorConfig                         | ✅      |                                                                  |
-| OmniTrackingGroup                            | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniUiCard                                   | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| OmniscriptDefinition                         | ✅      |                                                                  |
-| OnboardingDataObjectGroup                    | ✅      |                                                                  |
-| OnlineSalesSettings                          | ✅      |                                                                  |
-| OpportunityScoreSettings                     | ✅      |                                                                  |
-| OpportunitySettings                          | ✅      |                                                                  |
-| OptimizationSettings                         | ✅      |                                                                  |
-| OrchestrationPlanCtxMapping                  | ❌      | Not supported, but support could be added                        |
-| OrderManagementSettings                      | ✅      |                                                                  |
-| OrderSettings                                | ✅      |                                                                  |
-| OrgSettings                                  | ✅      |                                                                  |
-| OutboundNetworkConnection                    | ✅      |                                                                  |
-| PardotEinsteinSettings                       | ✅      |                                                                  |
-| PardotSettings                               | ✅      |                                                                  |
-| ParticipantRole                              | ✅      |                                                                  |
-| PartyDataModelSettings                       | ✅      |                                                                  |
-| PartyProfileDataObjectValidityDefinition     | ✅      |                                                                  |
-| PathAssistant                                | ✅      |                                                                  |
-| PathAssistantSettings                        | ✅      |                                                                  |
-| PaymentGatewayProvider                       | ✅      |                                                                  |
-| PaymentsManagementEnabledSettings            | ✅      |                                                                  |
-| PaymentsSettings                             | ✅      |                                                                  |
-| PaymentsSharingSettings                      | ✅      |                                                                  |
-| PaynowStarterUpgradeEnabledSettings          | ✅      |                                                                  |
-| PermissionSet                                | ✅      |                                                                  |
-| PermissionSetGroup                           | ✅      |                                                                  |
-| PermissionSetLicenseDefinition               | ✅      |                                                                  |
-| PersonAccountOwnerPowerUser                  | ✅      |                                                                  |
-| PicklistSettings                             | ✅      |                                                                  |
-| PicklistValue                                | ❌      | Not supported, but support could be added                        |
-| PipelineInspMetricConfig                     | ✅      |                                                                  |
-| PlanningMeasureDef                           | ❌      | Not supported, but support could be added                        |
-| PlanningMeasureGroup                         | ❌      | Not supported, but support could be added                        |
-| PlatformCachePartition                       | ✅      |                                                                  |
-| PlatformEventChannel                         | ✅      |                                                                  |
-| PlatformEventChannelMember                   | ✅      |                                                                  |
-| PlatformEventMigration                       | ❌      | Not supported, but support could be added                        |
-| PlatformEventSettings                        | ✅      |                                                                  |
-| PlatformEventSubscriberConfig                | ✅      |                                                                  |
-| PlatformSlackSettings                        | ✅      |                                                                  |
-| PlatformWebIdeSettings                       | ✅      |                                                                  |
-| PolicyRuleDefinition                         | ✅      |                                                                  |
-| PolicyRuleDefinitionSet                      | ✅      |                                                                  |
-| PortalDelegablePermissionSet                 | ✅      |                                                                  |
-| PortalsSettings                              | ✅      |                                                                  |
-| PostTemplate                                 | ✅      |                                                                  |
-| PredictionBuilderSettings                    | ✅      |                                                                  |
-| PresenceDeclineReason                        | ✅      |                                                                  |
-| PresenceUserConfig                           | ✅      |                                                                  |
-| PricingActionParameters                      | ✅      |                                                                  |
-| PricingRecipe                                | ✅      |                                                                  |
-| PrivacySettings                              | ✅      |                                                                  |
-| PrmCoreSettings                              | ✅      |                                                                  |
-| ProcedureOutputResolution                    | ❌      | Not supported, but support could be added (but not for tracking) |
-| ProcedurePlanDefinition                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| ProcessFlowMigration                         | ✅      |                                                                  |
-| ProductAttrDisplayConfig                     | ✅      |                                                                  |
-| ProductAttributeSet                          | ✅      |                                                                  |
-| ProductCatalogManagementSettings             | ✅      |                                                                  |
-| ProductConfiguratorSettings                  | ✅      |                                                                  |
-| ProductDiscoverySettings                     | ✅      |                                                                  |
-| ProductSettings                              | ✅      |                                                                  |
-| ProductSpecificationRecType                  | ✅      |                                                                  |
-| ProductSpecificationType                     | ✅      |                                                                  |
-| Profile                                      | ✅      |                                                                  |
-| ProfilePasswordPolicy                        | ✅      |                                                                  |
-| ProfileSessionSetting                        | ✅      |                                                                  |
-| Prompt                                       | ✅      |                                                                  |
-| ProviderSampleLimitTemplate                  | ❌      | Not supported, but support could be added                        |
-| PublicKeyCertificate                         | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| PublicKeyCertificateSet                      | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| PurchaseOrderMgmtSettings                    | ✅      |                                                                  |
-| QualityManagementSettings                    | ✅      |                                                                  |
-| Queue                                        | ✅      |                                                                  |
-| QueueRoutingConfig                           | ✅      |                                                                  |
-| QuickAction                                  | ✅      |                                                                  |
-| QuickTextSettings                            | ✅      |                                                                  |
-| QuoteSettings                                | ✅      |                                                                  |
-| RealTimeEventSettings                        | ✅      |                                                                  |
-| RebateAndAccrualMgmtAdvncdSettings           | ✅      |                                                                  |
-| RecAlrtDataSrcExpSetDef                      | ✅      |                                                                  |
-| RecommendationBuilderSettings                | ✅      |                                                                  |
-| RecommendationStrategy                       | ✅      |                                                                  |
-| RecordActionDeployment                       | ✅      |                                                                  |
-| RecordAggregationDefinition                  | ✅      |                                                                  |
-| RecordAlertCategory                          | ✅      |                                                                  |
-| RecordAlertDataSource                        | ✅      |                                                                  |
-| RecordAlertTemplate                          | ✅      |                                                                  |
-| RecordPageSettings                           | ✅      |                                                                  |
-| RecordType                                   | ✅      |                                                                  |
-| RedirectWhitelistUrl                         | ✅      |                                                                  |
-| ReferencedDashboard                          | ✅      |                                                                  |
-| ReferralMarketingConfig                      | ❌      | Not supported, but support could be added                        |
-| ReferralMarketingSettings                    | ✅      |                                                                  |
-| RegisteredExternalService                    | ✅      |                                                                  |
-| RelatedRecordAccessDef                       | ❌      | Not supported, but support could be added                        |
-| RelatedRecordAssocCriteria                   | ✅      |                                                                  |
-| RelationshipGraphDefinition                  | ✅      |                                                                  |
-| ReleaseMgmtSettings                          | ✅      |                                                                  |
-| RemoteSiteSetting                            | ✅      |                                                                  |
-| Report                                       | ✅      |                                                                  |
-| ReportFolder                                 | ✅      |                                                                  |
-| ReportType                                   | ✅      |                                                                  |
-| RestrictionRule                              | ✅      |                                                                  |
-| RetailExecutionSettings                      | ✅      |                                                                  |
-| RetrievalSummaryDefinition                   | ✅      |                                                                  |
-| RevenueManagementSettings                    | ✅      |                                                                  |
-| RiskMgmtSettings                             | ✅      |                                                                  |
-| Role                                         | ✅      |                                                                  |
-| SalesAgreementSettings                       | ✅      |                                                                  |
-| SalesDealAgentSettings                       | ✅      |                                                                  |
-| SalesWorkQueueSettings                       | ✅      |                                                                  |
-| SamlSsoConfig                                | ✅      |                                                                  |
-| SandboxSettings                              | ✅      |                                                                  |
-| SceGlobalModelOptOutSettings                 | ✅      |                                                                  |
-| SchedulingObjective                          | ✅      |                                                                  |
-| SchedulingRecipeSettings                     | ✅      |                                                                  |
-| SchedulingRule                               | ✅      |                                                                  |
-| SchemaSettings                               | ✅      |                                                                  |
-| ScoreCategory                                | ✅      |                                                                  |
-| SearchCustomization                          | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| SearchOrgWideObjectConfig                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| SearchSettings                               | ✅      |                                                                  |
-| SecurityAgentSettings                        | ✅      |                                                                  |
-| SecurityHubSettings                          | ✅      |                                                                  |
-| SecuritySettings                             | ✅      |                                                                  |
-| SelfSvcPortalTopic                           | ❌      | Not supported, but support could be added                        |
-| SequenceServiceSettings                      | ✅      |                                                                  |
-| ServiceAIRecommendationsSettings             | ✅      |                                                                  |
-| ServiceAISetupDefinition                     | ✅      |                                                                  |
-| ServiceAISetupField                          | ✅      |                                                                  |
-| ServiceChannel                               | ✅      |                                                                  |
-| ServiceCloudNotificationOrchestratorSettings | ✅      |                                                                  |
-| ServiceCloudVoiceSettings                    | ✅      |                                                                  |
-| ServiceIssueManagementSettings               | ✅      |                                                                  |
-| ServiceItsmChangeManagementSettings          | ✅      |                                                                  |
-| ServiceItsmIntelligenceUddSettings           | ✅      |                                                                  |
-| ServiceLegalStatusesSettings                 | ✅      |                                                                  |
-| ServiceMgmtKnwlgArtclConfig                  | ❌      | Not supported, but support could be added                        |
-| ServiceMgmtKnwlgArtclConfigSettings          | ✅      |                                                                  |
-| ServicePresenceStatus                        | ✅      |                                                                  |
-| ServiceProcess                               | ✅      |                                                                  |
-| ServiceProcessSettings                       | ✅      |                                                                  |
-| ServiceScheduleConfig                        | ❌      | Not supported, but support could be added                        |
-| ServiceSetupAssistantSettings                | ✅      |                                                                  |
-| SetupCopilotSettings                         | ✅      |                                                                  |
-| SharingCriteriaRule                          | ✅      |                                                                  |
-| SharingGuestRule                             | ✅      |                                                                  |
-| SharingOwnerRule                             | ✅      |                                                                  |
-| SharingReason                                | ✅      |                                                                  |
-| SharingRules                                 | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| SharingSet                                   | ✅      |                                                                  |
-| SharingSettings                              | ✅      |                                                                  |
-| SharingTerritoryRule                         | ✅      |                                                                  |
-| SiteDotCom                                   | ✅      |                                                                  |
-| SiteSettings                                 | ✅      |                                                                  |
-| Skill                                        | ✅      |                                                                  |
-| SkillType                                    | ✅      |                                                                  |
-| SlackApp                                     | ✅      |                                                                  |
-| SoFieldMappingSettings                       | ✅      |                                                                  |
-| SocialCustomerServiceSettings                | ✅      |                                                                  |
-| SourceTrackingSettings                       | ✅      |                                                                  |
-| SrvcMgmtObjCollabAppCnfg                     | ❌      | Not supported, but support could be added                        |
-| StageAssignment                              | ✅      |                                                                  |
-| StageDefinition                              | ✅      |                                                                  |
-| StandardValue                                | ❌      | Not supported, but support could be added                        |
-| StandardValueSet                             | ✅      |                                                                  |
-| StandardValueSetTranslation                  | ✅      |                                                                  |
-| StaticResource                               | ✅      |                                                                  |
-| StnryAssetEnvSrcCnfg                         | ✅      |                                                                  |
-| StockRotationSettings                        | ✅      |                                                                  |
-| StreamingAppDataConnector                    | ✅      |                                                                  |
-| SubscriptionManagementSettings               | ✅      |                                                                  |
-| SurveySettings                               | ✅      |                                                                  |
-| SurveyStyleSet                               | ❌      | Not supported, but support could be added                        |
-| SustainabilityUom                            | ✅      |                                                                  |
-| SustnUomConversion                           | ✅      |                                                                  |
-| SvcCatalogCategory                           | ✅      |                                                                  |
-| SvcCatalogFilterCriteria                     | ✅      |                                                                  |
-| SvcCatalogFulfillmentFlow                    | ✅      |                                                                  |
-| SvcCatalogItemDef                            | ✅      |                                                                  |
-| SynchronizeSettings                          | ✅      |                                                                  |
-| SynonymDictionary                            | ✅      |                                                                  |
-| SystemNotificationSettings                   | ✅      |                                                                  |
-| Tag                                          | ❌      | Not supported, but support could be added (but not for tracking) |
-| TagSet                                       | ❌      | Not supported, but support could be added (but not for tracking) |
-| TelemetryActionDefStep                       | ✅      |                                                                  |
-| TelemetryActionDefinition                    | ✅      |                                                                  |
-| TelemetryActnDefStepAttr                     | ✅      |                                                                  |
-| TelemetryDefinition                          | ✅      |                                                                  |
-| TelemetryDefinitionVersion                   | ✅      |                                                                  |
-| Territory                                    | ✅      |                                                                  |
-| Territory2                                   | ✅      |                                                                  |
-| Territory2Model                              | ✅      |                                                                  |
-| Territory2Rule                               | ✅      |                                                                  |
-| Territory2Settings                           | ✅      |                                                                  |
-| Territory2Type                               | ✅      |                                                                  |
-| ThunderbirdVoiceSettings                     | ✅      |                                                                  |
-| TimeSheetTemplate                            | ✅      |                                                                  |
-| TimelineObjectDefinition                     | ✅      |                                                                  |
-| TmfOutboundNotificationSettings              | ✅      |                                                                  |
-| TmshtLaborCostOptimAiSettings                | ✅      |                                                                  |
-| TopicsForObjects                             | ✅      |                                                                  |
-| TrailheadSettings                            | ✅      |                                                                  |
-| TransactableMarketplacePrivateOfferSettings  | ✅      |                                                                  |
-| TransactionProcessingType                    | ⚠️      | Supports deploy/retrieve but not source tracking                 |
-| TransactionSecurityPolicy                    | ✅      |                                                                  |
-| Translations                                 | ✅      |                                                                  |
-| TrialOrgSettings                             | ✅      |                                                                  |
-| TriggerConfigurationsSettings                | ✅      |                                                                  |
-| UIBundle                                     | ✅      |                                                                  |
-| UIBundleSettings                             | ✅      |                                                                  |
-| UIObjectRelationConfig                       | ✅      |                                                                  |
-| UiFormatSpecificationSet                     | ✅      |                                                                  |
-| UiPlugin                                     | ✅      |                                                                  |
-| UiPreviewMessageTabDef                       | ✅      |                                                                  |
-| UiWidgetBundle                               | ✅      |                                                                  |
-| UnifiedSalesIntelligenceSettings             | ✅      |                                                                  |
-| UserAccessPolicy                             | ✅      |                                                                  |
-| UserAuthCertificate                          | ✅      |                                                                  |
-| UserCriteria                                 | ✅      |                                                                  |
-| UserEngagementSettings                       | ✅      |                                                                  |
-| UserInterfaceSettings                        | ✅      |                                                                  |
-| UserManagementSettings                       | ✅      |                                                                  |
-| UserProvisioningConfig                       | ✅      |                                                                  |
-| ValidationRule                               | ✅      |                                                                  |
-| VehicleAssetEmssnSrcCnfg                     | ✅      |                                                                  |
-| ViewDefinition                               | ✅      |                                                                  |
-| VirtualVisitConfig                           | ✅      |                                                                  |
-| VoiceEngagementMediaFile                     | ❌      | Not supported, but support could be added                        |
-| VoiceEngagementMediaUsage                    | ❌      | Not supported, but support could be added                        |
-| VoiceEngmtMediaFileAsgnt                     | ❌      | Not supported, but support could be added                        |
-| VoiceSettings                                | ✅      |                                                                  |
-| WarrantyLifecycleMgmtSettings                | ✅      |                                                                  |
-| WaveAnalyticAssetCollection                  | ✅      |                                                                  |
-| WaveApplication                              | ✅      |                                                                  |
-| WaveComponent                                | ✅      |                                                                  |
-| WaveDashboard                                | ✅      |                                                                  |
-| WaveDataflow                                 | ✅      |                                                                  |
-| WaveDataset                                  | ✅      |                                                                  |
-| WaveLens                                     | ✅      |                                                                  |
-| WaveRecipe                                   | ✅      |                                                                  |
-| WaveTemplateBundle                           | ✅      |                                                                  |
-| WaveXmd                                      | ✅      |                                                                  |
-| Web3Settings                                 | ✅      |                                                                  |
-| WebLink                                      | ✅      |                                                                  |
-| WebStoreBundle                               | ✅      |                                                                  |
-| WebStoreTemplate                             | ✅      |                                                                  |
-| WebToXSettings                               | ✅      |                                                                  |
-| WorkDotComSettings                           | ✅      |                                                                  |
-| WorkSkillRouting                             | ✅      |                                                                  |
-| Workflow                                     | ✅      |                                                                  |
-| WorkflowAlert                                | ✅      |                                                                  |
-| WorkflowFieldUpdate                          | ✅      |                                                                  |
-| WorkflowFlowAction                           | ✅      |                                                                  |
-| WorkflowKnowledgePublish                     | ✅      |                                                                  |
-| WorkflowOutboundMessage                      | ✅      |                                                                  |
-| WorkflowRule                                 | ✅      |                                                                  |
-| WorkflowSend                                 | ✅      |                                                                  |
-| WorkflowTask                                 | ✅      |                                                                  |
-| WorkforceEngagementSettings                  | ✅      |                                                                  |
+|Metadata Type|Support|Notes|
+|:---|:---|:---|
+|AIApplication|✅||
+|AIApplicationConfig|✅||
+|AIReplyRecommendationsSettings|✅||
+|AIScoringModelDefVersion|✅||
+|AIScoringModelDefinition|✅||
+|AIUsecaseDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|AccountForecastSettings|✅||
+|AccountIntelligenceSettings|✅||
+|AccountPlanObjMeasCalcDef|✅||
+|AccountPlanSettings|✅||
+|AccountRelationshipShareRule|✅||
+|AccountSettings|✅||
+|AccountingFieldMapping|✅||
+|AccountingModelConfig|✅||
+|AccountingSettings|✅||
+|AcctMgrTargetSettings|✅||
+|ActionLauncherItemDef|✅||
+|ActionLinkGroupTemplate|✅||
+|ActionPlanTemplate|✅||
+|ActionableEventOrchDef|✅||
+|ActionableEventTypeDef|✅||
+|ActionableListDefinition|✅||
+|ActionsSettings|✅||
+|ActivationPlatform|✅||
+|ActivitiesSettings|✅||
+|ActnblListKeyPrfmIndDef|✅||
+|AddressSettings|✅||
+|AdminSuccessSettings|✅||
+|AdvAccountForecastSet|✅||
+|AdvAcctForecastDimSource|✅||
+|AdvAcctForecastPeriodGroup|✅||
+|AffinityScoreDefinition|✅||
+|AgentPlatformSettings|✅||
+|AgentforceAccountManagementSettings|✅||
+|AgentforceForDevelopersSettings|✅||
+|AgenticCtxtDecorDefinition|❌|Not supported, but support could be added|
+|Ai4mSettings|✅||
+|AiAgentScorerDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|AiAuthoringBundle|✅||
+|AiEvaluationDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|AiPlannerVoiceAvatarDef|❌|Not supported, but support could be added|
+|AiPlannerVoiceDef|❌|Not supported, but support could be added (but not for tracking)|
+|AiResponseFormat|⚠️|Supports deploy/retrieve but not source tracking|
+|AiResponseFormatIstr|❌|Not supported, but support could be added (but not for tracking)|
+|AiSurface|⚠️|Supports deploy/retrieve but not source tracking|
+|AiSurfaceInput|❌|Not supported, but support could be added (but not for tracking)|
+|AiSurfaceInstruction|❌|Not supported, but support could be added (but not for tracking)|
+|AiTestingDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|AnalyticSnapshot|✅||
+|AnalyticsDashboard|✅||
+|AnalyticsDatasetDefinition|❌|Not supported, but support could be added|
+|AnalyticsSettings|✅||
+|AnalyticsVisualization|✅||
+|AnalyticsWorkspace|✅||
+|AnimationRule|✅||
+|ApexClass|✅||
+|ApexComponent|✅||
+|ApexEmailNotifications|✅||
+|ApexLimitSettings|✅||
+|ApexPage|✅||
+|ApexSettings|✅||
+|ApexTestSuite|✅||
+|ApexTrigger|✅||
+|ApiNamedQuery|✅||
+|AppAnalyticsSettings|✅||
+|AppExperienceSettings|✅||
+|AppFrameworkTemplateBundle|✅||
+|AppMenu|✅||
+|ApplicationRecordTypeConfig|✅||
+|ApplicationSubtypeDefinition|✅||
+|AppointmentAssignmentPolicy|✅||
+|AppointmentBookingSettings|✅||
+|AppointmentSchedulingPolicy|✅||
+|ApprovalProcess|✅||
+|AssessmentConfiguration|✅||
+|AssessmentQuestion|✅||
+|AssessmentQuestionSet|✅||
+|AssignmentRules|✅||
+|AssistantContextItem|✅||
+|AssistantDefinition|✅||
+|AssistantSkillQuickAction|✅||
+|AssistantSkillSobjectAction|✅||
+|AssistantVersion|✅||
+|AssociationEngineSettings|✅||
+|Audience|✅||
+|AuraDefinitionBundle|✅||
+|AuthProvider|✅||
+|AutoResponseRules|✅||
+|AutomatorConfigSettings|✅||
+|BatchCalcJobDefinition|✅||
+|BatchProcessJobDefinition|✅||
+|BenefitAction|✅||
+|BillingSettings|✅||
+|BlacklistedConsumer|✅||
+|BldgEnrgyIntensityCnfg|✅||
+|BlockchainSettings|✅||
+|Bot|✅||
+|BotBlock|✅||
+|BotBlockVersion|❌|Not supported, but support could be added|
+|BotSettings|✅||
+|BotTemplate|✅||
+|BotVersion|✅||
+|BranchManagementSettings|✅||
+|BrandKitSettings|✅||
+|BrandingSet|✅||
+|BriefcaseDefinition|✅||
+|BusinessHoursSettings|✅||
+|BusinessProcess|✅||
+|BusinessProcessGroup|✅||
+|BusinessProcessTypeDefinition|✅||
+|CMSConnectSource|✅||
+|CallCenter|✅||
+|CallCenterRoutingMap|✅||
+|CallCoachingMediaProvider|⚠️|Supports deploy/retrieve but not source tracking|
+|CampaignInfluenceModel|✅||
+|CampaignSettings|✅||
+|CanvasMetadata|✅||
+|CareBenefitVerifySettings|✅||
+|CareLimitType|✅||
+|CareProviderAfflRoleConfig|✅||
+|CareProviderSearchConfig|✅||
+|CareRequestConfiguration|✅||
+|CareSystemFieldMapping|✅||
+|CaseSettings|✅||
+|CaseSubjectParticle|✅||
+|CatalogedApi|✅||
+|CatalogedApiArtifactVersionInfo|✅||
+|CatalogedApiVersion|✅||
+|Certificate|✅||
+|ChannelLayout|✅||
+|ChannelObjectLinkingRule|✅||
+|ChannelRevMgmtSettings|✅||
+|ChatterAnswersSettings|✅||
+|ChatterEmailsMDSettings|✅||
+|ChatterExtension|✅||
+|ChatterSettings|✅||
+|ChoiceList|⚠️|Supports deploy/retrieve but not source tracking|
+|ClaimCoverageProdtProcDef|❌|Not supported, but support could be added|
+|ClaimFinancialSettings|✅||
+|ClaimMgmtFoundationEnabledSettings|✅||
+|ClauseCatgConfiguration|✅||
+|CleanDataService|✅||
+|CmsnStmtLineItemConfig|❌|Not supported, but support could be added|
+|CmsnStmtLineItemTypConfig|❌|Not supported, but support could be added|
+|CnfgItemAttrDef|✅||
+|CnfgItemAttrPcklstValDef|✅||
+|CnfgItemAttrPicklistDef|✅||
+|CnfgItemAttrSetAttr|✅||
+|CnfgItemAttrSetDef|✅||
+|CnfgItemSourceDefinition|✅||
+|CnfgItemTypeAttrRelDef|✅||
+|CnfgItemTypeDef|✅||
+|CnfgItemTypeRelationDef|✅||
+|CnfgMgmtRelationTypeDef|✅||
+|CodeBuilderSettings|✅||
+|CollectionsDashboardSettings|✅||
+|CommandAction|✅||
+|CommerceSettings|✅||
+|CommissionStatementConfig|❌|Not supported, but support could be added|
+|CommsServiceConsoleSettings|✅||
+|CommunicationChannelLine|❌|Not supported, but support could be added|
+|CommunicationChannelType|❌|Not supported, but support could be added|
+|CommunitiesSettings|✅||
+|Community|✅||
+|CommunityTemplateDefinition|✅||
+|CommunityThemeDefinition|✅||
+|CompactLayout|✅||
+|CompanySettings|✅||
+|ComputeExtension|✅||
+|ConnectedApp|✅||
+|ConnectedAppSettings|✅||
+|ContentAsset|✅||
+|ContentSettings|✅||
+|ContentTypeBundle|✅||
+|ContextDefinition|✅||
+|ContextMappingConfig|❌|Not supported, but support could be added|
+|ContextUseCaseMapping|✅||
+|ContractSettings|✅||
+|ContractType|✅||
+|ConvIntelligenceSignalRule|✅||
+|ConversationChannelDefinition|✅||
+|ConversationGuidanceSettings|✅||
+|ConversationMessageDefinition|✅||
+|ConversationServiceIntegrationSettings|✅||
+|ConversationVendorInfo|✅||
+|ConversationalIntelligenceSettings|✅||
+|CorsWhitelistOrigin|✅||
+|CourseWaitlistConfig|❌|Not supported, but support could be added|
+|CriteriaSettings|✅||
+|CspTrustedSite|✅||
+|CurrencySettings|✅||
+|CustomAddressFieldSettings|✅||
+|CustomApplication|✅||
+|CustomApplicationComponent|✅||
+|CustomFeedFilter|✅||
+|CustomField|✅||
+|CustomFieldDisplay|❌|Not supported, but support could be added|
+|CustomHelpMenuSection|✅||
+|CustomIndex|✅||
+|CustomLabels|✅||
+|CustomMetadata|✅||
+|CustomNotificationType|✅||
+|CustomObject|✅||
+|CustomObjectBinding|❌|Not supported, but support could be added|
+|CustomObjectTranslation|✅||
+|CustomPageWebLink|✅||
+|CustomPermission|✅||
+|CustomSite|✅||
+|CustomTab|✅||
+|CustomValue|❌|Not supported, but support could be added|
+|CustomerDataPlatformSettings|✅||
+|CustomizablePropensityScoringSettings|✅||
+|Dashboard|✅||
+|DashboardFolder|✅||
+|DataCalcInsightTemplate|✅||
+|DataCategoryGroup|✅||
+|DataCleanRoomProvider|❌|Not supported, but support could be added|
+|DataConnector|✅||
+|DataConnectorIngestApi|✅||
+|DataConnectorS3|✅||
+|DataDotComSettings|✅||
+|DataImportManagementSettings|✅||
+|DataKitObjectDependency|✅||
+|DataKitObjectTemplate|✅||
+|DataMapperDefinition|✅||
+|DataMaskPolicy|❌|Not supported, but support could be added|
+|DataMaskSettings|✅||
+|DataObjectBuildOrgTemplate|✅||
+|DataObjectSearchIndexConf|⚠️|Supports deploy/retrieve but not source tracking|
+|DataPackageKitDefinition|✅||
+|DataPackageKitObject|✅||
+|DataSource|✅||
+|DataSourceBundleDefinition|✅||
+|DataSourceObject|✅||
+|DataSourceTenant|✅||
+|DataSrcDataModelFieldMap|✅||
+|DataStreamDefinition|✅||
+|DataStreamTemplate|✅||
+|DataWeaveResource|✅||
+|DealInsightsSettings|✅||
+|DecisionMatrixDefinition|✅||
+|DecisionMatrixDefinitionVersion|✅||
+|DecisionTable|✅||
+|DecisionTableDatasetLink|✅||
+|DelegateAccessDataSet|❌|Not supported, but support could be added|
+|DelegateAccessDef|❌|Not supported, but support could be added|
+|DelegateAccsDataSetObj|❌|Not supported, but support could be added|
+|DelegateGroup|✅||
+|DeploymentSettings|✅||
+|DevHubSettings|✅||
+|DgtAssetMgmtProvider|✅||
+|DgtAssetMgmtPrvdLghtCpnt|✅||
+|DictionariesSettings|✅||
+|DigitalExperience|✅||
+|DigitalExperienceBundle|✅||
+|DigitalExperienceConfig|✅||
+|DigitalWalletSettings|✅||
+|DisclosureDefinition|✅||
+|DisclosureDefinitionVersion|✅||
+|DisclosureType|✅||
+|DiscoveryAIModel|✅||
+|DiscoveryGoal|✅||
+|DiscoverySettings|✅||
+|DiscoveryStory|✅||
+|Document|✅||
+|DocumentCategory|✅||
+|DocumentCategoryDocumentType|✅||
+|DocumentChecklistSettings|✅||
+|DocumentExtractionDef|❌|Not supported, but support could be added|
+|DocumentFolder|✅||
+|DocumentGenerationSetting|✅||
+|DocumentTemplate|⚠️|Supports deploy/retrieve but not source tracking|
+|DocumentType|✅||
+|DripFeedConfigSettings|✅||
+|DuplicateRule|✅||
+|DxGlobalTermsSettings|✅||
+|DynamicFormsSettings|✅||
+|DynamicFulfillmentOrchestratorSettings|✅||
+|DynamicGanttSettings|✅||
+|EACSettings|✅||
+|ESignatureConfig|✅||
+|ESignatureEnvelopeConfig|✅||
+|EclairGeoData|✅||
+|EinsteinAISettings|✅||
+|EinsteinAgentSettings|✅||
+|EinsteinAssistantSettings|✅||
+|EinsteinCopilotSettings|✅||
+|EinsteinDealInsightsSettings|✅||
+|EinsteinDocumentCaptureSettings|✅||
+|EinsteinGptSettings|✅||
+|EmailAdministrationSettings|✅||
+|EmailAuthorizationSettings|✅||
+|EmailFolder|✅||
+|EmailIntegrationSettings|✅||
+|EmailServicesFunction|✅||
+|EmailTemplate|✅||
+|EmailTemplateFolder|✅||
+|EmailTemplateSettings|✅||
+|EmbeddedServiceBranding|✅||
+|EmbeddedServiceConfig|✅||
+|EmbeddedServiceFlowConfig|✅||
+|EmbeddedServiceLiveAgent|✅||
+|EmbeddedServiceMenuSettings|✅||
+|EmergencySettings|✅||
+|EmployeeDataSyncProfile|✅||
+|EmployeeFieldAccessSettings|✅||
+|EmployeeUserSettings|✅||
+|EnablementMeasureDefinition|✅||
+|EnablementProgramDefinition|✅||
+|EnblProgramTaskSubCategory|✅||
+|EnhancedNotesSettings|✅||
+|EnterpriseApiSettings|✅||
+|EntitlementProcess|✅||
+|EntitlementSettings|✅||
+|EntitlementTemplate|✅||
+|EscalationRules|✅||
+|EssentialsSettings|✅||
+|EventLogObjectSettings|✅||
+|EventRelayConfig|✅||
+|EventSettings|✅||
+|EvfSettings|✅||
+|EvidenceMgmtSettings|✅||
+|ExperienceBundle|✅||
+|ExperienceBundleSettings|✅||
+|ExperiencePropertyTypeBundle|✅||
+|ExplainabilityActionDefinition|✅||
+|ExplainabilityActionVersion|✅||
+|ExplainabilityMsgTemplate|✅||
+|ExpressionSetDefinition|✅||
+|ExpressionSetDefinitionVersion|✅||
+|ExpressionSetMessageToken|✅||
+|ExpressionSetObjectAlias|✅||
+|ExtDataTranFieldTemplate|❌|Not supported, but support could be added|
+|ExtDataTranObjectTemplate|✅||
+|ExternalAIModel|✅||
+|ExternalAuthIdentityProvider|✅||
+|ExternalClientAppSettings|✅||
+|ExternalClientApplication|✅||
+|ExternalCredential|✅||
+|ExternalDataConnector|✅||
+|ExternalDataSource|✅||
+|ExternalDataSrcDescriptor|❌|Not supported, but support could be added|
+|ExternalDataTranField|❌|Not supported, but support could be added|
+|ExternalDataTranObject|✅||
+|ExternalDocStorageConfig|✅||
+|ExternalServiceRegistration|✅||
+|ExternalStoragePrvdConfig|✅||
+|ExtlClntAppAttestConfigurablePolicies|❌|Not supported, but support could be added (but not for tracking)|
+|ExtlClntAppAttestSettings|✅||
+|ExtlClntAppCanvasSettings|✅||
+|ExtlClntAppConfigurablePolicies|✅||
+|ExtlClntAppGlobalOauthSettings|✅||
+|ExtlClntAppMobileConfigurablePolicies|✅||
+|ExtlClntAppMobileSettings|✅||
+|ExtlClntAppNotificationSettings|✅||
+|ExtlClntAppOauthConfigurablePolicies|✅||
+|ExtlClntAppOauthSecuritySettings|✅||
+|ExtlClntAppOauthSettings|✅||
+|ExtlClntAppPushConfigurablePolicies|✅||
+|ExtlClntAppPushSettings|✅||
+|ExtlClntAppSamlConfigurablePolicies|✅||
+|FeatureParameterBoolean|✅||
+|FeatureParameterDate|✅||
+|FeatureParameterInteger|✅||
+|FieldMappingConfig|✅||
+|FieldRestrictionRule|✅||
+|FieldServiceMobileConfig|✅||
+|FieldServiceMobileExtension|✅||
+|FieldServiceSettings|✅||
+|FieldSet|✅||
+|FieldSrcTrgtRelationship|✅||
+|FileUploadAndDownloadSecuritySettings|✅||
+|FilesConnectSettings|✅||
+|FinancialPortfolioUiConfig|❌|Not supported, but support could be added|
+|FlexcardDefinition|✅||
+|FlexiPage|✅||
+|Flow|✅||
+|FlowCategory|✅||
+|FlowDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|FlowSettings|✅||
+|FlowTest|✅||
+|FlowValueMap|✅||
+|ForecastingFilter|✅||
+|ForecastingFilterCondition|✅||
+|ForecastingGroup|✅||
+|ForecastingObjectListSettings|✅||
+|ForecastingSettings|✅||
+|ForecastingSourceDefinition|✅||
+|ForecastingType|✅||
+|ForecastingTypeSource|✅||
+|FormulaSettings|✅||
+|FuelType|✅||
+|FuelTypeSustnUom|✅||
+|FunctionReference|⚠️|Supports deploy/retrieve but not source tracking|
+|FundraisingConfig|✅||
+|GRCIntelligenceUddSettings|✅||
+|GatewayProviderPaymentMethodType|✅||
+|GenAiFunction|✅||
+|GenAiPlannerBundle|✅||
+|GenAiPlugin|✅||
+|GenAiPromptTemplate|✅||
+|GenAiPromptTemplateActv|✅||
+|GenComputingSummaryDef|❌|Not supported, but support could be added|
+|GenOpAgentConfig|❌|Not supported, but support could be added|
+|GenOpPlanEligibilityConfig|❌|Not supported, but support could be added|
+|GeneralConfigSettings|✅||
+|GeocodeSettings|✅||
+|GiftEntryGridTemplate|✅||
+|GlobalValueSet|✅||
+|GlobalValueSetTranslation|✅||
+|GoogleAppsSettings|✅||
+|Group|✅||
+|HerokuAppLinkSettings|✅||
+|HighVelocitySalesSettings|✅||
+|HomePageComponent|✅||
+|HomePageLayout|✅||
+|IPAddressRange|✅||
+|Icon|✅||
+|IdeasSettings|✅||
+|IdentityProviderSettings|✅||
+|IdentityRsolDataSyncDef|❌|Not supported, but support could be added|
+|IdentityVerificationProcDef|✅||
+|IframeWhiteListUrlSettings|✅||
+|InboundCertificate|✅||
+|InboundNetworkConnection|✅||
+|IncidentMgmtSettings|✅||
+|IncludeEstTaxInQuoteCPQSettings|✅||
+|IncludeEstTaxInQuoteSettings|✅||
+|Index|⚠️|Supports deploy/retrieve but not source tracking|
+|IndustriesAutomotiveSettings|✅||
+|IndustriesChannelPartnerInventorySettings|✅||
+|IndustriesConnectedServiceSettings|✅||
+|IndustriesConstraintsSettings|✅||
+|IndustriesContextSettings|✅||
+|IndustriesEinsteinFeatureSettings|✅||
+|IndustriesEnergyUtilitiesMultiSiteSettings|✅||
+|IndustriesEventOrchSettings|✅||
+|IndustriesFieldServiceSettings|✅||
+|IndustriesGamificationSettings|✅||
+|IndustriesInsuranceSettings|✅||
+|IndustriesLoyaltySettings|✅||
+|IndustriesLsCommercialSettings|✅||
+|IndustriesManufacturingSettings|✅||
+|IndustriesMfgSampleManagementSettings|✅||
+|IndustriesPricingSettings|✅||
+|IndustriesRatingSettings|✅||
+|IndustriesSettings|✅||
+|IndustriesUnifiedInventorySettings|✅||
+|IndustriesUnifiedPromotionsSettings|✅||
+|IndustriesUsageSettings|✅||
+|InsBillingConfig|❌|Not supported, but support could be added|
+|InsPlcyCoverageSpecConfig|❌|Not supported, but support could be added|
+|InsPlcyLimitConsumptionRule|❌|Not supported, but support could be added|
+|InsPlcyLineOfBusConfig|❌|Not supported, but support could be added|
+|InsPolicyLifecycleConfig|❌|Not supported, but support could be added|
+|InsPolicyManagementConfig|❌|Not supported, but support could be added|
+|InsRatePlanCmsnConfig|❌|Not supported, but support could be added|
+|InsRatePlanTypeConfig|❌|Not supported, but support could be added|
+|InstalledPackage|⚠️|Supports deploy/retrieve but not source tracking|
+|InsuranceBrokerageSettings|✅||
+|IntegArtifactDef|✅||
+|IntegratedPlanDefinition|❌|Not supported, but support could be added|
+|IntegrationProcdDefinition|✅||
+|IntegrationProviderDef|✅||
+|InterestTaggingSettings|✅||
+|InternalDataConnector|✅||
+|InvLatePymntRiskCalcSettings|✅||
+|InventoryAllocationSettings|✅||
+|InventoryReplenishmentSettings|✅||
+|InventorySettings|✅||
+|InvocableActionExtension|✅||
+|InvocableActionSettings|✅||
+|IoTSettings|✅||
+|KeywordList|✅||
+|KnowledgeGenerationSettings|✅||
+|KnowledgeSettings|✅||
+|LaborCostOptimCrewMgmtSettings|✅||
+|LaborCostOptimizationSettings|✅||
+|LanguageSettings|✅||
+|LargeQuotesandOrdersForRlmSettings|✅||
+|Layout|✅||
+|LeadConfigSettings|✅||
+|LeadConvertSettings|✅||
+|LearningAchievementConfig|✅||
+|LearningItemType|✅||
+|Letterhead|✅||
+|LicensingSettings|✅||
+|LifeSciConfigCategory|✅||
+|LifeSciConfigRecord|✅||
+|LightningBolt|✅||
+|LightningComponentBundle|✅||
+|LightningExperienceSettings|✅||
+|LightningExperienceTheme|✅||
+|LightningMessageChannel|✅||
+|LightningOnboardingConfig|✅||
+|LightningTypeBundle|✅||
+|ListView|✅||
+|LiveAgentSettings|✅||
+|LiveChatAgentConfig|✅||
+|LiveChatButton|✅||
+|LiveChatDeployment|✅||
+|LiveChatSensitiveDataRule|✅||
+|LiveMessageSettings|✅||
+|LocationUse|✅||
+|LogicSettings|✅||
+|LoyaltyProgramSetup|⚠️|Supports deploy/retrieve but not source tracking|
+|MacroSettings|✅||
+|MailMergeSettings|✅||
+|ManagedContentType|⚠️|Supports deploy/retrieve but not source tracking|
+|ManagedEventSubscription|✅||
+|ManagedTopics|✅||
+|MapReportSettings|✅||
+|MapsAndLocationSettings|✅||
+|MarketSegmentDefinition|✅||
+|MarketingAppExtActivity|❌|Not supported, but support could be added|
+|MarketingAppExtension|✅||
+|MatchingRules|✅||
+|McpServerDefinition|✅||
+|MediaAdSalesSettings|✅||
+|MediaAgentSettings|✅||
+|MeetingPlaybookDefinition|✅||
+|MeetingsSettings|✅||
+|MessagingChannel|⚠️|Supports deploy/retrieve but not source tracking|
+|MfgProgramTemplate|✅||
+|MfgServiceConsoleSettings|✅||
+|MilestoneType|✅||
+|MktCalcInsightObjectDef|✅||
+|MktDataConnection|✅||
+|MktDataConnectionParam|❌|Not supported, but support could be added|
+|MktDataConnectionSrcParam|✅||
+|MktDataTranObject|✅||
+|MlDomain|✅||
+|MobSecurityCertPinConfig|✅||
+|MobileApplicationDetail|✅||
+|MobileSecurityAssignment|✅||
+|MobileSecurityPolicy|✅||
+|MobileSettings|✅||
+|ModerationRule|✅||
+|MutingPermissionSet|✅||
+|MyDomainDiscoverableLogin|✅||
+|MyDomainSettings|✅||
+|NameSettings|✅||
+|NamedCredential|✅||
+|NavigationMenu|✅||
+|Network|✅||
+|NetworkBranding|✅||
+|NotificationTypeConfig|✅||
+|NotificationsSettings|✅||
+|OauthCustomScope|✅||
+|OauthOidcSettings|✅||
+|OauthTokenExchangeHandler|✅||
+|ObjIntegProviderDefMapping|✅||
+|ObjectHierarchyRelationship|✅||
+|ObjectLinkingSettings|✅||
+|ObjectMappingSettings|✅||
+|ObjectSourceTargetMap|✅||
+|OcrSampleDocument|✅||
+|OcrTemplate|✅||
+|OmniChannelPricingSettings|✅||
+|OmniChannelSettings|✅||
+|OmniDataTransform|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniExtTrackingDef|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniIntegrationProcedure|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniInteractionAccessConfig|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniInteractionConfig|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniScript|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniStudioSettings|✅||
+|OmniSupervisorConfig|✅||
+|OmniTrackingGroup|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniUiCard|⚠️|Supports deploy/retrieve but not source tracking|
+|OmniscriptDefinition|✅||
+|OnboardingDataObjectGroup|✅||
+|OnlineSalesSettings|✅||
+|OpportunityScoreSettings|✅||
+|OpportunitySettings|✅||
+|OptimizationSettings|✅||
+|OrchestrationPlanCtxMapping|❌|Not supported, but support could be added|
+|OrderManagementSettings|✅||
+|OrderSettings|✅||
+|OrgSettings|✅||
+|OutboundNetworkConnection|✅||
+|PardotEinsteinSettings|✅||
+|PardotSettings|✅||
+|ParticipantRole|✅||
+|PartyDataModelSettings|✅||
+|PartyProfileDataObjectValidityDefinition|✅||
+|PathAssistant|✅||
+|PathAssistantSettings|✅||
+|PaymentGatewayProvider|✅||
+|PaymentsManagementEnabledSettings|✅||
+|PaymentsSettings|✅||
+|PaymentsSharingSettings|✅||
+|PaynowStarterUpgradeEnabledSettings|✅||
+|PermissionSet|✅||
+|PermissionSetGroup|✅||
+|PermissionSetLicenseDefinition|✅||
+|PersonAccountOwnerPowerUser|✅||
+|PicklistSettings|✅||
+|PicklistValue|❌|Not supported, but support could be added|
+|PipelineInspMetricConfig|✅||
+|PlanningMeasureDef|❌|Not supported, but support could be added|
+|PlanningMeasureGroup|❌|Not supported, but support could be added|
+|PlatformCachePartition|✅||
+|PlatformEventChannel|✅||
+|PlatformEventChannelMember|✅||
+|PlatformEventMigration|❌|Not supported, but support could be added|
+|PlatformEventSettings|✅||
+|PlatformEventSubscriberConfig|✅||
+|PlatformSlackSettings|✅||
+|PlatformWebIdeSettings|✅||
+|PolicyRuleDefinition|✅||
+|PolicyRuleDefinitionSet|✅||
+|PortalDelegablePermissionSet|✅||
+|PortalsSettings|✅||
+|PostTemplate|✅||
+|PredictionBuilderSettings|✅||
+|PresenceDeclineReason|✅||
+|PresenceUserConfig|✅||
+|PricingActionParameters|✅||
+|PricingRecipe|✅||
+|PrivacySettings|✅||
+|PrmCoreSettings|✅||
+|ProcedureOutputResolution|❌|Not supported, but support could be added (but not for tracking)|
+|ProcedurePlanDefinition|⚠️|Supports deploy/retrieve but not source tracking|
+|ProcessFlowMigration|✅||
+|ProductAttrDisplayConfig|✅||
+|ProductAttributeSet|✅||
+|ProductCatalogManagementSettings|✅||
+|ProductConfiguratorSettings|✅||
+|ProductDiscoverySettings|✅||
+|ProductSettings|✅||
+|ProductSpecificationRecType|✅||
+|ProductSpecificationType|✅||
+|Profile|✅||
+|ProfilePasswordPolicy|✅||
+|ProfileSessionSetting|✅||
+|Prompt|✅||
+|ProviderSampleLimitTemplate|❌|Not supported, but support could be added|
+|PublicKeyCertificate|⚠️|Supports deploy/retrieve but not source tracking|
+|PublicKeyCertificateSet|⚠️|Supports deploy/retrieve but not source tracking|
+|PurchaseOrderMgmtSettings|✅||
+|QualityManagementSettings|✅||
+|Queue|✅||
+|QueueRoutingConfig|✅||
+|QuickAction|✅||
+|QuickTextSettings|✅||
+|QuoteSettings|✅||
+|RealTimeEventSettings|✅||
+|RebateAndAccrualMgmtAdvncdSettings|✅||
+|RecAlrtDataSrcExpSetDef|✅||
+|RecommendationBuilderSettings|✅||
+|RecommendationStrategy|✅||
+|RecordActionDeployment|✅||
+|RecordAggregationDefinition|✅||
+|RecordAlertCategory|✅||
+|RecordAlertDataSource|✅||
+|RecordAlertTemplate|✅||
+|RecordPageSettings|✅||
+|RecordType|✅||
+|RedirectWhitelistUrl|✅||
+|ReferencedDashboard|✅||
+|ReferralMarketingConfig|❌|Not supported, but support could be added|
+|ReferralMarketingSettings|✅||
+|RegisteredExternalService|✅||
+|RelatedRecordAccessDef|❌|Not supported, but support could be added|
+|RelatedRecordAssocCriteria|✅||
+|RelationshipGraphDefinition|✅||
+|ReleaseMgmtSettings|✅||
+|RemoteSiteSetting|✅||
+|Report|✅||
+|ReportFolder|✅||
+|ReportType|✅||
+|RestrictionRule|✅||
+|RetailExecutionSettings|✅||
+|RetrievalSummaryDefinition|✅||
+|RevenueManagementSettings|✅||
+|RiskMgmtSettings|✅||
+|Role|✅||
+|SalesAgreementSettings|✅||
+|SalesDealAgentSettings|✅||
+|SalesWorkQueueSettings|✅||
+|SamlSsoConfig|✅||
+|SandboxSettings|✅||
+|SceGlobalModelOptOutSettings|✅||
+|SchedulingObjective|✅||
+|SchedulingRecipeSettings|✅||
+|SchedulingRule|✅||
+|SchemaSettings|✅||
+|ScoreCategory|✅||
+|SearchCustomization|⚠️|Supports deploy/retrieve but not source tracking|
+|SearchOrgWideObjectConfig|⚠️|Supports deploy/retrieve but not source tracking|
+|SearchSettings|✅||
+|SecurityAgentSettings|✅||
+|SecurityHubSettings|✅||
+|SecuritySettings|✅||
+|SelfSvcPortalTopic|❌|Not supported, but support could be added|
+|SequenceServiceSettings|✅||
+|ServiceAIRecommendationsSettings|✅||
+|ServiceAISetupDefinition|✅||
+|ServiceAISetupField|✅||
+|ServiceChannel|✅||
+|ServiceCloudNotificationOrchestratorSettings|✅||
+|ServiceCloudVoiceSettings|✅||
+|ServiceIssueManagementSettings|✅||
+|ServiceItsmChangeManagementSettings|✅||
+|ServiceItsmIntelligenceUddSettings|✅||
+|ServiceLegalStatusesSettings|✅||
+|ServiceMgmtKnwlgArtclConfig|❌|Not supported, but support could be added|
+|ServiceMgmtKnwlgArtclConfigSettings|✅||
+|ServicePresenceStatus|✅||
+|ServiceProcess|✅||
+|ServiceProcessSettings|✅||
+|ServiceScheduleConfig|❌|Not supported, but support could be added|
+|ServiceSetupAssistantSettings|✅||
+|SetupCopilotSettings|✅||
+|SharingCriteriaRule|✅||
+|SharingGuestRule|✅||
+|SharingOwnerRule|✅||
+|SharingReason|✅||
+|SharingRules|⚠️|Supports deploy/retrieve but not source tracking|
+|SharingSet|✅||
+|SharingSettings|✅||
+|SharingTerritoryRule|✅||
+|SiteDotCom|✅||
+|SiteSettings|✅||
+|Skill|✅||
+|SkillType|✅||
+|SlackApp|✅||
+|SoFieldMappingSettings|✅||
+|SocialCustomerServiceSettings|✅||
+|SourceTrackingSettings|✅||
+|SrvcMgmtObjCollabAppCnfg|❌|Not supported, but support could be added|
+|StageAssignment|✅||
+|StageDefinition|✅||
+|StandardValue|❌|Not supported, but support could be added|
+|StandardValueSet|✅||
+|StandardValueSetTranslation|✅||
+|StaticResource|✅||
+|StnryAssetEnvSrcCnfg|✅||
+|StockRotationSettings|✅||
+|StreamingAppDataConnector|✅||
+|SubscriptionManagementSettings|✅||
+|SurveySettings|✅||
+|SurveyStyleSet|❌|Not supported, but support could be added|
+|SustainabilityUom|✅||
+|SustnUomConversion|✅||
+|SvcCatalogCategory|✅||
+|SvcCatalogFilterCriteria|✅||
+|SvcCatalogFulfillmentFlow|✅||
+|SvcCatalogItemDef|✅||
+|SynchronizeSettings|✅||
+|SynonymDictionary|✅||
+|SystemNotificationSettings|✅||
+|Tag|❌|Not supported, but support could be added (but not for tracking)|
+|TagSet|❌|Not supported, but support could be added (but not for tracking)|
+|TelemetryActionDefStep|✅||
+|TelemetryActionDefinition|✅||
+|TelemetryActnDefStepAttr|✅||
+|TelemetryDefinition|✅||
+|TelemetryDefinitionVersion|✅||
+|Territory|✅||
+|Territory2|✅||
+|Territory2Model|✅||
+|Territory2Rule|✅||
+|Territory2Settings|✅||
+|Territory2Type|✅||
+|ThunderbirdVoiceSettings|✅||
+|TimeSheetTemplate|✅||
+|TimelineObjectDefinition|✅||
+|TmfOutboundNotificationSettings|✅||
+|TmshtLaborCostOptimAiSettings|✅||
+|TopicsForObjects|✅||
+|TrailheadSettings|✅||
+|TransactableMarketplacePrivateOfferSettings|✅||
+|TransactionProcessingType|⚠️|Supports deploy/retrieve but not source tracking|
+|TransactionSecurityPolicy|✅||
+|Translations|✅||
+|TrialOrgSettings|✅||
+|TriggerConfigurationsSettings|✅||
+|UIBundle|✅||
+|UIBundleSettings|✅||
+|UIObjectRelationConfig|✅||
+|UiFormatSpecificationSet|✅||
+|UiPlugin|✅||
+|UiPreviewMessageTabDef|✅||
+|UiWidgetBundle|✅||
+|UnifiedSalesIntelligenceSettings|✅||
+|UserAccessPolicy|✅||
+|UserAuthCertificate|✅||
+|UserCriteria|✅||
+|UserEngagementSettings|✅||
+|UserInterfaceSettings|✅||
+|UserManagementSettings|✅||
+|UserProvisioningConfig|✅||
+|ValidationRule|✅||
+|VehicleAssetEmssnSrcCnfg|✅||
+|ViewDefinition|✅||
+|VirtualVisitConfig|✅||
+|VoiceEngagementMediaFile|❌|Not supported, but support could be added|
+|VoiceEngagementMediaUsage|❌|Not supported, but support could be added|
+|VoiceEngmtMediaFileAsgnt|❌|Not supported, but support could be added|
+|VoiceSettings|✅||
+|WarrantyLifecycleMgmtSettings|✅||
+|WaveAnalyticAssetCollection|✅||
+|WaveApplication|✅||
+|WaveComponent|✅||
+|WaveDashboard|✅||
+|WaveDataflow|✅||
+|WaveDataset|✅||
+|WaveLens|✅||
+|WaveRecipe|✅||
+|WaveTemplateBundle|✅||
+|WaveXmd|✅||
+|Web3Settings|✅||
+|WebLink|✅||
+|WebStoreBundle|✅||
+|WebStoreTemplate|✅||
+|WebToXSettings|✅||
+|WorkDotComSettings|✅||
+|WorkSkillRouting|✅||
+|Workflow|✅||
+|WorkflowAlert|✅||
+|WorkflowFieldUpdate|✅||
+|WorkflowFlowAction|✅||
+|WorkflowKnowledgePublish|✅||
+|WorkflowOutboundMessage|✅||
+|WorkflowRule|✅||
+|WorkflowSend|✅||
+|WorkflowTask|✅||
+|WorkforceEngagementSettings|✅||
+
+
 
 ## Next Release (v68)
 
-v68 introduces the following new types. Here's their current level of support
+v68 introduces the following new types.  Here's their current level of support
 
-| Metadata Type                     | Support | Notes                                            |
-| :-------------------------------- | :------ | :----------------------------------------------- |
-| AgentforcePlatformTracingSettings | ✅      |                                                  |
-| AiAgentDefinition                 | ❌      | Not supported, but support could be added        |
-| AiAgentDefinitionVersion          | ❌      | Not supported, but support could be added        |
-| BotEmailDefinition                | ❌      | Not supported, but support could be added        |
-| CnfgItemTypeIdentFieldMap         | ✅      |                                                  |
-| CnfgItemTypeIdentRule             | ✅      |                                                  |
-| ContentWorkspace                  | ❌      | Not supported, but support could be added        |
-| ContentWorkspacePermission        | ❌      | Not supported, but support could be added        |
-| DCOpportunityScoringSettings      | ✅      |                                                  |
-| DebugLevel                        | ❌      | Not supported, but support could be added        |
-| DynamicUiCardDefinition           | ✅      |                                                  |
-| HelpSettings                      | ✅      |                                                  |
-| HouseholdNamingConfig             | ✅      |                                                  |
-| IdpConfiguration                  | ⚠️      | Supports deploy/retrieve but not source tracking |
-| IndustriesRepossessionSettings    | ✅      |                                                  |
-| InvMgmtForUnusableQtySettings     | ✅      |                                                  |
-| LightningOutApp                   | ✅      |                                                  |
-| MCETransformationsSettings        | ✅      |                                                  |
-| MarketingHierarchyGroupDef        | ❌      | Not supported, but support could be added        |
-| MarketingHierarchyNodeDef         | ❌      | Not supported, but support could be added        |
-| MktPlanningOpsSettings            | ✅      |                                                  |
-| PlanningDimensionDef              | ❌      | Not supported, but support could be added        |
-| RecLifecyclCompanCpblDef          | ❌      | Not supported, but support could be added        |
-| RecLifecyclCompanDef              | ❌      | Not supported, but support could be added        |
-| ScndTelephPrvdOtbdDtl             | ❌      | Not supported, but support could be added        |
-| SecondaryTelephonyProvider        | ❌      | Not supported, but support could be added        |
-| ServiceItamSettings               | ✅      |                                                  |
-| StatisticalDealInsightsSettings   | ✅      |                                                  |
-| TelephonyProvider                 | ❌      | Not supported, but support could be added        |
-| TrustedTelephonyProvider          | ❌      | Not supported, but support could be added        |
-| WinProbabilityScoringSetup        | ❌      | Not supported, but support could be added        |
+|Metadata Type|Support|Notes|
+|:---|:---|:---|
+|AgentforcePlatformTracingSettings|✅||
+|AiAgentDefinition|❌|Not supported, but support could be added|
+|AiAgentDefinitionVersion|❌|Not supported, but support could be added|
+|BotEmailDefinition|❌|Not supported, but support could be added|
+|CnfgItemTypeIdentFieldMap|✅||
+|CnfgItemTypeIdentRule|✅||
+|ContentWorkspace|❌|Not supported, but support could be added|
+|ContentWorkspacePermission|❌|Not supported, but support could be added|
+|DCOpportunityScoringSettings|✅||
+|DebugLevel|❌|Not supported, but support could be added|
+|DynamicUiCardDefinition|✅||
+|HelpSettings|✅||
+|HouseholdNamingConfig|✅||
+|IdpConfiguration|⚠️|Supports deploy/retrieve but not source tracking|
+|IndustriesRepossessionSettings|✅||
+|InvMgmtForUnusableQtySettings|✅||
+|LightningOutApp|✅||
+|MCETransformationsSettings|✅||
+|MarketingHierarchyGroupDef|❌|Not supported, but support could be added|
+|MarketingHierarchyNodeDef|❌|Not supported, but support could be added|
+|MktPlanningOpsSettings|✅||
+|PlanningDimensionDef|❌|Not supported, but support could be added|
+|RecLifecyclCompanCpblDef|❌|Not supported, but support could be added|
+|RecLifecyclCompanDef|❌|Not supported, but support could be added|
+|ScndTelephPrvdOtbdDtl|❌|Not supported, but support could be added|
+|SecondaryTelephonyProvider|❌|Not supported, but support could be added|
+|ServiceItamSettings|✅||
+|StatisticalDealInsightsSettings|✅||
+|TelephonyProvider|❌|Not supported, but support could be added|
+|TrustedTelephonyProvider|❌|Not supported, but support could be added|
+|WinProbabilityScoringSetup|❌|Not supported, but support could be added|
 
 ## Additional Types
 
-> The following types are supported by this library but not in the coverage reports for either version. These are typically
+> The following types are supported by this library but not in the coverage reports for either version.  These are typically
 >
 > 1. types that have been removed from the metadata API but were supported in previous versions
 > 1. types that are available for pilots but not officially part of the metadata API (use with caution)

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -71,7 +71,8 @@
     "waveTemplates": "wavetemplatebundle",
     "appTemplates": "appframeworktemplatebundle",
     "lightningTypes": "lightningtypebundle",
-    "uiBundles": "uibundle"
+    "uiBundles": "uibundle",
+    "uiWidgets": "uiwidgetbundle"
   },
   "suffixes": {
     "Canvas": "canvasmetadata",
@@ -534,6 +535,7 @@
     "webStoreBundle": "webstorebundle",
     "webStoreTemplate": "webstoretemplate",
     "uibundle": "uibundle",
+    "uiwidget": "uiwidgetbundle",
     "workflowFlowAutomation": "workflowflowautomation",
     "weblink": "custompageweblink",
     "wlens": "wavelens",
@@ -5380,6 +5382,18 @@
       "directoryName": "idpConfigurations",
       "inFolder": false,
       "strictDirectoryName": false
+    },
+    "uiwidgetbundle": {
+      "id": "uiwidgetbundle",
+      "name": "UiWidgetBundle",
+      "suffix": "uiwidget",
+      "directoryName": "uiWidgets",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "strategies": {
+        "adapter": "bundle"
+      },
+      "supportsPartialDelete": true
     }
   }
 }

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -535,7 +535,6 @@
     "webStoreBundle": "webstorebundle",
     "webStoreTemplate": "webstoretemplate",
     "uibundle": "uibundle",
-    "uiwidget": "uiwidgetbundle",
     "workflowFlowAutomation": "workflowflowautomation",
     "weblink": "custompageweblink",
     "wlens": "wavelens",
@@ -5386,10 +5385,10 @@
     "uiwidgetbundle": {
       "id": "uiwidgetbundle",
       "name": "UiWidgetBundle",
-      "suffix": "uiwidget",
       "directoryName": "uiWidgets",
       "inFolder": false,
       "strictDirectoryName": true,
+      "metaFileSuffix": "uiwidget-meta.xml",
       "strategies": {
         "adapter": "bundle"
       },

--- a/src/resolve/metadataResolver.ts
+++ b/src/resolve/metadataResolver.ts
@@ -400,7 +400,13 @@ const parseAsMetadata =
     if (tree.isDirectory(fsPath)) {
       return;
     }
-    return ['DigitalExperience', 'ExperiencePropertyTypeBundle', 'LightningTypeBundle', 'ContentTypeBundle']
+    return [
+      'DigitalExperience',
+      'ExperiencePropertyTypeBundle',
+      'LightningTypeBundle',
+      'ContentTypeBundle',
+      'UiWidgetBundle',
+    ]
       .map((type) => registry.getTypeByName(type))
       .find((type) => fsPath.split(sep).includes(type.directoryName))?.name;
   };

--- a/src/utils/filePathGenerator.ts
+++ b/src/utils/filePathGenerator.ts
@@ -146,6 +146,14 @@ export const filePathsFromMetadataComponent = (
         'AiAuthoringBundle',
         [join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.aiAuthoringBundle${META_XML_SUFFIX}`)],
       ],
+      // schema.json is optional, so only the meta XML and the content JSON are guaranteed file paths.
+      [
+        'UiWidgetBundle',
+        [
+          join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.uiwidget${META_XML_SUFFIX}`),
+          join(packageDirWithTypeDir, `${fullName}${sep}${fullName}.json`),
+        ],
+      ],
     ]);
 
     const matched = mappings.get(type.name);

--- a/test/resolve/metadataResolver.test.ts
+++ b/test/resolve/metadataResolver.test.ts
@@ -268,6 +268,26 @@ describe('MetadataResolver', () => {
         expect(mdResolver.getComponentsFromPath(path)).to.deep.equal([expectedComponent]);
       });
 
+      it('Should determine type for UiWidgetBundle content file', () => {
+        const widgetPath = join('unpackaged', 'uiWidgets', 'myWidget', 'myWidget.json');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([widgetPath]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const components = mdResolver.getComponentsFromPath(widgetPath);
+        expect(components).to.have.lengthOf(1);
+        expect(components[0].type.name).to.equal('UiWidgetBundle');
+        expect(components[0].name).to.equal('myWidget');
+      });
+
+      it('Should determine type for UiWidgetBundle optional schema file', () => {
+        const schemaPath = join('unpackaged', 'uiWidgets', 'myWidget', 'schema.json');
+        const treeContainer = VirtualTreeContainer.fromFilePaths([schemaPath]);
+        const mdResolver = new MetadataResolver(undefined, treeContainer);
+        const components = mdResolver.getComponentsFromPath(schemaPath);
+        expect(components).to.have.lengthOf(1);
+        expect(components[0].type.name).to.equal('UiWidgetBundle');
+        expect(components[0].name).to.equal('myWidget');
+      });
+
       it('Should determine type for path of mixed content type', () => {
         const path = mixedContentDirectory.MIXED_CONTENT_DIRECTORY_SOURCE_PATHS[1];
         const access = testUtil.createMetadataResolver([

--- a/test/utils/filePathGenerator.test.ts
+++ b/test/utils/filePathGenerator.test.ts
@@ -182,6 +182,19 @@ const testData = {
       },
     ],
   },
+  bundleUiWidget: {
+    fullName: 'myWidget',
+    typeName: 'UiWidgetBundle',
+    expectedFilePaths: [
+      getFilePath('uiWidgets/myWidget/myWidget.uiwidget-meta.xml'),
+      getFilePath('uiWidgets/myWidget/myWidget.json'),
+    ],
+    expectedComponents: [
+      {
+        xml: getFilePath('uiWidgets/myWidget/myWidget.uiwidget-meta.xml'),
+      },
+    ],
+  },
   nonDecomposedExplicit: {
     fullName: 'CustomLabels',
     typeName: 'CustomLabels',
@@ -382,6 +395,10 @@ describe('generating virtual tree from component name/type', () => {
 
     it('appFrameworkTemplate', () => {
       runTest(testData.bundleAppTemplates);
+    });
+
+    it('uiWidget', () => {
+      runTest(testData.bundleUiWidget);
     });
   });
 


### PR DESCRIPTION
@W-23020460@

## What

Adds `UiWidgetBundle` as a first-class bundle-adapter metadata type in SDR so the sf CLI can deploy, retrieve, and convert widget bundles end-to-end. Mirrors the pattern used by `LightningComponentBundle`, `ContentTypeBundle`, and other existing bundle types.

## Why

CORE landed the `UiWidgetBundle` metadata type in 264 (renamed from `FragmentBundle`). The sf CLI needs to recognize the type so customers / packaging flows can ship widgets as source-format metadata.

On disk a widget bundle looks like:

```
uiWidgets/<name>/
  <name>.uiwidget-meta.xml   (required)
  <name>.json                (required — block-tree content)
  schema.json                (optional — attribute schema)
```

## Changes

- **`src/registry/metadataRegistry.json`** — new `uiwidgetbundle` entry (`directoryName: uiWidgets`, `suffix: uiwidget`, `strictDirectoryName`, `supportsPartialDelete`, `strategies.adapter: bundle`); add to `strictDirectoryNames` + `suffixes` maps.
- **`src/resolve/metadataResolver.ts`** — include `UiWidgetBundle` in `parseAsMetadata`'s directory-based bundle list.
- **`src/utils/filePathGenerator.ts`** — emit the two guaranteed bundle files (`<name>.uiwidget-meta.xml` + `<name>.json`); `schema.json` is omitted because it's optional.
- **`METADATA_SUPPORT.md`** — add `UiWidgetBundle` row (file also got a prettier whitespace pass from the pre-commit hook).
- **Tests** — `metadataResolver.test.ts` covers type resolution from the content file and from the optional `schema.json`; `filePathGenerator.test.ts` covers the bundle's file-path generation under `adapter = bundle`.

## Tests

- `yarn build` (compile + lint) ✓
- `mocha test/registry/registryValidation.test.ts` ✓ (uiwidgetbundle recognized as a bundle adapter)
- `mocha test/utils/filePathGenerator.test.ts` ✓
- `mocha test/resolve/metadataResolver.test.ts` ✓
- Full registry/resolve/utils sweep — **29,703 passing, 0 failing**
- <img width="940" height="337" alt="image" src="https://github.com/user-attachments/assets/181f0a36-aec2-4770-8eb6-c43d9550b412" />
- <img width="941" height="633" alt="image" src="https://github.com/user-attachments/assets/ae4f57d9-e1fd-463d-afb3-1ffa91b572dd" />
- Core changes needed [here](https://falcon.devhub.internal.salesforce.com/aihub/code-search/gitcore.soma.salesforce.com/core-2206/core-264-public@p4/264-main-42adacf5851f7d6dc48de523374777456ee25688/-/blob/core/udd-xml/java/resources/udd/udd-mdapi.xml?q=context%3Asf_core+repo%3Agitcore.soma.salesforce.com%2Fcore-2206%2Fcore-264-public+file%3Acore%2Fudd-xml%2Fjava%2Fresources%2Fudd%2F+udd-mdapi.xml&patternType=regex&branch=true&L=524) to enable retrieve preview
- <img width="941" height="444" alt="image" src="https://github.com/user-attachments/assets/f4d404bc-aecb-4b67-a3d2-231ff75f9bae" />




## Refs

- W-23020460