### PR TITLE
feat: add PlatformEventMigration to registry

### DIFF
--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -422,6 +422,7 @@
     "pipelineInspMetricConfig": "pipelineinspmetricconfig",
     "platformEventChannel": "platformeventchannel",
     "platformEventChannelMember": "platformeventchannelmember",
+    "platformEventMigration": "platformeventmigration",
     "platformEventSubscriberConfig": "platformeventsubscriberconfig",
     "policy": "appointmentassignmentpolicy",
     "portal": "portal",
@@ -3778,6 +3779,14 @@
       "name": "PlatformEventChannelMember",
       "strictDirectoryName": false,
       "suffix": "platformEventChannelMember"
+    },
+    "platformeventmigration": {
+      "id": "platformeventmigration",
+      "name": "PlatformEventMigration",
+      "suffix": "platformEventMigration",
+      "directoryName": "platformEventMigrations",
+      "inFolder": false,
+      "strictDirectoryName": false
     },
     "platformeventsubscriberconfig": {
       "directoryName": "PlatformEventSubscriberConfigs",


### PR DESCRIPTION
### What does this PR do?
Adds PlatformEventMigration to the metadata registry.

### What issues does this PR fix or reference?
Closes a gap in METADATA_SUPPORT.md.

### Registry values
Values were verified from a live org describe (sf org list metadata-types):
- directoryName: platformEventMigrations
- suffix: platformEventMigration
- xmlName: PlatformEventMigration
- inFolder: false

### Validation
- yarn mocha test/registry/registryValidation.test.ts — 29,124 passing
- CLI successfully resolves the type (previously threw RegistryError: Missing metadata type definition in registry)

### Is there anything else we should know?
Live org testing showed the type is recognized by the CLI after registry addition. The org returned "Entity type not available in this API version" — confirming the registry entry is structurally correct and the limitation is at the org/API level, not the registry.