### PR TITLE
feat: support sf/sfdx retrieve & deploy of recursively-foldered TagSet

### DIFF
--- a/src/collections/componentSet.ts
+++ b/src/collections/componentSet.ts
@@ -816,6 +816,10 @@ const constructFullName = (registry: RegistryAccess, type: MetadataType, fullNam
   // a "/" so the metadata API can identify it as a folder.
   ['DashboardFolder', 'ReportFolder', 'EmailTemplateFolder'].includes(type.name) && !fullName.endsWith('/')
     ? `${fullName}/`
+    : // TagSet nests recursively by parent-set identity. inFolder stores it on disk as A/B/C, but the
+    // metadata API contract for TagSet fullNames is dot-separated (A.B.C), so translate on the way out.
+    type.name === 'TagSet'
+    ? fullName.replace(/\//g, '.')
     : registry.getParentType(type.name)?.strategies?.recomposition === 'startEmpty' && fullName.includes('.')
     ? // they're reassembled like CustomLabels.MyLabel
       fullName.split('.')[1]

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -604,7 +604,8 @@
     "cnfgItemTypeRelationDef": "cnfgitemtyperelationdef",
     "cnfgMgmtRelationTypeDef": "cnfgmgmtrelationtypedef",
     "meetingPlaybookDefinition": "meetingplaybookdefinition",
-    "idpConfiguration": "idpconfiguration"
+    "idpConfiguration": "idpconfiguration",
+    "tagSet": "tagset"
   },
   "types": {
     "accesscontrolpolicy": {
@@ -5394,6 +5395,15 @@
         "adapter": "bundle"
       },
       "supportsPartialDelete": true
+    },
+    "tagset": {
+      "id": "tagset",
+      "name": "TagSet",
+      "suffix": "tagSet",
+      "directoryName": "tagSet",
+      "inFolder": true,
+      "strictDirectoryName": false,
+      "supportsWildcardAndName": true
     }
   }
 }

--- a/test/collections/componentSet.test.ts
+++ b/test/collections/componentSet.test.ts
@@ -944,6 +944,20 @@ describe('ComponentSet', () => {
       ]);
     });
 
+    it('should translate a recursively-foldered TagSet path to a dot-separated member', async () => {
+      // On disk, nested tag sets are stored as folders (tagSet/A/B/C.tagSet), so the resolved
+      // fullName is slash-separated. The TagSet metadata API contract is dot-separated.
+      const member = { fullName: 'DataGovernanceTags/CustomTags__as/CustomTagsChild1__as', type: 'TagSet' };
+      const set = new ComponentSet([member], registryAccess);
+
+      expect((await set.getObject()).Package.types).to.deep.equal([
+        {
+          name: 'TagSet',
+          members: ['DataGovernanceTags.CustomTags__as.CustomTagsChild1__as'],
+        },
+      ]);
+    });
+
     it('should include required child types as defined in the registry', async () => {
       const set = new ComponentSet([MATCHING_RULES_COMPONENT]);
       expect((await set.getObject()).Package.types).to.deep.equal([


### PR DESCRIPTION
**DRAFT — internal review before engaging the CLI team. Do not merge.**

## Problem
`sf project retrieve start -m TagSet:...` fails with `RegistryError: Missing metadata type definition in registry for id 'TagSet'` — SDR has no registry entry for Tag/TagSet, so the command errors before contacting the org.

## Shape of the metadata
Core's Metadata API returns TagSet with a **dotted** `fullName` (`A.B.C`) and a **recursively-foldered** `fileName` (`tagSet/A/B/C.tagSet`). Nested tag sets fold by parent-set identity, unbounded depth.

## Fix (3 files)
1. **Registry entry** — `TagSet` with `inFolder: true`. This reuses the existing Report/Dashboard unbounded-folder mechanism (`parseNestedFullName` + `calculateRelativePath`), giving correct recursive foldering on retrieve-write for free.
2. **Separator bridge** — `inFolder` yields a slash-separated fullName on disk (`A/B/C`), but the TagSet MDAPI contract is dot-separated (`A.B.C`). Added a `TagSet` case in `constructFullName`, symmetric to the existing `ReportFolder`/`DashboardFolder` special-cases, that translates `/` to `.` for the manifest.
3. **Test** — `ComponentSet.getObject()` asserts `A/B/C` produces `<members>A.B.C</members>`.

## Open question for CLI team
Tag/TagSet are v66+. SDR has no per-type API-version gating; that convention is the CLI team's call (ComponentSet layer or registry coverage).

## Prerequisite
Server-side listMetadata foldering is fixed by Core W-23465184 (already committed).
