### PR TITLE
feat: add AiAgentDefinition and AiAgentDefinitionVersion metadata types @W-23818734@

### DIFF
--- a/METADATA_SUPPORT.md
+++ b/METADATA_SUPPORT.md
@@ -854,9 +854,9 @@ v68 introduces the following new types.  Here's their current level of support
 |Metadata Type|Support|Notes|
 |:---|:---|:---|
 |AgentforcePlatformTracingSettings|✅||
-|AiAgentDefinition|❌|Not supported, but support could be added|
+|AiAgentDefinition|✅||
 |AiAgentDefinitionPlanner|❌|Not supported, but support could be added|
-|AiAgentDefinitionVersion|❌|Not supported, but support could be added|
+|AiAgentDefinitionVersion|✅||
 |AutomationPipeline|❌|Not supported, but support could be added|
 |BotEmailDefinition|❌|Not supported, but support could be added|
 |CnfgItemTypeIdentFieldMap|✅||

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -327,7 +327,7 @@ export type RetrieveOptions = {
   packageOptions?: PackageOptions;
   /**
    * An array of metadata type names for which related, dependent metadata
-   * will be retrieved. At this time only `Bot` is supported.
+   * will be retrieved. Supported values: `Bot`, `AiAgentDefinitionVersion`.
    */
   rootTypesWithDependencies?: string[];
   /**

--- a/src/registry/metadataRegistry.json
+++ b/src/registry/metadataRegistry.json
@@ -40,6 +40,7 @@
   "strictDirectoryNames": {
     "ActionableEventOrchDefSettings": "actionableeventorchdef",
     "ActionableEventTypeDefSettings": "actionableeventtypedef",
+    "aiAgentDefinitionVersions": "aiagentdefinitionversion",
     "aiAuthoringBundles": "aiauthoringbundle",
     "IndustriesManufacturingSettings": "industriesmanufacturingsettings",
     "ObjectHierarchyRelationship": "objecthierarchyrelationship",
@@ -115,6 +116,7 @@
     "advAcctForecastPeriodGroup": "advacctforecastperiodgroup",
     "affinityScoreDefinition": "affinityscoredefinition",
     "ai": "aiapplication",
+    "aiAgentDefinition": "aiagentdefinition",
     "aiAgentScorerDefinition": "aiagentscorerdefinition",
     "aiAssistantTemplate": "aiassistanttemplate",
     "aiResponseFormat": "airesponseformat",
@@ -771,6 +773,22 @@
       "name": "AIApplicationConfig",
       "strictDirectoryName": false,
       "suffix": "aiapplicationconfig"
+    },
+    "aiagentdefinition": {
+      "id": "aiagentdefinition",
+      "name": "AiAgentDefinition",
+      "directoryName": "aiAgents",
+      "inFolder": false,
+      "suffix": "aiAgentDefinition",
+      "strictDirectoryName": false
+    },
+    "aiagentdefinitionversion": {
+      "id": "aiagentdefinitionversion",
+      "name": "AiAgentDefinitionVersion",
+      "directoryName": "aiAgentDefinitionVersions",
+      "inFolder": false,
+      "strictDirectoryName": true,
+      "strategies": { "adapter": "bundle" }
     },
     "aiagentscorerdefinition": {
       "directoryName": "aiAgentScorerDefinitions",


### PR DESCRIPTION
## Summary
- Adds `AiAgentDefinition` type to the metadata registry (suffix-based, `aiAgents` directory)
- Adds `AiAgentDefinitionVersion` type to the metadata registry (bundle adapter, `aiAgentDefinitionVersions` strict directory)
- Adds corresponding entries in `suffixes` and `strictDirectoryNames` lookup maps

## Work Item
@W-23818734@: Add a new flag for rootTypesWithDependencies MDAPI Option

## Test plan
- [x] Registry validation tests pass (29,313 passing)
- [x] Registry access tests pass (19 passing)
- [x] JSON is valid
- [ ] CI passes