### PR TITLE
fix: resolved TOCTOU attack (W-23808206)

### DIFF
--- a/messages/sdr.md
+++ b/messages/sdr.md
@@ -113,6 +113,10 @@ No components in the package to retrieve.
 
 Entry '%s' in static resource '%s' resolves to a location outside the extraction directory ('%s').
 
+# error_static_resource_symlink
+
+Entry '%s' in static resource '%s' would be written through a symbolic link ('%s'). Writing through symbolic links is not allowed because it can place files outside the extraction directory ('%s').
+
 # error_static_resource_expected_archive_type
 
 A StaticResource directory must have a content type of application/zip or application/jar - found %s for %s.

--- a/src/convert/transformers/staticResourceMetadataTransformer.ts
+++ b/src/convert/transformers/staticResourceMetadataTransformer.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { Readable } from 'node:stream';
 import JSZip from 'jszip';
 import { getExtension } from 'mime';
 import { JsonMap } from '@salesforce/ts-types';
-import { createWriteStream } from 'graceful-fs';
+import { createWriteStream, promises as fs } from 'graceful-fs';
 import { Logger } from '@salesforce/core/logger';
 import { Messages } from '@salesforce/core/messages';
 import { SfError } from '@salesforce/core/sfError';
@@ -144,7 +144,24 @@ export class StaticResourceMetadataTransformer extends BaseMetadataTransformer {
               baseDestinationPath,
             ]);
           }
-          pipelinePromises.push(this.pipeline(new Readable().wrap(zipObj.nodeStream()), fullDest));
+          pipelinePromises.push(
+            (async (): Promise<void> => {
+              // A path validity check alone is not enough: a symbolic link already present on
+              // disk (e.g. planted as repo content) can redirect an in-bounds write to a target
+              // outside the extraction directory. Node's write stream opens without O_NOFOLLOW,
+              // so refuse to follow any symlink found along the destination path.
+              const symlink = await findSymlinkOnPath(baseDestinationPath, fullDest);
+              if (symlink) {
+                throw messages.createError('error_static_resource_symlink', [
+                  filePath,
+                  component.name,
+                  relative(baseDestinationPath, symlink),
+                  baseDestinationPath,
+                ]);
+              }
+              return this.pipeline(new Readable().wrap(zipObj.nodeStream()), fullDest);
+            })()
+          );
         }
       }
 
@@ -252,6 +269,32 @@ const componentIsExpandedArchive = async (component: SourceComponent): Promise<b
     );
   }
   return false;
+};
+
+/**
+ * Walk every path segment between the extraction root (exclusive) and the destination
+ * (inclusive) and return the first one that is a symbolic link, or undefined if none is.
+ *
+ * `createWriteStream` and recursive `mkdir` both follow symlinks, so a link planted anywhere
+ * along the destination path can redirect the write outside the extraction root even when the
+ * zip entry name itself contains no `..`. The root is assumed trusted and is not checked.
+ */
+const findSymlinkOnPath = async (root: string, destination: string): Promise<string | undefined> => {
+  const rel = relative(root, destination);
+  const segments = rel.split(sep).filter((s) => s.length > 0);
+  // Build the cumulative path for each segment below the root, then lstat them concurrently.
+  const paths = segments.map((_, i) => join(root, ...segments.slice(0, i + 1)));
+  const results = await Promise.all(
+    paths.map(async (p) => {
+      try {
+        return (await fs.lstat(p)).isSymbolicLink();
+      } catch {
+        // Path segment does not exist yet; it will be created as a regular file/dir, so it is safe.
+        return false;
+      }
+    })
+  );
+  return paths.find((_, i) => results[i]);
 };
 
 async function getStaticResourceZip(component: SourceComponent, content: string): Promise<JSZip> {

--- a/test/convert/transformers/staticResourceMetadataTransformer.test.ts
+++ b/test/convert/transformers/staticResourceMetadataTransformer.test.ts
@@ -15,6 +15,7 @@
  */
 import { Readable } from 'node:stream';
 import { basename, join } from 'node:path';
+import { promises as fs } from 'graceful-fs';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import { Messages } from '@salesforce/core';
 import chai, { assert, expect } from 'chai';
@@ -374,6 +375,38 @@ describe('StaticResourceMetadataTransformer', () => {
       } catch (error) {
         expect((error as Error).message).to.include('resolves to a location outside the extraction directory');
       }
+    });
+
+    it('blocks static resources written through a pre-existing symlink', async () => {
+      assert(typeof transformer.defaultDirectory === 'string');
+
+      const component = mixedContentSingleFile.COMPONENT;
+      const { xml } = component;
+      assert(xml);
+      env.stub(component, 'parseXml').resolves({
+        StaticResource: {
+          contentType: 'application/zip',
+        },
+      });
+
+      // Entry name is entirely in-bounds (no '..'), so the zip-slip guard passes. The escape is
+      // a symlink already present on disk along the destination path.
+      const filePath = join('js', 'bundle.min.js');
+      const testZip = new JSZip().file(filePath, 'malicious content');
+      env.stub(JSZip, 'loadAsync').resolves(testZip);
+
+      env.stub(fs, 'lstat').callsFake(((p: string) =>
+        Promise.resolve({
+          isSymbolicLink: () => p.endsWith('js'),
+        })) as unknown as typeof fs.lstat);
+
+      try {
+        void (await transformer.toSourceFormat({ component }));
+        assert.fail('SHOULD HAVE THROWN ERROR');
+      } catch (error) {
+        expect((error as Error).message).to.include('would be written through a symbolic link');
+      }
+      expect(pipelineStub.callCount).to.equal(0);
     });
 
     it('should merge output with merge component when content is archive', async () => {


### PR DESCRIPTION
### What does this PR do?
Resolves a potential security vulnerability wherein a malicious static resource could use a symlink-follow-through to write to non-permitted files during `sf project convert mdapi`

### What issues does this PR fix or reference?

@W-23808206@

### Functionality Before

Static resource unpacking would follow symlinks and write to the original file.

### Functionality After

An error is thrown indicating that the resource attempted to break containment.

### Metadata Registry: Successful Deploy and Retrieve (required if applicable)

N/A

**Deploy output:**

N/A

**Retrieve output:**

N/A