### PR TITLE
feat: add DeployNotification type for deploy-level notifications @W-23939851@

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@salesforce/core": "^9.1.6",
+    "@salesforce/core": "^9.1.7",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/ts-types": "^3.0.0",
     "@salesforce/types": "^1.6.0",
@@ -41,7 +41,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@jsforce/jsforce-node": "^3.10.19",
+    "@jsforce/jsforce-node": "^3.10.23",
     "@salesforce/cli-plugins-testkit": "^5.3.58",
     "@salesforce/dev-scripts": "^13.0.2",
     "@types/chai": "^4.3.17",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -35,6 +35,7 @@ export {
   RetrieveFailure,
   RetrieveSuccess,
   MetadataApiDeployStatus,
+  DeployNotification,
   DeployDetails,
   RunTestResult,
   CodeCoverage,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -146,7 +146,10 @@ export type MetadataApiDeployStatus = {
   rollbackOnError: boolean;
   startDate?: string;
   stateDetail?: string;
+  notifications?: DeployNotification | DeployNotification[];
 } & MetadataRequestStatus;
+
+export type DeployNotification = { messageCode: string; messageText: string };
 
 export type DeployDetails = {
   componentFailures?: DeployMessage | DeployMessage[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   RetrieveFailure,
   RetrieveSuccess,
   MetadataApiDeployStatus,
+  DeployNotification,
   DeployDetails,
   RunTestResult,
   CodeCoverage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,25 +655,10 @@
     node-fetch "^2.6.1"
     xml2js "^0.6.2"
 
-"@jsforce/jsforce-node@^3.10.19":
-  version "3.10.19"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.19.tgz#ccbc539c12f4f7dff9cfdcc6cfb8f07bd840f731"
-  integrity sha512-k7i2Tntu1fLvkMtRcKDFU64/Fr2M692ECtbwIGX6hcOh5mj+jrMa1tlvcdwffxAMl+lPYCXnY2bjErxWmP84zA==
-  dependencies:
-    "@sindresorhus/is" "^4"
-    base64url "^3.0.1"
-    csv-parse "^5.5.2"
-    csv-stringify "^6.6.0"
-    faye "^1.4.0"
-    form-data "^4.0.4"
-    multistream "^3.1.0"
-    undici "^8.5.0"
-    xml2js "^0.6.2"
-
-"@jsforce/jsforce-node@^3.10.22":
-  version "3.10.22"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.22.tgz#b15d0bfa8280dff3d2b6d5a833a6febb6bef138c"
-  integrity sha512-4TLjnvTlBW59NmNSsRRV5dDEepQGfBKVD0WWQlJUJwkU0d5FFxo8GbfNmCOXkjjYAe1wv7SuvMzJKcLZHU6qyw==
+"@jsforce/jsforce-node@^3.10.23":
+  version "3.10.23"
+  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.23.tgz#464be5621ee638a29d3bd43d97ade5b16470118f"
+  integrity sha512-sepBNb9Bt0vSdXqZqq97p/EP8NJjjOnDQoRmiH2Lcm/nsznQsrsUttoNmNxfxrRubuJTIL9m4H1I7uOb8HrgRg==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"
@@ -809,12 +794,12 @@
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
-"@salesforce/core@^9.1.6":
-  version "9.1.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.1.6.tgz#cdc951ab573b92f482d0371d29687f9170e4a9d9"
-  integrity sha512-suF9uvuTwuer8zAlN4mRr3Dvd5Z+rM58r//P3JiYEgY4e1cMdiq7LOKA0PLZpbtNJL3rcZZDFTvqD6ypQAU1gA==
+"@salesforce/core@^9.1.7":
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-9.1.7.tgz#6084959bfab927d062cf4ef39d261b9a6e655cb0"
+  integrity sha512-6ecm8k3RQ5lLZ8ecv4kuY9ORpdZ5vceQO/QEDkEIfg+XbT3k10lMztX6/Q0lM6EmeNGT8xqwbdHaYvcKhCwyDQ==
   dependencies:
-    "@jsforce/jsforce-node" "^3.10.22"
+    "@jsforce/jsforce-node" "^3.10.23"
     "@salesforce/kit" "^4.0.0"
     "@salesforce/ts-types" "^3.0.0"
     ajv "^8.18.0"


### PR DESCRIPTION
## Summary
- Adds `DeployNotification` type (`{ messageCode: string; messageText: string }`)
- Adds optional `notifications` field to `MetadataApiDeployStatus` (single object or array, matching SOAP API behavior)
- Exports `DeployNotification` from package barrel

## Work Item
@W-23939851@: Add Deploy-Level notifications to the CLI

## Test plan
- [ ] Unit tests pass (`yarn test`)
- [ ] Dependent PR in plugin-deploy-retrieve consumes the type and displays notifications