### PR TITLE
fix: resolved zip-slip vulnerability (W-23558165)

### DIFF
--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -109,6 +109,10 @@ No source-backed components present in the package.
 
 No components in the package to retrieve.
 
+# error_static_resource_attempting_zip_slip
+
+Entry '%s' in static resource '%s' resolves to a location outside the extraction directory ('%s').
+
 # error_static_resource_expected_archive_type
 
 A StaticResource directory must have a content type of application/zip or application/jar - found %s for %s.

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -129,12 +129,12 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
 
       const srZip = await getStaticResourceZip(component, content);
       const pipelinePromises: Array<Promise<void>> = [];
+      const baseDestinationPath = isAbsolute(baseContentPath)
+        ? baseContentPath
+        : join(this.defaultDirectory ?? component.getPackageRelativePath('', 'source'), baseContentPath);
       for (const filePath of Object.keys(srZip.files)) {
         const zipObj = srZip.file(filePath);
         if (zipObj && !zipObj.dir) {
-          const baseDestinationPath = isAbsolute(baseContentPath)
-            ? baseContentPath
-            : join(this.defaultDirectory ?? component.getPackageRelativePath('', 'source'), baseContentPath);
           const fullDest = join(baseDestinationPath, filePath);
           const relativeDest = relative(baseDestinationPath, fullDest);
           if (relativeDest.startsWith('..') || isAbsolute(relativeDest)) {

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -132,10 +132,18 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
       for (const filePath of Object.keys(srZip.files)) {
         const zipObj = srZip.file(filePath);
         if (zipObj && !zipObj.dir) {
-          const path = join(baseContentPath, filePath);
-          const fullDest = isAbsolute(path)
-            ? path
-            : join(this.defaultDirectory ?? component.getPackageRelativePath('', 'source'), path);
+          const baseDestinationPath = isAbsolute(baseContentPath)
+            ? baseContentPath
+            : join(this.defaultDirectory ?? component.getPackageRelativePath('', 'source'), baseContentPath);
+          const fullDest = join(baseDestinationPath, filePath);
+          const relativeDest = relative(baseDestinationPath, fullDest);
+          if (relativeDest.startsWith('..') || isAbsolute(relativeDest)) {
+            throw messages.createError('error_static_resource_attempting_zip_slip', [
+              filePath,
+              component.name,
+              baseDestinationPath,
+            ]);
+          }
           pipelinePromises.push(this.pipeline(new Readable().wrap(zipObj.nodeStream()), fullDest));
         }
       }

--- a/test/convert/transformers/staticResourceMetadataTransformer.test.ts
+++ b/test/convert/transformers/staticResourceMetadataTransformer.test.ts
@@ -352,6 +352,30 @@ describe('StaticResourceMetadataTransformer', () => {
       expect(await transformer.toSourceFormat({ component })).to.deep.equalInAnyOrder(expectedInfos);
     });
 
+    it('blocks static resources attempting zip-slip attack', async () => {
+      assert(typeof transformer.defaultDirectory === 'string');
+
+      const component = mixedContentSingleFile.COMPONENT;
+      const { xml } = component;
+      assert(xml);
+      env.stub(component, 'parseXml').resolves({
+        StaticResource: {
+          contentType: 'application/zip',
+        },
+      });
+
+      const filePath = join('..', '..', '..', 'b', 'c.css');
+      const testZip = new JSZip().file(filePath, 'malicious css content');
+      env.stub(JSZip, 'loadAsync').resolves(testZip);
+
+      try {
+        void (await transformer.toSourceFormat({ component }));
+        assert.fail('SHOULD HAVE THROWN ERROR');
+      } catch (error) {
+        expect((error as Error).message).to.include('resolves to a location outside the extraction directory');
+      }
+    });
+
     it('should merge output with merge component when content is archive', async () => {
       const root = join('path', 'to', 'another', 'mixedSingleFiles');
       const component = mixedContentSingleFile.COMPONENT;


### PR DESCRIPTION
### What does this PR do?
Today, a malicious static resource could use a zip-slip attack to seize control of a user's machine when the resource is retrieved and unpacked. This PR closes that security gap.

### What issues does this PR fix or reference?
@W-23558165@

### Functionality Before
Unpacking a malicious resource could lead to a file getting dropped into, e.g., the user's startup folder, taking over the machine the next time they reboot.

### Functionality After

A static resource attempting a zip-slip attack is detected, and the retrieval fails with a message about how the resource attempted to extract a file outside of its extraction directory.

### Metadata Registry: Successful Deploy and Retrieve (required if applicable)
N/A

**Deploy output:**

N/A

**Retrieve output:**

N/A
