### PR TITLE
feat: export stdValueSetRegistry.json from main index.ts to be called properly outside this repo - W-23802414

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -10,6 +10,7 @@
   - [Metadata registry entries](#metadata-registry-file)
   - [Updating the Metadata registry file](#updating-the-metadata-registry-file)
   - [The registry object](#the-registry-object)
+  - [Standard value sets](#standard-value-sets)
   - [Querying registry data](#querying-registry-data)
 - [Component Resolution](#component-resolution)
   - [Overview](#overview-1)
@@ -145,6 +146,17 @@ registry.types.auradefinitionbundle.directoryName; // => 'aura'
 ```
 
 📝 _The registry object is “deeply frozen”, meaning none of its properties, even the nested ones, are mutable. This is to ensure that a consumer cannot change registry information in a process and potentially affect functionality._
+
+### Standard value sets
+
+The library also exports `standardValueSet`, a reference to all supported StandardValueSet full names (e.g., `AccountContactMultiRoles`, `AccountOwnership`). This is useful when querying StandardValueSet metadata from an org:
+
+```typescript
+import { standardValueSet } from '@salesforce/source-deploy-retrieve';
+
+// Get all standard value set names
+const allStandardValueSets = standardValueSet.fullnames;
+```
 
 ### Registry Variants
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^9.0.0",
+    "@salesforce/core": "^9.1.4",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/ts-types": "^3.0.0",
     "@salesforce/types": "^1.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,14 @@ export {
   FromManifestOptions,
 } from './collections';
 
-export { RegistryAccess, registry, getCurrentApiVersion, MetadataRegistry, MetadataType } from './registry';
+export {
+  RegistryAccess,
+  registry,
+  getCurrentApiVersion,
+  MetadataRegistry,
+  MetadataType,
+  standardValueSet,
+} from './registry';
 
 // TODO: don't export these strategies
 export { DecompositionStrategy, TransformerStrategy, RecompositionStrategy } from './registry/types';

--- a/src/registry/standardvalueset.ts
+++ b/src/registry/standardvalueset.ts
@@ -16,9 +16,12 @@
 import * as standardValueSetData from './stdValueSetRegistry.json';
 
 /**
- * The standardValueSet fullNames.
+ * StandardValueSet metadata reference data.
+ *
+ * Contains a list of all supported StandardValueSet full names (e.g., `AccountContactMultiRoles`, `AccountOwnership`)
+ * that can be queried from Salesforce orgs. Useful for working with StandardValueSet metadata via the Metadata API.
  *
  * The static import of json file should never be changed,
- * other read methods might make esbuild fail to bundle the json file
+ * other read methods might make esbuild fail to bundle the json file.
  */
 export const standardValueSet = standardValueSetData as Readonly<typeof standardValueSetData>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,10 +661,25 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
-"@jsforce/jsforce-node@^3.10.17", "@jsforce/jsforce-node@^3.10.19":
+"@jsforce/jsforce-node@^3.10.19":
   version "3.10.19"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.19.tgz#ccbc539c12f4f7dff9cfdcc6cfb8f07bd840f731"
   integrity sha512-k7i2Tntu1fLvkMtRcKDFU64/Fr2M692ECtbwIGX6hcOh5mj+jrMa1tlvcdwffxAMl+lPYCXnY2bjErxWmP84zA==
+  dependencies:
+    "@sindresorhus/is" "^4"
+    base64url "^3.0.1"
+    csv-parse "^5.5.2"
+    csv-stringify "^6.6.0"
+    faye "^1.4.0"
+    form-data "^4.0.4"
+    multistream "^3.1.0"
+    undici "^8.5.0"
+    xml2js "^0.6.2"
+
+"@jsforce/jsforce-node@^3.10.22":
+  version "3.10.22"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.22.tgz#b15d0bfa8280dff3d2b6d5a833a6febb6bef138c"
+  integrity sha512-4TLjnvTlBW59NmNSsRRV5dDEepQGfBKVD0WWQlJUJwkU0d5FFxo8GbfNmCOXkjjYAe1wv7SuvMzJKcLZHU6qyw==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"
@@ -798,12 +813,12 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
-"@salesforce/core@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.0.0.tgz#bf7a2816a322b8febc5349f5a1c884b8be073b06"
-  integrity sha512-sL4sr8MXcdsHZJr0bacMY0ZJmbPwBEvJudDIlKxKdQu/62d1aNBvACPFfL32QJdu2sOkEpgF3CX/0znkU43g2g==
+"@salesforce/core@^9.1.4":
+  version "9.1.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.1.4.tgz#264a618f962b7306794d5a7a42698bdb7dec6d04"
+  integrity sha512-S4VZ0xstYOAs5dwt7EDGkuFZA8rddy0wmuPTGjsIhgAPzuq3I5lKyBNwqXMMxdhBcWi+P4cXccHLpOYivgdrXQ==
   dependencies:
-    "@jsforce/jsforce-node" "^3.10.17"
+    "@jsforce/jsforce-node" "^3.10.22"
     "@salesforce/kit" "^4.0.0"
     "@salesforce/ts-types" "^3.0.0"
     ajv "^8.18.0"


### PR DESCRIPTION
### What does this PR do?
Paired with https://github.com/forcedotcom/salesforcedx-vscode/pull/8006.  Exports **stdValueSetRegistry.json** from index.ts to avoid doing the ugly import of `import * as stdValueSetRegistry from '@salesforce/source-deploy-retrieve/lib/src/registry/stdValueSetRegistry.json';` in salesforcedx-vscode.

### What issues does this PR fix or reference?
@W-23802414@
